### PR TITLE
Remove OS_OCTAVIA_BATCH_MEMBERS_ENVIRONMENT

### DIFF
--- a/openstack/import_openstack_lb_members_v2_test.go
+++ b/openstack/import_openstack_lb_members_v2_test.go
@@ -13,7 +13,6 @@ func TestAccLBV2Members_importBasic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheckLB(t)
 			testAccPreCheckUseOctavia(t)
-			testAccPreCheckOctaviaBatchMembersEnv(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLBV2MembersDestroy,

--- a/openstack/provider_test.go
+++ b/openstack/provider_test.go
@@ -136,14 +136,6 @@ func testAccPreCheckUseOctavia(t *testing.T) {
 	}
 }
 
-func testAccPreCheckOctaviaBatchMembersEnv(t *testing.T) {
-	testAccPreCheckRequiredEnvVars(t)
-
-	if OS_OCTAVIA_BATCH_MEMBERS_ENVIRONMENT == "" {
-		t.Skip("This environment does not support Octavia batch member update tests")
-	}
-}
-
 func testAccPreCheckFW(t *testing.T) {
 	testAccPreCheckRequiredEnvVars(t)
 

--- a/openstack/resource_openstack_lb_members_v2_test.go
+++ b/openstack/resource_openstack_lb_members_v2_test.go
@@ -48,7 +48,6 @@ func TestAccLBV2Members_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheckLB(t)
 			testAccPreCheckUseOctavia(t)
-			testAccPreCheckOctaviaBatchMembersEnv(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLBV2MembersDestroy,


### PR DESCRIPTION
Do not use a separate environment to check if environment can run
lb_members_v2 tests.