### PR TITLE
Upgrade golangci-lint-action for new github actions env changes

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,6 +14,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
           version: v1.31


### PR DESCRIPTION
Github deprecated some env things:

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

New golangci-lint looks like it fixes this

https://github.com/golangci/golangci-lint-action/issues/127#issuecomment-729139550