### PR TITLE
Properly read fixed_ip property for network attachment

### DIFF
--- a/openstack/resource_openstack_compute_interface_attach_v2.go
+++ b/openstack/resource_openstack_compute_interface_attach_v2.go
@@ -56,9 +56,11 @@ func resourceComputeInterfaceAttachV2() *schema.Resource {
 			},
 
 			"fixed_ip": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"port_id"},
 			},
 		},
 	}

--- a/openstack/resource_openstack_compute_interface_attach_v2.go
+++ b/openstack/resource_openstack_compute_interface_attach_v2.go
@@ -148,6 +148,10 @@ func resourceComputeInterfaceAttachV2Read(d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] Retrieved openstack_compute_interface_attach_v2 %s: %#v", d.Id(), attachment)
 
+	if len(attachment.FixedIPs) > 0 {
+		d.Set("fixed_ip", attachment.FixedIPs[0].IPAddress)
+	}
+
 	d.Set("instance_id", instanceID)
 	d.Set("port_id", attachment.PortID)
 	d.Set("network_id", attachment.NetID)


### PR DESCRIPTION
Currently if `fixed_ip` is specified idempotence is not respected because the property is not read on refresh.