### PR TITLE
Moved global mutexKV to Config structure

### DIFF
--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -9,13 +9,11 @@ import (
 	"github.com/gophercloud/utils/terraform/auth"
 )
 
-// This is a global MutexKV for use within this plugin.
-var osMutexKV = mutexkv.NewMutexKV()
-
 // Use openstackbase.Config as the base/foundation of this provider's
-// Config struct.
+// Config struct and contains a global MutexKV.
 type Config struct {
 	auth.Config
+	*mutexkv.MutexKV
 }
 
 // Provider returns a schema.Provider for OpenStack.
@@ -511,6 +509,7 @@ func configureProvider(d *schema.ResourceData, terraformVersion string) (interfa
 			TerraformVersion:            terraformVersion,
 			SDKVersion:                  meta.SDKVersionString(),
 		},
+		mutexkv.NewMutexKV(),
 	}
 
 	v, ok := d.GetOkExists("insecure")

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -9,8 +9,7 @@ import (
 	"github.com/gophercloud/utils/terraform/auth"
 )
 
-// Use openstackbase.Config as the base/foundation of this provider's
-// Config struct and contains a global MutexKV.
+// Config contains auth parameters and also provides an instance of MutexKV.
 type Config struct {
 	auth.Config
 	*mutexkv.MutexKV

--- a/openstack/provider_test.go
+++ b/openstack/provider_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/pathorcontents"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -409,6 +410,7 @@ func testAccAuthFromEnv() (*Config, error) {
 			Username:          os.Getenv("OS_USERNAME"),
 			UserID:            os.Getenv("OS_USER_ID"),
 		},
+		mutexkv.NewMutexKV(),
 	}
 
 	if err := config.LoadAndValidate(); err != nil {

--- a/openstack/resource_openstack_networking_router_route_v2.go
+++ b/openstack/resource_openstack_networking_router_route_v2.go
@@ -55,8 +55,9 @@ func resourceNetworkingRouterRouteV2Create(d *schema.ResourceData, meta interfac
 	}
 
 	routerID := d.Get("router_id").(string)
-	osMutexKV.Lock(routerID)
-	defer osMutexKV.Unlock(routerID)
+	mutex := config.MutexKV
+	mutex.Lock(routerID)
+	defer mutex.Unlock(routerID)
 
 	r, err := routers.Get(networkingClient, routerID).Extract()
 	if err != nil {
@@ -146,8 +147,9 @@ func resourceNetworkingRouterRouteV2Delete(d *schema.ResourceData, meta interfac
 	}
 
 	routerID := d.Get("router_id").(string)
-	osMutexKV.Lock(routerID)
-	defer osMutexKV.Unlock(routerID)
+	mutex := config.MutexKV
+	mutex.Lock(routerID)
+	defer mutex.Unlock(routerID)
 
 	r, err := routers.Get(networkingClient, routerID).Extract()
 	if err != nil {

--- a/openstack/resource_openstack_networking_router_v2.go
+++ b/openstack/resource_openstack_networking_router_v2.go
@@ -347,8 +347,9 @@ func resourceNetworkingRouterV2Update(d *schema.ResourceData, meta interface{}) 
 	}
 
 	routerID := d.Id()
-	osMutexKV.Lock(routerID)
-	defer osMutexKV.Unlock(routerID)
+	mutex := config.MutexKV
+	mutex.Lock(routerID)
+	defer mutex.Unlock(routerID)
 
 	var hasChange bool
 	var updateOpts routers.UpdateOpts

--- a/openstack/resource_openstack_networking_secgroup_rule_v2.go
+++ b/openstack/resource_openstack_networking_secgroup_rule_v2.go
@@ -107,11 +107,12 @@ func resourceNetworkingSecGroupRuleV2() *schema.Resource {
 }
 
 func resourceNetworkingSecGroupRuleV2Create(d *schema.ResourceData, meta interface{}) error {
-	securityGroupID := d.Get("security_group_id").(string)
-	osMutexKV.Lock(securityGroupID)
-	defer osMutexKV.Unlock(securityGroupID)
-
 	config := meta.(*Config)
+	securityGroupID := d.Get("security_group_id").(string)
+	mutex := config.MutexKV
+	mutex.Lock(securityGroupID)
+	defer mutex.Unlock(securityGroupID)
+
 	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
@@ -204,11 +205,12 @@ func resourceNetworkingSecGroupRuleV2Read(d *schema.ResourceData, meta interface
 }
 
 func resourceNetworkingSecGroupRuleV2Delete(d *schema.ResourceData, meta interface{}) error {
-	securityGroupID := d.Get("security_group_id").(string)
-	osMutexKV.Lock(securityGroupID)
-	defer osMutexKV.Unlock(securityGroupID)
-
 	config := meta.(*Config)
+	securityGroupID := d.Get("security_group_id").(string)
+	mutex := config.MutexKV
+	mutex.Lock(securityGroupID)
+	defer mutex.Unlock(securityGroupID)
+
 	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)

--- a/openstack/resource_openstack_networking_subnet_route_v2.go
+++ b/openstack/resource_openstack_networking_subnet_route_v2.go
@@ -59,8 +59,9 @@ func resourceNetworkingSubnetRouteV2Create(d *schema.ResourceData, meta interfac
 	nextHop := d.Get("next_hop").(string)
 
 	subnetID := d.Get("subnet_id").(string)
-	osMutexKV.Lock(subnetID)
-	defer osMutexKV.Unlock(subnetID)
+	mutex := config.MutexKV
+	mutex.Lock(subnetID)
+	defer mutex.Unlock(subnetID)
 
 	subnet, err := subnets.Get(networkingClient, subnetID).Extract()
 	if err != nil {
@@ -162,8 +163,9 @@ func resourceNetworkingSubnetRouteV2Delete(d *schema.ResourceData, meta interfac
 	}
 
 	subnetID := d.Get("subnet_id").(string)
-	osMutexKV.Lock(subnetID)
-	defer osMutexKV.Unlock(subnetID)
+	mutex := config.MutexKV
+	mutex.Lock(subnetID)
+	defer mutex.Unlock(subnetID)
 
 	subnet, err := subnets.Get(networkingClient, subnetID).Extract()
 	if err != nil {


### PR DESCRIPTION
So this global mutex kv struct available everywhere in provider without
being a global variable.

For #1063 