### PR TITLE
Update repo name in CI, modules and README.md

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,5 +1,5 @@
 - project:
-    name: terraform-providers/terraform-provider-openstack
+    name: terraform-provider-openstack/terraform-provider-openstack
     check:
       jobs:
         - terraform-provider-openstack-unittest

--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ Requirements
 Building The Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-openstack`
+Clone repository to: `$GOPATH/src/github.com/terraform-provider-openstack/terraform-provider-openstack`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone https://github.com/terraform-providers/terraform-provider-openstack
+$ mkdir -p $GOPATH/src/github.com/terraform-provider-openstack; cd $GOPATH/src/github.com/terraform-provider-openstack
+$ git clone https://github.com/terraform-provider-openstack/terraform-provider-openstack
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack
+$ cd $GOPATH/src/github.com/terraform-provider-openstack/terraform-provider-openstack
 $ make build
 ```
 
@@ -43,7 +43,7 @@ Using the provider
 ----------------------
 Please see the documentation at [terraform.io](https://www.terraform.io/docs/providers/openstack/index.html).
 
-Or you can browse the documentation within this repo [here](https://github.com/terraform-providers/terraform-provider-openstack/tree/master/website/docs).
+Or you can browse the documentation within this repo [here](https://github.com/terraform-provider-openstack/terraform-provider-openstack/tree/master/website/docs).
 
 Developing the Provider
 ---------------------------

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-openstack
+module github.com/terraform-provider-openstack/terraform-provider-openstack
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-openstack/openstack"
+	"github.com/terraform-provider-openstack/terraform-provider-openstack/openstack"
 )
 
 func main() {


### PR DESCRIPTION
Use terraform-provider-openstack/terraform-provider-openstack as Go module name.

Use terraform-provider-openstack/terraform-provider-openstack repo in README.md.

Use terraform-provider-openstack/terraform-provider-openstack name in .zuul.