### PR TITLE
compute/instance: add different_cell scheduler hint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-provider-openstack/terraform-provider-openstack
 go 1.14
 
 require (
-	github.com/gophercloud/gophercloud v0.12.1-0.20200821143728-362eb785d617
+	github.com/gophercloud/gophercloud v0.12.1-0.20200827191144-bb4781e9de45
 	github.com/gophercloud/utils v0.0.0-20201016024308-5fc12d2a573d
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/gophercloud/gophercloud v0.6.1-0.20191122030953-d8ac278c1c9d/go.mod h1:ozGNgr9KYOVATV5jsgHl/ceCDXGuguqOZAzoQ/2vcNM=
 github.com/gophercloud/gophercloud v0.12.1-0.20200821143728-362eb785d617 h1:8Kj1KcL5PXrH3CIC+U5LnbyfueWr/Fh/4CdM5yP+XKM=
 github.com/gophercloud/gophercloud v0.12.1-0.20200821143728-362eb785d617/go.mod h1:w2NJEd88d4igNL1KUHzBsKMvS/ByJTzgltTGWKT7AC8=
+github.com/gophercloud/gophercloud v0.12.1-0.20200827191144-bb4781e9de45 h1:qvMqZxf8hx1Udiv1dXTp9rmGflhBYvgoVva+AQBJ4XM=
+github.com/gophercloud/gophercloud v0.12.1-0.20200827191144-bb4781e9de45/go.mod h1:w2NJEd88d4igNL1KUHzBsKMvS/ByJTzgltTGWKT7AC8=
 github.com/gophercloud/utils v0.0.0-20200508015959-b0167b94122c h1:iawx2ojEQA7c+GmkaVO5sN+k8YONibXyDO8RlsC+1bs=
 github.com/gophercloud/utils v0.0.0-20200508015959-b0167b94122c/go.mod h1:ehWUbLQJPqS0Ep+CxeD559hsm9pthPXadJNKwZkp43w=
 github.com/gophercloud/utils v0.0.0-20201016024308-5fc12d2a573d h1:8jNzDhxbZwbIJDSoLX0+6J5Ehi2jMdJQNS1rKJPVlH4=

--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -340,6 +340,12 @@ func resourceComputeInstanceV2() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 						},
+						"different_cell": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
 						"build_near_host_ip": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -1256,12 +1262,20 @@ func resourceInstanceSchedulerHintsV2(d *schema.ResourceData, schedulerHintsRaw 
 		}
 	}
 
+	differentCell := []string{}
+	if v, ok := schedulerHintsRaw["different_cell"].([]interface{}); ok {
+		for _, dh := range v {
+			differentCell = append(differentCell, dh.(string))
+		}
+	}
+
 	schedulerHints := schedulerhints.SchedulerHints{
 		Group:                schedulerHintsRaw["group"].(string),
 		DifferentHost:        differentHost,
 		SameHost:             sameHost,
 		Query:                query,
 		TargetCell:           schedulerHintsRaw["target_cell"].(string),
+		DifferentCell:        differentCell,
 		BuildNearHostIP:      schedulerHintsRaw["build_near_host_ip"].(string),
 		AdditionalProperties: schedulerHintsRaw["additional_properties"].(map[string]interface{}),
 	}
@@ -1404,6 +1418,7 @@ func resourceComputeSchedulerHintsHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", m["different_host"].([]interface{})))
 	buf.WriteString(fmt.Sprintf("%s-", m["same_host"].([]interface{})))
 	buf.WriteString(fmt.Sprintf("%s-", m["query"].([]interface{})))
+	buf.WriteString(fmt.Sprintf("%s-", m["different_cell"].([]interface{})))
 
 	return hashcode.String(buf.String())
 }

--- a/vendor/github.com/gophercloud/gophercloud/.zuul.yaml
+++ b/vendor/github.com/gophercloud/gophercloud/.zuul.yaml
@@ -24,6 +24,24 @@
     nodeset: ubuntu-bionic
 
 - job:
+    name: gophercloud-acceptance-test-ussuri
+    parent: gophercloud-acceptance-test
+    description: |
+      Run gophercloud acceptance test on ussuri branch
+    vars:
+      global_env:
+        OS_BRANCH: stable/ussuri
+
+- job:
+    name: gophercloud-acceptance-test-train
+    parent: gophercloud-acceptance-test
+    description: |
+      Run gophercloud acceptance test on train branch
+    vars:
+      global_env:
+        OS_BRANCH: stable/train
+
+- job:
     name: gophercloud-acceptance-test-stein
     parent: gophercloud-acceptance-test
     description: |
@@ -37,7 +55,6 @@
     parent: gophercloud-acceptance-test
     description: |
       Run gophercloud acceptance test on rocky branch
-    nodeset: ubuntu-xenial
     vars:
       global_env:
         OS_BRANCH: stable/rocky
@@ -52,6 +69,8 @@
       global_env:
         OS_BRANCH: stable/queens
 
+# NOTE: A Pike-based devstack environment is currently
+# not building correctly. This might be a temporary issue.
 - job:
     name: gophercloud-acceptance-test-pike
     parent: gophercloud-acceptance-test
@@ -72,6 +91,8 @@
       global_env:
         OS_BRANCH: stable/ocata
 
+# NOTE: A Newton-based devstack environment is currently
+# not building correctly. This might be a temporary issue.
 - job:
     name: gophercloud-acceptance-test-newton
     parent: gophercloud-acceptance-test
@@ -107,3 +128,9 @@
     recheck-stein:
       jobs:
         - gophercloud-acceptance-test-stein
+    recheck-train:
+      jobs:
+        - gophercloud-acceptance-test-train
+    recheck-ussuri:
+      jobs:
+        - gophercloud-acceptance-test-ussuri

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints/requests.go
@@ -31,6 +31,9 @@ type SchedulerHints struct {
 	// TargetCell specifies a cell name where the instance will be placed.
 	TargetCell string `json:"target_cell,omitempty"`
 
+	// DifferentCell specifies cells names where an instance should not be placed.
+	DifferentCell []string `json:"different_cell,omitempty"`
+
 	// BuildNearHostIP specifies a subnet of compute nodes to host the instance.
 	BuildNearHostIP string
 
@@ -122,6 +125,10 @@ func (opts SchedulerHints) ToServerSchedulerHintsCreateMap() (map[string]interfa
 
 	if opts.TargetCell != "" {
 		sh["target_cell"] = opts.TargetCell
+	}
+
+	if len(opts.DifferentCell) > 0 {
+		sh["different_cell"] = opts.DifferentCell
 	}
 
 	if opts.BuildNearHostIP != "" {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -78,7 +78,7 @@ github.com/google/go-cmp/cmp/internal/value
 github.com/google/uuid
 # github.com/googleapis/gax-go/v2 v2.0.5
 github.com/googleapis/gax-go/v2
-# github.com/gophercloud/gophercloud v0.12.1-0.20200821143728-362eb785d617
+# github.com/gophercloud/gophercloud v0.12.1-0.20200827191144-bb4781e9de45
 ## explicit
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/internal

--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -453,6 +453,8 @@ The `scheduler_hints` block supports:
 
 * `target_cell` - (Optional) The name of a cell to host the instance.
 
+* `different_cell` - (Optional) The names of cells where not to build the instance.
+
 * `build_near_host_ip` - (Optional) An IP Address in CIDR form. The instance
     will be placed on a compute node that is in the same subnet.
 


### PR DESCRIPTION
While the code base supported the target_cell scheduler hint to get
instances to build in a specified cell, there was no support to skip
cells if you were attempting to skip a specific cell.