### PR TITLE
Add flavor_id to openstack_compute_flavor_v2 resource creation options

### DIFF
--- a/openstack/resource_openstack_compute_flavor_v2.go
+++ b/openstack/resource_openstack_compute_flavor_v2.go
@@ -26,6 +26,12 @@ func resourceComputeFlavorV2() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"flavor_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -101,6 +107,7 @@ func resourceComputeFlavorV2Create(d *schema.ResourceData, meta interface{}) err
 		RAM:        d.Get("ram").(int),
 		VCPUs:      d.Get("vcpus").(int),
 		Disk:       &disk,
+		ID:         d.Get("flavor_id").(string),
 		Swap:       &swap,
 		RxTxFactor: d.Get("rx_tx_factor").(float64),
 		IsPublic:   &isPublic,
@@ -146,6 +153,7 @@ func resourceComputeFlavorV2Read(d *schema.ResourceData, meta interface{}) error
 	d.Set("ram", fl.RAM)
 	d.Set("vcpus", fl.VCPUs)
 	d.Set("disk", fl.Disk)
+	d.Set("flavor_id", fl.ID)
 	d.Set("swap", fl.Swap)
 	d.Set("rx_tx_factor", fl.RxTxFactor)
 	d.Set("is_public", fl.IsPublic)

--- a/openstack/resource_openstack_compute_flavor_v2_test.go
+++ b/openstack/resource_openstack_compute_flavor_v2_test.go
@@ -35,6 +35,20 @@ func TestAccComputeV2Flavor_basic(t *testing.T) {
 						"openstack_compute_flavor_v2.flavor_1", "disk", "5"),
 				),
 			},
+			{
+				Config: testAccComputeV2FlavorBasicWithID(flavorName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2FlavorExists("openstack_compute_flavor_v2.flavor_1", &flavor),
+					resource.TestCheckResourceAttr(
+						"openstack_compute_flavor_v2.flavor_1", "ram", "2048"),
+					resource.TestCheckResourceAttr(
+						"openstack_compute_flavor_v2.flavor_1", "vcpus", "2"),
+					resource.TestCheckResourceAttr(
+						"openstack_compute_flavor_v2.flavor_1", "disk", "5"),
+					resource.TestCheckResourceAttr(
+						"openstack_compute_flavor_v2.flavor_1", "flavor_id", "b50e603d-29d0-461a-88f7-bd6750d4ce3d"),
+				),
+			},
 		},
 	})
 }
@@ -143,6 +157,19 @@ func testAccComputeV2FlavorBasic(flavorName string) string {
     `, flavorName)
 }
 
+func testAccComputeV2FlavorBasicWithID(flavorName string) string {
+	return fmt.Sprintf(`
+    resource "openstack_compute_flavor_v2" "flavor_1" {
+      name = "%s"
+      flavor_id = "b50e603d-29d0-461a-88f7-bd6750d4ce3d"
+      ram = 2048
+      vcpus = 2
+      disk = 5
+
+      is_public = true
+    }
+    `, flavorName)
+}
 func testAccComputeV2FlavorExtraSpecs1(flavorName string) string {
 	return fmt.Sprintf(`
     resource "openstack_compute_flavor_v2" "flavor_1" {

--- a/website/docs/r/compute_flavor_v2.html.markdown
+++ b/website/docs/r/compute_flavor_v2.html.markdown
@@ -41,6 +41,9 @@ The following arguments are supported:
 * `ram` - (Required) The amount of RAM to use, in megabytes. Changing this
     creates a new flavor.
 
+* `flavor_id` - (Optional) Unique ID (integer or UUID) of flavor to create. Changing 
+    this creates a new flavor.
+
 * `vcpus` - (Required) The number of virtual CPUs to use. Changing this creates
     a new flavor.
 


### PR DESCRIPTION
Openstack and Gopherclioud have ability to set compute flavor UUID while creating flavor.
Replicating this functionality in terraform. Docs and tests also altered.