### PR TITLE
add: ignore image stores propertie

### DIFF
--- a/openstack/images_image_v2.go
+++ b/openstack/images_image_v2.go
@@ -171,6 +171,13 @@ func resourceImagesImageV2UpdateComputedAttributes(diff *schema.ResourceDiff, me
 					}
 				}
 
+				// stores is provided by the OpenStack Image service.
+				if oldKey == "stores" {
+					if v, ok := oldValue.(string); ok {
+						newProperties[oldKey] = v
+					}
+				}
+
 				// direct_url is provided by some storage drivers.
 				if oldKey == "direct_url" {
 					if v, ok := oldValue.(string); ok {

--- a/openstack/resource_openstack_images_image_v2.go
+++ b/openstack/resource_openstack_images_image_v2.go
@@ -411,6 +411,14 @@ func resourceImagesImageV2Update(d *schema.ResourceData, meta interface{}) error
 				changed = false
 			}
 
+			// stores is provided by the OpenStack Image service.
+			// This is a read-only property that cannot be modified.
+			// Ignore it here and let CustomizeDiff handle it.
+			if newKey == "stores" {
+				found = true
+				changed = false
+			}
+
 			// direct_url is provided by some storage drivers.
 			// This is a read-only property that cannot be modified.
 			// Ignore it here and let CustomizeDiff handle it.

--- a/website/docs/r/images_image_v2.html.markdown
+++ b/website/docs/r/images_image_v2.html.markdown
@@ -128,7 +128,7 @@ These properties start with the prefix `os_`. If these properties are detected,
 this resource will automatically reconcile these with the user-provided
 properties.
 
-In addition, the `direct_url` property is also automatically reconciled if the
+In addition, the `direct_url` and `stores` properties are also automatically reconciled if the
 Image Service set it.
 
 ## Import


### PR DESCRIPTION
In newer OpenStack releases (Ussuri) glance adds read-only image propertie _stores_.
<img width="1094" alt="Screenshot 2021-01-07 at 23 45 56" src="https://user-images.githubusercontent.com/18698204/103948506-8a9a6e00-5142-11eb-82e1-bcc30fd72507.png">
It need to be excluded like _direct_url_