### PR TITLE
compute_instance_v2: handle special case of 2 default networks

### DIFF
--- a/openstack/compute_instance_v2.go
+++ b/openstack/compute_instance_v2.go
@@ -341,7 +341,35 @@ func getInstanceNetworkInfoNeutron(
 func getInstanceAddresses(addresses map[string]interface{}) []InstanceAddresses {
 	var allInstanceAddresses []InstanceAddresses
 
-	for networkName, v := range addresses {
+	// Addresses includes a list of all IP addresses assigned to the server,
+	// keyed by pool. This unfortunately causes problems because addresses are a
+	// JSON object which means that they are unordered because gophercloud
+	// uses a map[string]interface{} to hold them and maps are unordered.
+	// However OpenStack uses OrderedDict to return this data and this
+	// provider uses a List type for the networks which is an ordered type,
+	// this means that importing resources into terraform will result in
+	// networks import out of order which causes terraform to say it has to
+	// rebuild the instance. Unfortunately there is no way to ensure the
+	// ordering is correct, lastly this issue occurs only when there's
+	// "public" and "private" as the only networks so account for that
+	// case specially. Create a list of the network names and if it's
+	// the special case override it.
+	networkNames := make([]string, len(addresses))
+	i := 0
+	for k := range addresses {
+		networkNames[i] = k
+		i++
+	}
+
+	if len(networkNames) == 2 {
+		if networkNames[0] == "private" && networkNames[1] == "public" {
+			networkNames[0] = "public"
+			networkNames[1] = "private"
+		}
+	}
+
+	for _, networkName := range networkNames {
+		v, _ := addresses[networkName]
 		instanceAddresses := InstanceAddresses{
 			NetworkName: networkName,
 		}


### PR DESCRIPTION
When you query for the details on a server in OpenStack, you get a list
of addresses assigned to that server which is keyed by pool. This
unfortunately causes problems becauses addresses are actually a JSON
object keyed by their network name. JSON objects are unordered by spec
and Go uses map[string]interface{} for JSON objects which is also
unordered. However this provider keeps the networks in a TypeList which
is order dependent. If you import a server then the networks will come
in a random order and terraform will insist it must rebuild the server.
Unfortunately there's no way to ensure that the ordering matches how it
came back from OpenStack due to this. This is only an issue when there
are two default networks such as for a provider with "public" and
"private" as default networks. Without a way to generically fix the
ordering of networks for imported servers, this fix just special cases
that situation to workaround the issue. fixes #1071
