### PR TITLE
Remove global variables

### DIFF
--- a/openstack/data_source_openstack_keymanager_container_v1.go
+++ b/openstack/data_source_openstack_keymanager_container_v1.go
@@ -99,8 +99,8 @@ func dataSourceKeyManagerContainerV1() *schema.Resource {
 	elem := &schema.Resource{
 		Schema: make(map[string]*schema.Schema),
 	}
-	for _, aclOp := range aclOperations {
-		elem.Schema[aclOp] = aclSchema
+	for _, aclOp := range getSupportedACLOperations() {
+		elem.Schema[aclOp] = getACLSchema()
 	}
 	ret.Schema["acl"].Elem = elem
 

--- a/openstack/identity_user_v3.go
+++ b/openstack/identity_user_v3.go
@@ -8,11 +8,13 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
 )
 
-var userOptions = map[users.Option]string{
-	users.IgnoreChangePasswordUponFirstUse: "ignore_change_password_upon_first_use",
-	users.IgnorePasswordExpiry:             "ignore_password_expiry",
-	users.IgnoreLockoutFailureAttempts:     "ignore_lockout_failure_attempts",
-	users.MultiFactorAuthEnabled:           "multi_factor_auth_enabled",
+func getUserOptions() [4]users.Option {
+	return [4]users.Option{
+		users.IgnoreChangePasswordUponFirstUse,
+		users.IgnorePasswordExpiry,
+		users.IgnoreLockoutFailureAttempts,
+		users.MultiFactorAuthEnabled,
+	}
 }
 
 func expandIdentityUserV3MFARules(rules []interface{}) []interface{} {

--- a/openstack/keymanager_v1.go
+++ b/openstack/keymanager_v1.go
@@ -8,35 +8,39 @@ import (
 )
 
 // So far only "read" is supported.
-var aclOperations = []string{"read"}
+func getSupportedACLOperations() [1]string {
+	return [1]string{"read"}
+}
 
-var aclSchema = &schema.Schema{
-	Type:     schema.TypeList, // the list, returned by Barbican, is always ordered
-	Optional: true,
-	Computed: true,
-	MaxItems: 1,
-	Elem: &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"project_access": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true, // defaults to true in OpenStack Barbican code
-			},
-			"users": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"created_at": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"updated_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+func getACLSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList, // the list, returned by Barbican, is always ordered
+		Optional: true,
+		Computed: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"project_access": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true, // defaults to true in OpenStack Barbican code
+				},
+				"users": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"created_at": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"updated_at": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
 			},
 		},
-	},
+	}
 }
 
 func expandKeyManagerV1ACL(v interface{}, aclType string) acls.SetOpt {
@@ -91,7 +95,7 @@ func flattenKeyManagerV1ACLs(acl *acls.ACL) []map[string][]map[string]interface{
 
 	if acl != nil {
 		allAcls := *acl
-		for _, aclOp := range aclOperations {
+		for _, aclOp := range getSupportedACLOperations() {
 			if v, ok := allAcls[aclOp]; ok {
 				if m == nil {
 					m = make([]map[string][]map[string]interface{}, 1)

--- a/openstack/lb_v2_shared.go
+++ b/openstack/lb_v2_shared.go
@@ -25,14 +25,28 @@ import (
 
 const octaviaLBClientType = "load-balancer"
 
+const (
+	lbPendingCreate = "PENDING_CREATE"
+	lbPendingUpdate = "PENDING_UPDATE"
+	lbPendingDelete = "PENDING_DELETE"
+	lbActive        = "ACTIVE"
+	lbError         = "ERROR"
+)
+
 // lbPendingStatuses are the valid statuses a LoadBalancer will be in while
 // it's updating.
-var lbPendingStatuses = []string{"PENDING_CREATE", "PENDING_UPDATE"}
+func getLbPendingStatuses() []string {
+	return []string{lbPendingCreate, lbPendingUpdate}
+}
 
 // lbPendingDeleteStatuses are the valid statuses a LoadBalancer will be before delete.
-var lbPendingDeleteStatuses = []string{"ERROR", "PENDING_UPDATE", "PENDING_DELETE", "ACTIVE"}
+func getLbPendingDeleteStatuses() []string {
+	return []string{lbError, lbPendingUpdate, lbPendingDelete, lbActive}
+}
 
-var lbSkipLBStatuses = []string{"ERROR", "ACTIVE"}
+func getLbSkipStatuses() []string {
+	return []string{lbError, lbActive}
+}
 
 // chooseLBV2Client will determine which load balacing client to use:
 // either the Octavia/LBaaS client or the Neutron/Networking v2 client.
@@ -371,7 +385,7 @@ func resourceLBV2ListenerRefreshFunc(lbClient *gophercloud.ServiceClient, lbID s
 			if err != nil {
 				return lb, status, err
 			}
-			if !strSliceContains(lbSkipLBStatuses, status) {
+			if !strSliceContains(getLbSkipStatuses(), status) {
 				return lb, status, nil
 			}
 
@@ -609,7 +623,7 @@ func resourceLBV2MemberRefreshFunc(lbClient *gophercloud.ServiceClient, lbID str
 			if err != nil {
 				return lb, status, err
 			}
-			if !strSliceContains(lbSkipLBStatuses, status) {
+			if !strSliceContains(getLbSkipStatuses(), status) {
 				return lb, status, nil
 			}
 
@@ -662,7 +676,7 @@ func resourceLBV2MonitorRefreshFunc(lbClient *gophercloud.ServiceClient, lbID st
 			if err != nil {
 				return lb, status, err
 			}
-			if !strSliceContains(lbSkipLBStatuses, status) {
+			if !strSliceContains(getLbSkipStatuses(), status) {
 				return lb, status, nil
 			}
 
@@ -716,7 +730,7 @@ func resourceLBV2PoolRefreshFunc(lbClient *gophercloud.ServiceClient, lbID strin
 			if err != nil {
 				return lb, status, err
 			}
-			if !strSliceContains(lbSkipLBStatuses, status) {
+			if !strSliceContains(getLbSkipStatuses(), status) {
 				return lb, status, nil
 			}
 
@@ -772,7 +786,7 @@ func resourceLBV2LoadBalancerStatusRefreshFuncNeutron(lbClient *gophercloud.Serv
 		if statuses == nil || statuses.Loadbalancer == nil {
 			statuses = new(neutronloadbalancers.StatusTree)
 			statuses.Loadbalancer = new(neutronloadbalancers.LoadBalancer)
-		} else if !strSliceContains(lbSkipLBStatuses, statuses.Loadbalancer.ProvisioningStatus) {
+		} else if !strSliceContains(getLbSkipStatuses(), statuses.Loadbalancer.ProvisioningStatus) {
 			return statuses.Loadbalancer, statuses.Loadbalancer.ProvisioningStatus, nil
 		}
 
@@ -863,7 +877,7 @@ func resourceLBV2L7PolicyRefreshFunc(lbClient *gophercloud.ServiceClient, lbID s
 			if err != nil {
 				return lb, status, err
 			}
-			if !strSliceContains(lbSkipLBStatuses, status) {
+			if !strSliceContains(getLbSkipStatuses(), status) {
 				return lb, status, nil
 			}
 
@@ -947,7 +961,7 @@ func resourceLBV2L7RuleRefreshFunc(lbClient *gophercloud.ServiceClient, lbID str
 			if err != nil {
 				return lb, status, err
 			}
-			if !strSliceContains(lbSkipLBStatuses, status) {
+			if !strSliceContains(getLbSkipStatuses(), status) {
 				return lb, status, nil
 			}
 

--- a/openstack/resource_openstack_identity_user_v3.go
+++ b/openstack/resource_openstack_identity_user_v3.go
@@ -124,9 +124,9 @@ func resourceIdentityUserV3Create(d *schema.ResourceData, meta interface{}) erro
 
 	// Build the user options
 	options := map[users.Option]interface{}{}
-	for optionType, option := range userOptions {
-		if v, ok := d.GetOk(option); ok {
-			options[optionType] = v.(bool)
+	for _, option := range getUserOptions() {
+		if v, ok := d.GetOk(string(option)); ok {
+			options[option] = v.(bool)
 		}
 	}
 
@@ -177,9 +177,9 @@ func resourceIdentityUserV3Read(d *schema.ResourceData, meta interface{}) error 
 
 	// Check and see if any options match those defined in the schema.
 	options := user.Options
-	for _, option := range userOptions {
-		if v, ok := options[option]; ok {
-			d.Set(option, v.(bool))
+	for _, option := range getUserOptions() {
+		if v, ok := options[string(option)]; ok {
+			d.Set(string(option), v.(bool))
 		}
 	}
 
@@ -235,10 +235,10 @@ func resourceIdentityUserV3Update(d *schema.ResourceData, meta interface{}) erro
 
 	// Determine if the options have changed
 	options := map[users.Option]interface{}{}
-	for optionType, option := range userOptions {
-		if d.HasChange(option) {
+	for _, option := range getUserOptions() {
+		if d.HasChange(string(option)) {
 			hasChange = true
-			options[optionType] = d.Get(option).(bool)
+			options[option] = d.Get(string(option)).(bool)
 		}
 	}
 

--- a/openstack/resource_openstack_keymanager_container_v1.go
+++ b/openstack/resource_openstack_keymanager_container_v1.go
@@ -124,8 +124,8 @@ func resourceKeyManagerContainerV1() *schema.Resource {
 	elem := &schema.Resource{
 		Schema: make(map[string]*schema.Schema),
 	}
-	for _, aclOp := range aclOperations {
-		elem.Schema[aclOp] = aclSchema
+	for _, aclOp := range getSupportedACLOperations() {
+		elem.Schema[aclOp] = getACLSchema()
 	}
 	ret.Schema["acl"].Elem = elem
 

--- a/openstack/resource_openstack_keymanager_secret_v1.go
+++ b/openstack/resource_openstack_keymanager_secret_v1.go
@@ -175,8 +175,8 @@ func resourceKeyManagerSecretV1() *schema.Resource {
 	elem := &schema.Resource{
 		Schema: make(map[string]*schema.Schema),
 	}
-	for _, aclOp := range aclOperations {
-		elem.Schema[aclOp] = aclSchema
+	for _, aclOp := range getSupportedACLOperations() {
+		elem.Schema[aclOp] = getACLSchema()
 	}
 	ret.Schema["acl"].Elem = elem
 

--- a/openstack/resource_openstack_lb_l7policy_v2.go
+++ b/openstack/resource_openstack_lb_l7policy_v2.go
@@ -151,7 +151,7 @@ func resourceL7PolicyV2Create(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("Unable to retrieve %s: %s", redirectPoolID, err)
 		}
 
-		err = waitForLBV2Pool(lbClient, pool, "ACTIVE", lbPendingStatuses, timeout)
+		err = waitForLBV2Pool(lbClient, pool, "ACTIVE", getLbPendingStatuses(), timeout)
 		if err != nil {
 			return err
 		}
@@ -164,7 +164,7 @@ func resourceL7PolicyV2Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for parent Listener to become active before continuing.
-	err = waitForLBV2Listener(lbClient, parentListener, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Listener(lbClient, parentListener, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -184,7 +184,7 @@ func resourceL7PolicyV2Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for L7 Policy to become active before continuing
-	err = waitForLBV2L7Policy(lbClient, parentListener, l7Policy, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2L7Policy(lbClient, parentListener, l7Policy, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -278,7 +278,7 @@ func resourceL7PolicyV2Update(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("Unable to retrieve %s: %s", redirectPoolID, err)
 		}
 
-		err = waitForLBV2Pool(lbClient, pool, "ACTIVE", lbPendingStatuses, timeout)
+		err = waitForLBV2Pool(lbClient, pool, "ACTIVE", getLbPendingStatuses(), timeout)
 		if err != nil {
 			return err
 		}
@@ -297,13 +297,13 @@ func resourceL7PolicyV2Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for parent Listener to become active before continuing.
-	err = waitForLBV2Listener(lbClient, parentListener, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Listener(lbClient, parentListener, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
 
 	// Wait for L7 Policy to become active before continuing
-	err = waitForLBV2L7Policy(lbClient, parentListener, l7Policy, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2L7Policy(lbClient, parentListener, l7Policy, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -322,7 +322,7 @@ func resourceL7PolicyV2Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for L7 Policy to become active before continuing
-	err = waitForLBV2L7Policy(lbClient, parentListener, l7Policy, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2L7Policy(lbClient, parentListener, l7Policy, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -353,7 +353,7 @@ func resourceL7PolicyV2Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for Listener to become active before continuing.
-	err = waitForLBV2Listener(lbClient, listener, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Listener(lbClient, listener, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -371,7 +371,7 @@ func resourceL7PolicyV2Delete(d *schema.ResourceData, meta interface{}) error {
 		return CheckDeleted(d, err, "Error deleting L7 Policy")
 	}
 
-	err = waitForLBV2L7Policy(lbClient, listener, l7Policy, "DELETED", lbPendingDeleteStatuses, timeout)
+	err = waitForLBV2L7Policy(lbClient, listener, l7Policy, "DELETED", getLbPendingDeleteStatuses(), timeout)
 	if err != nil {
 		return err
 	}

--- a/openstack/resource_openstack_lb_l7rule_v2.go
+++ b/openstack/resource_openstack_lb_l7rule_v2.go
@@ -161,7 +161,7 @@ func resourceL7RuleV2Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for parent L7 Policy to become active before continuing
-	err = waitForLBV2L7Policy(lbClient, parentListener, parentL7Policy, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2L7Policy(lbClient, parentListener, parentL7Policy, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -181,7 +181,7 @@ func resourceL7RuleV2Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for L7 Rule to become active before continuing
-	err = waitForLBV2L7Rule(lbClient, parentListener, parentL7Policy, l7Rule, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2L7Rule(lbClient, parentListener, parentL7Policy, l7Rule, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -279,13 +279,13 @@ func resourceL7RuleV2Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for parent L7 Policy to become active before continuing
-	err = waitForLBV2L7Policy(lbClient, parentListener, parentL7Policy, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2L7Policy(lbClient, parentListener, parentL7Policy, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
 
 	// Wait for L7 Rule to become active before continuing
-	err = waitForLBV2L7Rule(lbClient, parentListener, parentL7Policy, l7Rule, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2L7Rule(lbClient, parentListener, parentL7Policy, l7Rule, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -304,7 +304,7 @@ func resourceL7RuleV2Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for L7 Rule to become active before continuing
-	err = waitForLBV2L7Rule(lbClient, parentListener, parentL7Policy, l7Rule, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2L7Rule(lbClient, parentListener, parentL7Policy, l7Rule, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -343,7 +343,7 @@ func resourceL7RuleV2Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for parent L7 Policy to become active before continuing
-	err = waitForLBV2L7Policy(lbClient, parentListener, parentL7Policy, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2L7Policy(lbClient, parentListener, parentL7Policy, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -361,7 +361,7 @@ func resourceL7RuleV2Delete(d *schema.ResourceData, meta interface{}) error {
 		return CheckDeleted(d, err, "Error deleting L7 Rule")
 	}
 
-	err = waitForLBV2L7Rule(lbClient, parentListener, parentL7Policy, l7Rule, "DELETED", lbPendingDeleteStatuses, timeout)
+	err = waitForLBV2L7Rule(lbClient, parentListener, parentL7Policy, l7Rule, "DELETED", getLbPendingDeleteStatuses(), timeout)
 	if err != nil {
 		return err
 	}

--- a/openstack/resource_openstack_lb_listener_v2.go
+++ b/openstack/resource_openstack_lb_listener_v2.go
@@ -154,7 +154,7 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 	timeout := d.Timeout(schema.TimeoutCreate)
 
 	// Wait for LoadBalancer to become active before continuing.
-	err = waitForLBV2LoadBalancer(lbClient, d.Get("loadbalancer_id").(string), "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2LoadBalancer(lbClient, d.Get("loadbalancer_id").(string), "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for the listener to become ACTIVE.
-	err = waitForLBV2Listener(lbClient, listener, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Listener(lbClient, listener, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -278,7 +278,7 @@ func resourceListenerV2Update(d *schema.ResourceData, meta interface{}) error {
 
 	// Wait for the listener to become ACTIVE.
 	timeout := d.Timeout(schema.TimeoutUpdate)
-	err = waitForLBV2Listener(lbClient, listener, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Listener(lbClient, listener, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -306,7 +306,7 @@ func resourceListenerV2Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for the listener to become ACTIVE.
-	err = waitForLBV2Listener(lbClient, listener, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Listener(lbClient, listener, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -343,7 +343,7 @@ func resourceListenerV2Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for the listener to become DELETED.
-	err = waitForLBV2Listener(lbClient, listener, "DELETED", lbPendingDeleteStatuses, timeout)
+	err = waitForLBV2Listener(lbClient, listener, "DELETED", getLbPendingDeleteStatuses(), timeout)
 	if err != nil {
 		return err
 	}

--- a/openstack/resource_openstack_lb_loadbalancer_v2.go
+++ b/openstack/resource_openstack_lb_loadbalancer_v2.go
@@ -144,7 +144,7 @@ func resourceLoadBalancerV2Create(d *schema.ResourceData, meta interface{}) erro
 
 	// Wait for load-balancer to become active before continuing.
 	timeout := d.Timeout(schema.TimeoutCreate)
-	err = waitForLBV2LoadBalancer(lbClient, lbID, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2LoadBalancer(lbClient, lbID, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -252,7 +252,7 @@ func resourceLoadBalancerV2Update(d *schema.ResourceData, meta interface{}) erro
 	if updateOpts != (neutronloadbalancers.UpdateOpts{}) {
 		// Wait for load-balancer to become active before continuing.
 		timeout := d.Timeout(schema.TimeoutUpdate)
-		err = waitForLBV2LoadBalancer(lbClient, d.Id(), "ACTIVE", lbPendingStatuses, timeout)
+		err = waitForLBV2LoadBalancer(lbClient, d.Id(), "ACTIVE", getLbPendingStatuses(), timeout)
 		if err != nil {
 			return err
 		}
@@ -271,7 +271,7 @@ func resourceLoadBalancerV2Update(d *schema.ResourceData, meta interface{}) erro
 		}
 
 		// Wait for load-balancer to become active before continuing.
-		err = waitForLBV2LoadBalancer(lbClient, d.Id(), "ACTIVE", lbPendingStatuses, timeout)
+		err = waitForLBV2LoadBalancer(lbClient, d.Id(), "ACTIVE", getLbPendingStatuses(), timeout)
 		if err != nil {
 			return err
 		}
@@ -314,7 +314,7 @@ func resourceLoadBalancerV2Delete(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	// Wait for load-balancer to become deleted.
-	err = waitForLBV2LoadBalancer(lbClient, d.Id(), "DELETED", lbPendingDeleteStatuses, timeout)
+	err = waitForLBV2LoadBalancer(lbClient, d.Id(), "DELETED", getLbPendingDeleteStatuses(), timeout)
 	if err != nil {
 		return err
 	}

--- a/openstack/resource_openstack_lb_member_v2.go
+++ b/openstack/resource_openstack_lb_member_v2.go
@@ -129,7 +129,7 @@ func resourceMemberV2Create(d *schema.ResourceData, meta interface{}) error {
 
 	// Wait for parent pool to become active before continuing
 	timeout := d.Timeout(schema.TimeoutCreate)
-	err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -149,7 +149,7 @@ func resourceMemberV2Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for member to become active before continuing
-	err = waitForLBV2Member(lbClient, parentPool, member, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Member(lbClient, parentPool, member, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -223,13 +223,13 @@ func resourceMemberV2Update(d *schema.ResourceData, meta interface{}) error {
 
 	// Wait for parent pool to become active before continuing.
 	timeout := d.Timeout(schema.TimeoutUpdate)
-	err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
 
 	// Wait for the member to become active before continuing.
-	err = waitForLBV2Member(lbClient, parentPool, member, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Member(lbClient, parentPool, member, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -248,7 +248,7 @@ func resourceMemberV2Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for the member to become active before continuing.
-	err = waitForLBV2Member(lbClient, parentPool, member, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Member(lbClient, parentPool, member, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -278,7 +278,7 @@ func resourceMemberV2Delete(d *schema.ResourceData, meta interface{}) error {
 
 	// Wait for parent pool to become active before continuing.
 	timeout := d.Timeout(schema.TimeoutDelete)
-	err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return CheckDeleted(d, err, "Error waiting for the members pool status")
 	}
@@ -297,7 +297,7 @@ func resourceMemberV2Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for the member to become DELETED.
-	err = waitForLBV2Member(lbClient, parentPool, member, "DELETED", lbPendingDeleteStatuses, timeout)
+	err = waitForLBV2Member(lbClient, parentPool, member, "DELETED", getLbPendingDeleteStatuses(), timeout)
 	if err != nil {
 		return err
 	}

--- a/openstack/resource_openstack_lb_members_v2.go
+++ b/openstack/resource_openstack_lb_members_v2.go
@@ -112,7 +112,7 @@ func resourceMembersV2Create(d *schema.ResourceData, meta interface{}) error {
 
 	// Wait for parent pool to become active before continuing
 	timeout := d.Timeout(schema.TimeoutCreate)
-	err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -131,7 +131,7 @@ func resourceMembersV2Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for parent pool to become active before continuing
-	err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,7 @@ func resourceMembersV2Update(d *schema.ResourceData, meta interface{}) error {
 
 		// Wait for parent pool to become active before continuing.
 		timeout := d.Timeout(schema.TimeoutUpdate)
-		err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", lbPendingStatuses, timeout)
+		err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", getLbPendingStatuses(), timeout)
 		if err != nil {
 			return err
 		}
@@ -204,7 +204,7 @@ func resourceMembersV2Update(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		// Wait for parent pool to become active before continuing
-		err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", lbPendingStatuses, timeout)
+		err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", getLbPendingStatuses(), timeout)
 		if err != nil {
 			return err
 		}
@@ -228,7 +228,7 @@ func resourceMembersV2Delete(d *schema.ResourceData, meta interface{}) error {
 
 	// Wait for parent pool to become active before continuing.
 	timeout := d.Timeout(schema.TimeoutDelete)
-	err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return CheckDeleted(d, err, "Error waiting for the members' pool status")
 	}
@@ -247,7 +247,7 @@ func resourceMembersV2Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for parent pool to become active before continuing.
-	err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return CheckDeleted(d, err, "Error waiting for the members' pool status")
 	}

--- a/openstack/resource_openstack_lb_monitor_v2.go
+++ b/openstack/resource_openstack_lb_monitor_v2.go
@@ -133,7 +133,7 @@ func resourceMonitorV2Create(d *schema.ResourceData, meta interface{}) error {
 
 	// Wait for parent pool to become active before continuing.
 	timeout := d.Timeout(schema.TimeoutCreate)
-	err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -153,7 +153,7 @@ func resourceMonitorV2Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for monitor to become active before continuing
-	err = waitForLBV2Monitor(lbClient, parentPool, monitor, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Monitor(lbClient, parentPool, monitor, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -256,13 +256,13 @@ func resourceMonitorV2Update(d *schema.ResourceData, meta interface{}) error {
 
 	// Wait for parent pool to become active before continuing.
 	timeout := d.Timeout(schema.TimeoutUpdate)
-	err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
 
 	// Wait for monitor to become active before continuing.
-	err = waitForLBV2Monitor(lbClient, parentPool, monitor, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Monitor(lbClient, parentPool, monitor, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -281,7 +281,7 @@ func resourceMonitorV2Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for monitor to become active before continuing
-	err = waitForLBV2Monitor(lbClient, parentPool, monitor, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Monitor(lbClient, parentPool, monitor, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -312,7 +312,7 @@ func resourceMonitorV2Delete(d *schema.ResourceData, meta interface{}) error {
 
 	// Wait for parent pool to become active before continuing
 	timeout := d.Timeout(schema.TimeoutUpdate)
-	err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Pool(lbClient, parentPool, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -331,7 +331,7 @@ func resourceMonitorV2Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for monitor to become DELETED
-	err = waitForLBV2Monitor(lbClient, parentPool, monitor, "DELETED", lbPendingDeleteStatuses, timeout)
+	err = waitForLBV2Monitor(lbClient, parentPool, monitor, "DELETED", getLbPendingDeleteStatuses(), timeout)
 	if err != nil {
 		return err
 	}

--- a/openstack/resource_openstack_lb_pool_v2.go
+++ b/openstack/resource_openstack_lb_pool_v2.go
@@ -179,13 +179,13 @@ func resourcePoolV2Create(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("Unable to get openstack_lb_listener_v2 %s: %s", listenerID, err)
 		}
 
-		waitErr := waitForLBV2Listener(lbClient, listener, "ACTIVE", lbPendingStatuses, timeout)
+		waitErr := waitForLBV2Listener(lbClient, listener, "ACTIVE", getLbPendingStatuses(), timeout)
 		if waitErr != nil {
 			return fmt.Errorf(
 				"Error waiting for openstack_lb_listener_v2 %s to become active: %s", listenerID, err)
 		}
 	} else {
-		waitErr := waitForLBV2LoadBalancer(lbClient, lbID, "ACTIVE", lbPendingStatuses, timeout)
+		waitErr := waitForLBV2LoadBalancer(lbClient, lbID, "ACTIVE", getLbPendingStatuses(), timeout)
 		if waitErr != nil {
 			return fmt.Errorf(
 				"Error waiting for openstack_lb_loadbalancer_v2 %s to become active: %s", lbID, err)
@@ -208,7 +208,7 @@ func resourcePoolV2Create(d *schema.ResourceData, meta interface{}) error {
 
 	// Pool was successfully created
 	// Wait for pool to become active before continuing
-	err = waitForLBV2Pool(lbClient, pool, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Pool(lbClient, pool, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -277,7 +277,7 @@ func resourcePoolV2Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for pool to become active before continuing
-	err = waitForLBV2Pool(lbClient, pool, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Pool(lbClient, pool, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -296,7 +296,7 @@ func resourcePoolV2Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for pool to become active before continuing
-	err = waitForLBV2Pool(lbClient, pool, "ACTIVE", lbPendingStatuses, timeout)
+	err = waitForLBV2Pool(lbClient, pool, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return err
 	}
@@ -333,7 +333,7 @@ func resourcePoolV2Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for Pool to delete
-	err = waitForLBV2Pool(lbClient, pool, "DELETED", lbPendingDeleteStatuses, timeout)
+	err = waitForLBV2Pool(lbClient, pool, "DELETED", getLbPendingDeleteStatuses(), timeout)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Prepare to enable gochecknoglobals linter for #1063 

Replace global variables with getter functions:
* supported ACL operations and ACL schema
* valid date filters
* user options
* lb statuses