### PR TITLE
VPNaaS endpoint group resource: use schema.TypeSet for endpoints

### DIFF
--- a/openstack/resource_openstack_vpnaas_endpoint_group_v2.go
+++ b/openstack/resource_openstack_vpnaas_endpoint_group_v2.go
@@ -55,7 +55,7 @@ func resourceEndpointGroupV2() *schema.Resource {
 				ForceNew: true,
 			},
 			"endpoints": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},


### PR DESCRIPTION
The order of endpoints does not matter. If OpenStack API
returns a different order than specified in the terraform
resource, terraform will unnecessarily try to recreate the
resource.

Fixes #1088