### PR TITLE
Allow to disable status check in resource_openstack_dns_zone_v2

### DIFF
--- a/openstack/import_openstack_dns_zone_v2_test.go
+++ b/openstack/import_openstack_dns_zone_v2_test.go
@@ -25,6 +25,9 @@ func TestAccDNSV2Zone_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"disable_status_check",
+				},
 			},
 		},
 	})

--- a/website/docs/r/dns_zone_v2.html.markdown
+++ b/website/docs/r/dns_zone_v2.html.markdown
@@ -58,6 +58,10 @@ The following arguments are supported:
 * `value_specs` - (Optional) Map of additional options. Changing this creates a
   new zone.
 
+* `disable_status_check` - (Optional) Disable wait for zone to reach ACTIVE
+  status. The check is enabled by default. If this argument is true, zone
+  will be considered as created/updated if OpenStack request returned success.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
This will allow terraform to tolerate some backend issues in Designate. If zone is created in Designate, and even all the backends are down, Designate will try to recover.

If only one of the backends is down, zone will be in ERROR state, but will be served by other backends. In this case, waiting for ACTIVE state also doesn't make sense.