### PR TITLE
Docs: remove mention of `floating_ip` option in `openstack_compute_instance_v2`.

### DIFF
--- a/website/docs/r/compute_floatingip_associate_v2.html.markdown
+++ b/website/docs/r/compute_floatingip_associate_v2.html.markdown
@@ -8,8 +8,7 @@ description: |-
 
 # openstack\_compute\_floatingip_associate_v2
 
-Associate a floating IP to an instance. This can be used instead of the
-`floating_ip` options in `openstack_compute_instance_v2`.
+Associate a floating IP to an instance.
 
 ## Example Usage
 


### PR DESCRIPTION
Remove mention of `floating_ip` option in `openstack_compute_instance_v2`
from the documentation of `openstack_compute_floatingip_associate_v2`
resource as that option was removed with 3d426884761ca431da5ed361bf59f9c4a26e1d90.

Fix #1115.

Signed-off-by: Alessandro Degano <a.degano@gmail.com>
