### PR TITLE
Issue/897 update compute_flavor_v2 and compute_instance_v2 docs with missing arguments

### DIFF
--- a/openstack/resource_openstack_compute_flavor_v2_test.go
+++ b/openstack/resource_openstack_compute_flavor_v2_test.go
@@ -33,6 +33,8 @@ func TestAccComputeV2Flavor_basic(t *testing.T) {
 						"openstack_compute_flavor_v2.flavor_1", "vcpus", "2"),
 					resource.TestCheckResourceAttr(
 						"openstack_compute_flavor_v2.flavor_1", "disk", "5"),
+					resource.TestCheckResourceAttr(
+						"openstack_compute_flavor_v2.flavor_1", "ephemeral", "64"),
 				),
 			},
 			{
@@ -151,6 +153,7 @@ func testAccComputeV2FlavorBasic(flavorName string) string {
       ram = 2048
       vcpus = 2
       disk = 5
+      ephemeral = 64
 
       is_public = true
     }

--- a/website/docs/r/compute_flavor_v2.html.markdown
+++ b/website/docs/r/compute_flavor_v2.html.markdown
@@ -41,14 +41,17 @@ The following arguments are supported:
 * `ram` - (Required) The amount of RAM to use, in megabytes. Changing this
     creates a new flavor.
 
-* `flavor_id` - (Optional) Unique ID (integer or UUID) of flavor to create. Changing 
+* `flavor_id` - (Optional) Unique ID (integer or UUID) of flavor to create. Changing
     this creates a new flavor.
 
 * `vcpus` - (Required) The number of virtual CPUs to use. Changing this creates
     a new flavor.
 
-* `disk` - (Required) The amount of disk space in gigabytes to use for the root
+* `disk` - (Required) The amount of disk space in GiB to use for the root
     (/) partition. Changing this creates a new flavor.
+
+* `ephemeral` - (Optional) The amount of ephemeral in GiB. If unspecified,
+    the default is 0. Changing this creates a new flavor.
 
 * `swap` - (Optional) The amount of disk space in megabytes to use. If
     unspecified, the default is 0. Changing this creates a new flavor.
@@ -70,6 +73,7 @@ The following attributes are exported:
 * `ram` - See Argument Reference above.
 * `vcpus` - See Argument Reference above.
 * `disk` - See Argument Reference above.
+* `ephemeral` - See Argument Reference above.
 * `swap` - See Argument Reference above.
 * `rx_tx_factor` - See Argument Reference above.
 * `is_public` - See Argument Reference above.

--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -247,6 +247,7 @@ resource "openstack_compute_instance_v2" "multi-eph" {
     destination_type      = "local"
     source_type           = "blank"
     volume_size           = 1
+    guest_format          = "ext4"
   }
 
   block_device {
@@ -255,6 +256,42 @@ resource "openstack_compute_instance_v2" "multi-eph" {
     destination_type      = "local"
     source_type           = "blank"
     volume_size           = 1
+  }
+}
+```
+
+### Instance with Boot Disk and Swap Disk
+
+```hcl
+resource "openstack_compute_flavor_v2" "flavor-with-swap" {
+  name  = "flavor-with-swap"
+  ram   = "8096"
+  vcpus = "2"
+  disk  = "20"
+  swap  = "4096"
+}
+
+resource "openstack_compute_instance_v2" "vm-swap" {
+  name            = "vm_swap"
+  flavor_id       = "${openstack_compute_flavor_v2.flavor-with-swap.id}"
+  key_pair        = "my_key_pair_name"
+  security_groups = ["default"]
+
+  block_device {
+    boot_index            = 0
+    delete_on_termination = true
+    destination_type      = "local"
+    source_type           = "image"
+    uuid                  = "<image-id>"
+  }
+
+  block_device {
+    boot_index            = -1
+    delete_on_termination = true
+    destination_type      = "local"
+    source_type           = "blank"
+    guest_format          = "swap"
+    volume_size           = 4
   }
 }
 ```
@@ -407,6 +444,13 @@ The `block_device` block supports:
     in the following combinations: source=image and destination=volume,
     source=blank and destination=local, and source=blank and destination=volume.
     Changing this creates a new server.
+
+* `guest_format` - (Optional) Specifies the guest server disk file system format,
+    such as `ext2`, `ext3`, `ext4`, `xfs` or `swap`. Swap block device mappings
+    have the following restrictions: source_type must be blank and destination_type
+    must be local and only one swap disk per server and the size of the swap disk
+    must be less than or equal to the swap size of the flavor. Changing this
+    creates a new server.
 
 * `boot_index` - (Optional) The boot index of the volume. It defaults to 0.
     Changing this creates a new server.


### PR DESCRIPTION
- compute_flavor_v2:
  `ephemeral` argument was missing from docs while it is [supported](https://github.com/terraform-provider-openstack/terraform-provider-openstack/blob/master/openstack/resource_openstack_compute_flavor_v2.go#L78). Updated the docs and added the argument in one of the tests

- compute_instance_v2
  `guest_format` argument was missing from docs while it is [supported](https://github.com/hashicorp/terraform-provider-openstack/blob/5b145a14e27f78440aeaf60f0156f0cd014f7c39/openstack/resource_openstack_compute_instance_v2.go#L1065). Updated the docs with info and added an example with swap.

Close #897 