### PR TITLE
Run BlockStorage attach tests as admin only

### DIFF
--- a/openstack/resource_openstack_blockstorage_volume_attach_v2_test.go
+++ b/openstack/resource_openstack_blockstorage_volume_attach_v2_test.go
@@ -15,7 +15,10 @@ func TestAccBlockStorageVolumeAttachV2_basic(t *testing.T) {
 	var va volumes.Attachment
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBlockStorageVolumeAttachV2Destroy,
 		Steps: []resource.TestStep{
@@ -33,7 +36,10 @@ func TestAccBlockStorageVolumeAttachV2_timeout(t *testing.T) {
 	var va volumes.Attachment
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBlockStorageVolumeAttachV2Destroy,
 		Steps: []resource.TestStep{

--- a/openstack/resource_openstack_blockstorage_volume_attach_v3_test.go
+++ b/openstack/resource_openstack_blockstorage_volume_attach_v3_test.go
@@ -15,7 +15,10 @@ func TestAccBlockStorageVolumeAttachV3_basic(t *testing.T) {
 	var va volumes.Attachment
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBlockStorageVolumeAttachV3Destroy,
 		Steps: []resource.TestStep{
@@ -33,7 +36,10 @@ func TestAccBlockStorageVolumeAttachV3_timeout(t *testing.T) {
 	var va volumes.Attachment
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBlockStorageVolumeAttachV3Destroy,
 		Steps: []resource.TestStep{

--- a/website/docs/r/blockstorage_volume_attach_v2.html.markdown
+++ b/website/docs/r/blockstorage_volume_attach_v2.html.markdown
@@ -8,19 +8,18 @@ description: |-
 
 # openstack\_blockstorage\_volume\_attach\_v2
 
-This resource is experimental and may be removed in the future! Feedback
-is requested if you find this resource useful or if you find any problems
-with it.
+~> **Note:** This resource usually requires admin privileges.
+
+~> **Note:** This resource does not actually attach a volume to an instance. Please use
+the `openstack_compute_volume_attach_v2` resource for that.
 
 Creates a general purpose attachment connection to a Block
 Storage volume using the OpenStack Block Storage (Cinder) v2 API.
+
 Depending on your Block Storage service configuration, this
 resource can assist in attaching a volume to a non-OpenStack resource
 such as a bare-metal server or a remote virtual machine in a
 different cloud provider.
-
-This does not actually attach a volume to an instance. Please use
-the `openstack_compute_volume_attach_v2` resource for that.
 
 ## Example Usage
 

--- a/website/docs/r/blockstorage_volume_attach_v3.html.markdown
+++ b/website/docs/r/blockstorage_volume_attach_v3.html.markdown
@@ -8,19 +8,18 @@ description: |-
 
 # openstack\_blockstorage\_volume\_attach\_v3
 
-This resource is experimental and may be removed in the future! Feedback
-is requested if you find this resource useful or if you find any problems
-with it.
+~> **Note:** This resource usually requires admin privileges.
+
+~> **Note:** This resource does not actually attach a volume to an instance. Please use
+the `openstack_compute_volume_attach_v2` resource for that.
 
 Creates a general purpose attachment connection to a Block
 Storage volume using the OpenStack Block Storage (Cinder) v3 API.
+
 Depending on your Block Storage service configuration, this
 resource can assist in attaching a volume to a non-OpenStack resource
 such as a bare-metal server or a remote virtual machine in a
 different cloud provider.
-
-This does not actually attach a volume to an instance. Please use
-the `openstack_compute_volume_attach_v2` resource for that.
 
 ## Example Usage
 


### PR DESCRIPTION
There were some changes in Cinder code that prevent non-admin user to
retrieve "host_name" for volume attachments:

https://review.opendev.org/#/c/726751/
https://github.com/openstack/cinder/commit/8bf454b0b5c7b77bdde8fe8a98d5225957e9c912

Volume attachment tests should check if user is admin via PreCheck
function.

See https://github.com/theopenlab/openlab/issues/571 for additional details.