### PR TITLE
Tenant attribute support for openstack_dns_zone_v2

### DIFF
--- a/openstack/data_source_openstack_dns_zone_v2.go
+++ b/openstack/data_source_openstack_dns_zone_v2.go
@@ -20,6 +20,11 @@ func dataSourceDNSZoneV2() *schema.Resource {
 				Computed: true,
 			},
 
+			"all_projects": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -140,6 +145,8 @@ func dataSourceDNSZoneV2Read(d *schema.ResourceData, meta interface{}) error {
 	if v, ok := d.GetOk("type"); ok {
 		listOpts.Type = v.(string)
 	}
+
+	dnsClientSetAuthHeader(d, dnsClient)
 
 	pages, err := zones.List(dnsClient, listOpts).AllPages()
 	if err != nil {

--- a/openstack/data_source_openstack_dns_zone_v2_test.go
+++ b/openstack/data_source_openstack_dns_zone_v2_test.go
@@ -14,19 +14,20 @@ func zoneName() string {
 }
 
 func TestAccOpenStackDNSZoneV2DataSource_basic(t *testing.T) {
+	zoneName := zoneName()
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckDNS(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOpenStackDNSZoneV2DataSourceZone(),
+				Config: testAccOpenStackDNSZoneV2DataSourceZone(zoneName),
 			},
 			{
-				Config: testAccOpenStackDNSZoneV2DataSourceBasic(),
+				Config: testAccOpenStackDNSZoneV2DataSourceBasic(zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDNSZoneV2DataSourceID("data.openstack_dns_zone_v2.z1"),
 					resource.TestCheckResourceAttr(
-						"data.openstack_dns_zone_v2.z1", "name", zoneName()),
+						"data.openstack_dns_zone_v2.z1", "name", zoneName),
 					resource.TestCheckResourceAttr(
 						"data.openstack_dns_zone_v2.z1", "type", "PRIMARY"),
 					resource.TestCheckResourceAttr(
@@ -52,21 +53,21 @@ func testAccCheckDNSZoneV2DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccOpenStackDNSZoneV2DataSourceZone() string {
+func testAccOpenStackDNSZoneV2DataSourceZone(zoneName string) string {
 	return fmt.Sprintf(`
 resource "openstack_dns_zone_v2" "z1" {
   name = "%s"
   email = "terraform-dns-zone-v2-test-name@example.com"
   type = "PRIMARY"
   ttl = 7200
-}`, zoneName())
+}`, zoneName)
 }
 
-func testAccOpenStackDNSZoneV2DataSourceBasic() string {
+func testAccOpenStackDNSZoneV2DataSourceBasic(zoneName string) string {
 	return fmt.Sprintf(`
 %s
 data "openstack_dns_zone_v2" "z1" {
 	name = "${openstack_dns_zone_v2.z1.name}"
 }
-`, testAccOpenStackDNSZoneV2DataSourceZone())
+`, testAccOpenStackDNSZoneV2DataSourceZone(zoneName))
 }

--- a/openstack/data_source_openstack_identity_project_v3.go
+++ b/openstack/data_source_openstack_identity_project_v3.go
@@ -129,7 +129,7 @@ func dataSourceIdentityProjectV3Read(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if len(allProjects) > 1 {
-		return fmt.Errorf("Your openstack_identity_project_v3 query returned more than one result")
+		return fmt.Errorf("Your openstack_identity_project_v3 query returned more than one result %#v", allProjects)
 	}
 
 	project = allProjects[0]

--- a/openstack/dns_zone_v2.go
+++ b/openstack/dns_zone_v2.go
@@ -5,9 +5,11 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/zones"
+	tokens3 "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 )
 
 // ZoneCreateOpts represents the attributes used when creating a new DNS zone.
@@ -35,6 +37,45 @@ func (opts ZoneCreateOpts) ToZoneCreateMap() (map[string]interface{}, error) {
 	return nil, fmt.Errorf("Expected map but got %T", b[""])
 }
 
+const headerAuthSudoTenantID string = "X-Auth-Sudo-Tenant-ID"
+const headerAuthAllProjects string = "X-Auth-All-Projects"
+
+// dnsClientSetAuthHeaders sets auth headers for interacting with different projects.
+func dnsClientSetAuthHeader(resourceData *schema.ResourceData, dnsClient *gophercloud.ServiceClient) error {
+	// Extracting project ID from token to compare with provided one
+	project, err := getProjectFromToken(dnsClient)
+	if err != nil {
+		return fmt.Errorf("Error extracting project ID from token: %s", err)
+	}
+	headers := make(map[string]string)
+	// If all projects need to be listed to lookup a zone, set AuthAllProjects header
+	if v, ok := resourceData.GetOk("all_projects"); ok {
+		if allProjects, ok := v.(string); ok {
+			headers[headerAuthAllProjects] = allProjects
+		} else {
+			return fmt.Errorf("Expected all_projects as string, but got %T", v)
+		}
+	}
+
+	// If project_id is different from auth one, set AuthSudo header
+	if v, ok := resourceData.GetOk("project_id"); ok {
+		if projectID, ok := v.(string); ok {
+			if project.ID != projectID {
+				headers[headerAuthSudoTenantID] = projectID
+			}
+		} else {
+			return fmt.Errorf("Expected project_id as string, but got %T", v)
+		}
+	}
+
+	if len(headers) != 0 {
+		dnsClient.MoreHeaders = headers
+		log.Printf("[DEBUG] openstack_dns_zone_v2 request headers set: %#v", headers)
+	}
+
+	return nil
+}
+
 func dnsZoneV2RefreshFunc(dnsClient *gophercloud.ServiceClient, zoneID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		zone, err := zones.Get(dnsClient, zoneID).Extract()
@@ -49,4 +90,31 @@ func dnsZoneV2RefreshFunc(dnsClient *gophercloud.ServiceClient, zoneID string) r
 		log.Printf("[DEBUG] openstack_dns_zone_v2 %s current status: %s", zone.ID, zone.Status)
 		return zone, zone.Status, nil
 	}
+}
+
+func getProjectFromToken(dnsClient *gophercloud.ServiceClient) (*tokens3.Project, error) {
+	var (
+		project *tokens3.Project
+		err     error
+	)
+	r := dnsClient.ProviderClient.GetAuthResult()
+	switch result := r.(type) {
+	case tokens3.CreateResult:
+		project, err = result.ExtractProject()
+		if err != nil {
+			return nil, err
+		}
+	case tokens3.GetResult:
+		project, err = result.ExtractProject()
+		if err != nil {
+			return nil, err
+		}
+	default:
+		res := tokens3.Get(dnsClient, dnsClient.ProviderClient.TokenID)
+		project, err = res.ExtractProject()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return project, nil
 }

--- a/openstack/resource_openstack_dns_zone_v2.go
+++ b/openstack/resource_openstack_dns_zone_v2.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/zones"
@@ -19,7 +20,18 @@ func resourceDNSZoneV2() *schema.Resource {
 		Update: resourceDNSZoneV2Update,
 		Delete: resourceDNSZoneV2Delete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				// Allow import from different project with id:project_id
+				parts := strings.Split(d.Id(), ":")
+				if parts[0] == "" || len(parts) > 2 {
+					return nil, fmt.Errorf("unexpected format of ID (%s), expected zone <id> or <id>:<project_id>", d.Id())
+				} else if len(parts) == 2 {
+					d.Set("project_id", parts[1])
+				}
+
+				d.SetId(parts[0])
+				return []*schema.ResourceData{d}, nil
+			},
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -34,6 +46,13 @@ func resourceDNSZoneV2() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+			},
+
+			"project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
 			},
 
 			"name": {
@@ -113,6 +132,10 @@ func resourceDNSZoneV2Create(d *schema.ResourceData, meta interface{}) error {
 		MapValueSpecs(d),
 	}
 
+	if err := dnsClientSetAuthHeader(d, dnsClient); err != nil {
+		return fmt.Errorf("Error setting dns client auth headers: %s", err)
+	}
+
 	log.Printf("[DEBUG] openstack_dns_zone_v2 create options: %#v", createOpts)
 	n, err := zones.Create(dnsClient, createOpts).Extract()
 	if err != nil {
@@ -148,6 +171,10 @@ func resourceDNSZoneV2Read(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating OpenStack DNS client: %s", err)
 	}
 
+	if err := dnsClientSetAuthHeader(d, dnsClient); err != nil {
+		return fmt.Errorf("Error setting dns client auth headers: %s", err)
+	}
+
 	n, err := zones.Get(dnsClient, d.Id()).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "Error retrieving openstack_dns_zone_v2")
@@ -163,6 +190,7 @@ func resourceDNSZoneV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("attributes", n.Attributes)
 	d.Set("masters", n.Masters)
 	d.Set("region", GetRegion(d, config))
+	d.Set("project_id", n.ProjectID)
 
 	return nil
 }
@@ -190,6 +218,10 @@ func resourceDNSZoneV2Update(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("description") {
 		description := d.Get("description").(string)
 		updateOpts.Description = &description
+	}
+
+	if err := dnsClientSetAuthHeader(d, dnsClient); err != nil {
+		return fmt.Errorf("Error setting dns client auth headers: %s", err)
 	}
 
 	log.Printf("[DEBUG] Updating openstack_dns_zone_v2 %s with options: %#v", d.Id(), updateOpts)
@@ -222,6 +254,10 @@ func resourceDNSZoneV2Delete(d *schema.ResourceData, meta interface{}) error {
 	dnsClient, err := config.DNSV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack DNS client: %s", err)
+	}
+
+	if err := dnsClientSetAuthHeader(d, dnsClient); err != nil {
+		return fmt.Errorf("Error setting dns client auth headers: %s", err)
 	}
 
 	_, err = zones.Delete(dnsClient, d.Id()).Extract()

--- a/website/docs/d/dns_zone_v2.html.markdown
+++ b/website/docs/d/dns_zone_v2.html.markdown
@@ -26,6 +26,9 @@ data "openstack_dns_zone_v2" "zone_1" {
 
 * `name` - (Optional) The name of the zone.
 
+* `project_id` - (Optional) The ID of the project the DNS zone is obtained from,
+  sets `X-Auth-Sudo-Tenant-ID` header (requires an assigned user role in target project)
+
 * `description` - (Optional) A description of the zone.
 
 * `email` - (Optional) The email contact for the zone record.
@@ -35,6 +38,9 @@ data "openstack_dns_zone_v2" "zone_1" {
 * `ttl` - (Optional) The time to live (TTL) of the zone.
 
 * `type` - (Optional) The type of the zone. Can either be `PRIMARY` or `SECONDARY`.
+
+* `all_projects` - (Optional) Try to obtain zone ID by listing all projects
+  (requires admin role by default, depends on your policy configuration)
 
 ## Attributes Reference
 

--- a/website/docs/r/dns_zone_v2.html.markdown
+++ b/website/docs/r/dns_zone_v2.html.markdown
@@ -36,6 +36,10 @@ The following arguments are supported:
 * `name` - (Required) The name of the zone. Note the `.` at the end of the name.
   Changing this creates a new DNS zone.
 
+* `project_id` - (Optional) The ID of the project DNS zone is created
+  for, sets `X-Auth-Sudo-Tenant-ID` header (requires an assigned 
+  user role in target project)
+
 * `email` - (Optional) The email contact for the zone record.
 
 * `type` - (Optional) The type of zone. Can either be `PRIMARY` or `SECONDARY`.
@@ -60,6 +64,7 @@ The following attributes are exported:
 
 * `region` - See Argument Reference above.
 * `name` - See Argument Reference above.
+* `project_id` - See Argument Reference above.
 * `email` - See Argument Reference above.
 * `type` - See Argument Reference above.
 * `attributes` - See Argument Reference above.
@@ -70,8 +75,9 @@ The following attributes are exported:
 
 ## Import
 
-This resource can be imported by specifying the zone ID:
+This resource can be imported by specifying the zone ID with optional project ID:
 
 ```
 $ terraform import openstack_dns_zone_v2.zone_1 <zone_id>
+$ terraform import openstack_dns_zone_v2.zone_1 <zone_id>:<project_id>
 ```


### PR DESCRIPTION
  * Replicates `--all-projects` and `--sudo-project-id` functionality
    from openstackclient
  * Users can set project_id and create designate dns zones in a
    different project
  * Resource import support with `<zone_uuid>:<project_id>`
  * `project_id` attribute support for data source
  * Support for getting a zone id from a unique zone name by listing all
    projects