### PR TITLE
Networking V2: fix 'binding.host_id' reset (#1082)

### DIFF
--- a/openstack/resource_openstack_networking_port_v2.go
+++ b/openstack/resource_openstack_networking_port_v2.go
@@ -224,6 +224,7 @@ func resourceNetworkingPortV2() *schema.Resource {
 						"host_id": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"profile": {
 							Type:             schema.TypeString,


### PR DESCRIPTION
Hi,

This is linked to my issue #1082.

I don't know if this is the right fix but this seems to fix my issue (and maybe it would prevent an explicit setting of the host_id in the Terraform file?). It seems to be set as "Computed " as well in openstack/data_source_openstack_networking_port_v2.go but I am really not aware of the difference in purpose between these 2 files.

Thanks for the feedback,
Gregory

----

If the binding section is defined in the ressource definition (e.g.
just with "binding.vnic_type" set), but "binding.host_id" is left empty,
the port is created correctly and "binding.host_id" populated with the
id of the selected hypervisor. However, upon a subsequent plan/apply,
Terraform seems to reset "binding.host_id" to NULL. The port enters
status DOWN and connectivity is lost. Not sure this is the right fix,
but it seems the "host_id" should not be overriden in this case.

Signed-off-by: Gregory Vander Schueren <gregory.vanderschueren@tessares.net>