### PR TITLE
Flavor V2: make "flavor_id" computed

### DIFF
--- a/openstack/resource_openstack_compute_flavor_v2.go
+++ b/openstack/resource_openstack_compute_flavor_v2.go
@@ -29,6 +29,7 @@ func resourceComputeFlavorV2() *schema.Resource {
 			"flavor_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 


### PR DESCRIPTION
We set it on Read() call so it should be computed and it shouldn't
create plan changes in case of an empty value.

For #1119 