### PR TITLE
Add image_id to openstack_images_image_v2 resource creation options

### DIFF
--- a/openstack/resource_openstack_images_image_v2.go
+++ b/openstack/resource_openstack_images_image_v2.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -61,6 +62,14 @@ func resourceImagesImageV2() *schema.Resource {
 			"file": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+
+			"image_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([0-9a-fA-F]){8}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F]){12}$`), "image_id must be valid UUID"),
 			},
 
 			"image_cache_path": {
@@ -218,6 +227,7 @@ func resourceImagesImageV2Create(d *schema.ResourceData, meta interface{}) error
 		DiskFormat:      d.Get("disk_format").(string),
 		MinDisk:         d.Get("min_disk_gb").(int),
 		MinRAM:          d.Get("min_ram_mb").(int),
+		ID:              d.Get("image_id").(string),
 		Protected:       &protected,
 		Visibility:      &visibility,
 		Properties:      imageProperties,
@@ -342,6 +352,7 @@ func resourceImagesImageV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("disk_format", img.DiskFormat)
 	d.Set("min_disk_gb", img.MinDiskGigabytes)
 	d.Set("min_ram_mb", img.MinRAMMegabytes)
+	d.Set("image_id", img.ID)
 	d.Set("file", img.File)
 	d.Set("name", img.Name)
 	d.Set("protected", img.Protected)

--- a/openstack/resource_openstack_images_image_v2.go
+++ b/openstack/resource_openstack_images_image_v2.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"regexp"
 	"strings"
 	"time"
 
@@ -69,7 +68,7 @@ func resourceImagesImageV2() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([0-9a-fA-F]){8}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F]){12}$`), "image_id must be valid UUID"),
+				ValidateFunc: validation.IsUUID,
 			},
 
 			"image_cache_path": {

--- a/openstack/resource_openstack_images_image_v2_test.go
+++ b/openstack/resource_openstack_images_image_v2_test.go
@@ -32,6 +32,22 @@ func TestAccImagesImageV2_basic(t *testing.T) {
 						"openstack_images_image_v2.image_1", "schema", "/v2/schemas/image"),
 				),
 			},
+			{
+				Config: testAccImagesImageV2BasicWithID,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImagesImageV2Exists("openstack_images_image_v2.image_1", &image),
+					resource.TestCheckResourceAttr(
+						"openstack_images_image_v2.image_1", "name", "Rancher TerraformAccTest"),
+					resource.TestCheckResourceAttr(
+						"openstack_images_image_v2.image_1", "container_format", "bare"),
+					resource.TestCheckResourceAttr(
+						"openstack_images_image_v2.image_1", "disk_format", "qcow2"),
+					resource.TestCheckResourceAttr(
+						"openstack_images_image_v2.image_1", "schema", "/v2/schemas/image"),
+					resource.TestCheckResourceAttr(
+						"openstack_images_image_v2.image_1", "image_id", "c1efdf94-9a1a-4401-88b8-d616029d2551"),
+				),
+			},
 		},
 	})
 }
@@ -358,6 +374,19 @@ func testAccCheckImagesImageV2TagCount(n string, expected int) resource.TestChec
 const testAccImagesImageV2Basic = `
   resource "openstack_images_image_v2" "image_1" {
       name   = "Rancher TerraformAccTest"
+      image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
+      container_format = "bare"
+      disk_format = "qcow2"
+
+      timeouts {
+        create = "10m"
+      }
+  }`
+
+const testAccImagesImageV2BasicWithID = `
+  resource "openstack_images_image_v2" "image_1" {
+	  name   = "Rancher TerraformAccTest"
+	  image_id = "c1efdf94-9a1a-4401-88b8-d616029d2551"
       image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
       container_format = "bare"
       disk_format = "qcow2"

--- a/openstack/resource_openstack_images_image_v2_test.go
+++ b/openstack/resource_openstack_images_image_v2_test.go
@@ -385,15 +385,15 @@ const testAccImagesImageV2Basic = `
 
 const testAccImagesImageV2BasicWithID = `
   resource "openstack_images_image_v2" "image_1" {
-	name             = "Rancher TerraformAccTest"
-	image_id         = "c1efdf94-9a1a-4401-88b8-d616029d2551"
-    image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
-    container_format = "bare"
-    disk_format      = "qcow2"
+      name = "Rancher TerraformAccTest"
+      image_id = "c1efdf94-9a1a-4401-88b8-d616029d2551"
+      image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
+      container_format = "bare"
+      disk_format = "qcow2"
 
-    timeouts {
-      create = "10m"
-    }
+      timeouts {
+        create = "10m"
+      }
   }`
 
 const testAccImagesImageV2Name1 = `

--- a/openstack/resource_openstack_images_image_v2_test.go
+++ b/openstack/resource_openstack_images_image_v2_test.go
@@ -385,15 +385,15 @@ const testAccImagesImageV2Basic = `
 
 const testAccImagesImageV2BasicWithID = `
   resource "openstack_images_image_v2" "image_1" {
-	  name   = "Rancher TerraformAccTest"
-	  image_id = "c1efdf94-9a1a-4401-88b8-d616029d2551"
-      image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
-      container_format = "bare"
-      disk_format = "qcow2"
+	name             = "Rancher TerraformAccTest"
+	image_id         = "c1efdf94-9a1a-4401-88b8-d616029d2551"
+    image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
+    container_format = "bare"
+    disk_format      = "qcow2"
 
-      timeouts {
-        create = "10m"
-      }
+    timeouts {
+      create = "10m"
+    }
   }`
 
 const testAccImagesImageV2Name1 = `

--- a/website/docs/r/images_image_v2.html.markdown
+++ b/website/docs/r/images_image_v2.html.markdown
@@ -56,6 +56,9 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the image.
 
+* `image_id` - (Optional) Unique ID (valid UUID) of image to create. Changing 
+    this creates a new image.
+
 * `properties` - (Optional) A map of key/value pairs to set freeform
     information about an image. See the "Notes" section for further
     information about properties.


### PR DESCRIPTION
OpenStack and GopherCloud have ability to set Glance image UUID while creating image.
Replicating this functionality in Terraform. Docs and tests also altered.
Regex taken from Glance API response.
This is useful with images dedicated to Ironic when creating bundles of AKI/AMI and QCOW2 and in QCOW2 properties info about _ramdisk_id_ and _kernel_id_ can be filled with AKI and AMI UUID's.
