### PR TITLE
Hypervisor data source support

### DIFF
--- a/openstack/data_source_openstack_compute_hypervisor_v2.go
+++ b/openstack/data_source_openstack_compute_hypervisor_v2.go
@@ -1,0 +1,98 @@
+package openstack
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceComputeHypervisorV2() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceComputeHypervisorV2Read,
+		Schema: map[string]*schema.Schema{
+			"hostname": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"host_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vcpus": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"memory": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"disk": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceComputeHypervisorV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	region := GetRegion(d, config)
+	computeClient, err := config.ComputeV2Client(region)
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
+	}
+
+	allPages, err := hypervisors.List(computeClient).AllPages()
+	if err != nil {
+		return fmt.Errorf("Error listing compute hypervisors: %s", err)
+	}
+
+	allHypervisors, err := hypervisors.ExtractHypervisors(allPages)
+	if err != nil {
+		return fmt.Errorf("Error extracting compute hypervisors: %s", err)
+	}
+
+	name := d.Get("hostname").(string)
+
+	var refinedHypervisors []hypervisors.Hypervisor
+	for _, hypervisor := range allHypervisors {
+		if hypervisor.HypervisorHostname == name {
+			refinedHypervisors = append(refinedHypervisors, hypervisor)
+		}
+	}
+
+	if len(refinedHypervisors) < 1 {
+		return fmt.Errorf("Could not find any hypervisor with this name: %s", name)
+	}
+	if len(refinedHypervisors) > 1 {
+		return fmt.Errorf("More than one hypervisor found with this name: %s", name)
+	}
+
+	h := refinedHypervisors[0]
+
+	d.SetId(h.ID)
+	d.Set("hostname", h.HypervisorHostname)
+	d.Set("host_ip", h.HostIP)
+	d.Set("state", h.State)
+	d.Set("status", h.Status)
+	d.Set("type", h.HypervisorType)
+
+	d.Set("vcpus", h.VCPUs)
+	d.Set("memory", h.MemoryMB)
+	d.Set("disk", h.LocalGB)
+
+	return nil
+}

--- a/openstack/data_source_openstack_compute_hypervisor_v2.go
+++ b/openstack/data_source_openstack_compute_hypervisor_v2.go
@@ -15,30 +15,37 @@ func dataSourceComputeHypervisorV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+
 			"host_ip": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
 			"state": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
 			"type": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
 			"vcpus": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+
 			"memory": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+
 			"disk": {
 				Type:     schema.TypeInt,
 				Computed: true,

--- a/openstack/data_source_openstack_compute_hypervisor_v2_test.go
+++ b/openstack/data_source_openstack_compute_hypervisor_v2_test.go
@@ -1,0 +1,51 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func testAccHypervisorDataSource() string {
+	return fmt.Sprintf(`
+data "openstack_compute_hypervisor_v2" "host01" {
+  hostname = "%s"
+}
+    `, osHypervisorEnvironment)
+}
+
+func TestAccComputeHypervisorV2DataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckAdminOnly(t)
+			testAccPreCheckHypervisor(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHypervisorDataSource(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeHypervisorV2DataSourceID("data.openstack_compute_hypervisor_v2.host01"),
+					resource.TestCheckResourceAttr("data.openstack_compute_hypervisor_v2.host01", "hostname", osHypervisorEnvironment),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckComputeHypervisorV2DataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Data source ID not set")
+		}
+
+		return nil
+	}
+}

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -254,6 +254,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_compute_availability_zones_v2":            dataSourceComputeAvailabilityZonesV2(),
 			"openstack_compute_instance_v2":                      dataSourceComputeInstanceV2(),
 			"openstack_compute_flavor_v2":                        dataSourceComputeFlavorV2(),
+			"openstack_compute_hypervisor_v2":                    dataSourceComputeHypervisorV2(),
 			"openstack_compute_keypair_v2":                       dataSourceComputeKeypairV2(),
 			"openstack_containerinfra_clustertemplate_v1":        dataSourceContainerInfraClusterTemplateV1(),
 			"openstack_containerinfra_cluster_v1":                dataSourceContainerInfraCluster(),

--- a/openstack/provider_test.go
+++ b/openstack/provider_test.go
@@ -42,6 +42,7 @@ var (
 	osTransparentVlanEnvironment = os.Getenv("OS_TRANSPARENT_VLAN_ENVIRONMENT")
 	osKeymanagerEnvironment      = os.Getenv("OS_KEYMANAGER_ENVIRONMENT")
 	osGlanceimportEnvironment    = os.Getenv("OS_GLANCEIMPORT_ENVIRONMENT")
+	osHypervisorEnvironment      = os.Getenv("OS_HYPERVISOR_HOSTNAME")
 )
 
 var testAccProviders map[string]terraform.ResourceProvider
@@ -220,6 +221,12 @@ func testAccPreCheckAdminOnly(t *testing.T) {
 func testAccPreCheckGlanceImport(t *testing.T) {
 	if osGlanceimportEnvironment == "" {
 		t.Skip("This environment does not support Glance import tests")
+	}
+}
+
+func testAccPreCheckHypervisor(t *testing.T) {
+	if osHypervisorEnvironment == "" {
+		t.Skip("This environment does not support Hypervisor data source tests")
 	}
 }
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors/doc.go
@@ -1,0 +1,70 @@
+/*
+Package hypervisors returns details about list of hypervisors, shows details for a hypervisor
+and shows summary statistics for all hypervisors over all compute nodes in the OpenStack cloud.
+
+Example of Show Hypervisor Details
+
+	hypervisorID := "42"
+	hypervisor, err := hypervisors.Get(computeClient, hypervisorID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", hypervisor)
+
+Example of Show Hypervisor Details with Compute API microversion greater than 2.53
+
+    hypervisorID := "c48f6247-abe4-4a24-824e-ea39e108874f"
+    hypervisor, err := hypervisors.Get(computeClient, hypervisorID).Extract()
+    if err != nil {
+        panic(err)
+    }
+
+	fmt.Printf("%+v\n", hypervisor)
+
+Example of Retrieving Details of All Hypervisors
+
+	allPages, err := hypervisors.List(computeClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allHypervisors, err := hypervisors.ExtractHypervisors(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, hypervisor := range allHypervisors {
+		fmt.Printf("%+v\n", hypervisor)
+	}
+
+Example of Show Hypervisors Statistics
+
+	hypervisorsStatistics, err := hypervisors.GetStatistics(computeClient).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", hypervisorsStatistics)
+
+Example of Show Hypervisor Uptime
+
+	hypervisorID := "42"
+	hypervisorUptime, err := hypervisors.GetUptime(computeClient, hypervisorID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", hypervisorUptime)
+
+Example of Show Hypervisor Uptime with Compute API microversion greater than 2.53
+
+    hypervisorID := "c48f6247-abe4-4a24-824e-ea39e108874f"
+    hypervisorUptime, err := hypervisors.GetUptime(computeClient, hypervisorID).Extract()
+    if err != nil {
+        panic(err)
+    }
+
+	fmt.Printf("%+v\n", hypervisorUptime)
+*/
+package hypervisors

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors/requests.go
@@ -1,0 +1,40 @@
+package hypervisors
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// List makes a request against the API to list hypervisors.
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, hypervisorsListDetailURL(client), func(r pagination.PageResult) pagination.Page {
+		return HypervisorPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Statistics makes a request against the API to get hypervisors statistics.
+func GetStatistics(client *gophercloud.ServiceClient) (r StatisticsResult) {
+	resp, err := client.Get(hypervisorsStatisticsURL(client), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Get makes a request against the API to get details for specific hypervisor.
+func Get(client *gophercloud.ServiceClient, hypervisorID string) (r HypervisorResult) {
+	resp, err := client.Get(hypervisorsGetURL(client, hypervisorID), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// GetUptime makes a request against the API to get uptime for specific hypervisor.
+func GetUptime(client *gophercloud.ServiceClient, hypervisorID string) (r UptimeResult) {
+	resp, err := client.Get(hypervisorsUptimeURL(client, hypervisorID), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors/results.go
@@ -1,0 +1,367 @@
+package hypervisors
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Topology represents a CPU Topology.
+type Topology struct {
+	Sockets int `json:"sockets"`
+	Cores   int `json:"cores"`
+	Threads int `json:"threads"`
+}
+
+// CPUInfo represents CPU information of the hypervisor.
+type CPUInfo struct {
+	Vendor   string   `json:"vendor"`
+	Arch     string   `json:"arch"`
+	Model    string   `json:"model"`
+	Features []string `json:"features"`
+	Topology Topology `json:"topology"`
+}
+
+// Service represents a Compute service running on the hypervisor.
+type Service struct {
+	Host           string `json:"host"`
+	ID             string `json:"-"`
+	DisabledReason string `json:"disabled_reason"`
+}
+
+func (r *Service) UnmarshalJSON(b []byte) error {
+	type tmp Service
+	var s struct {
+		tmp
+		ID interface{} `json:"id"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = Service(s.tmp)
+
+	// OpenStack Compute service returns ID in string representation since
+	// 2.53 microversion API (Pike release).
+	switch t := s.ID.(type) {
+	case int:
+		r.ID = strconv.Itoa(t)
+	case float64:
+		r.ID = strconv.Itoa(int(t))
+	case string:
+		r.ID = t
+	default:
+		return fmt.Errorf("ID has unexpected type: %T", t)
+	}
+
+	return nil
+}
+
+// Hypervisor represents a hypervisor in the OpenStack cloud.
+type Hypervisor struct {
+	// A structure that contains cpu information like arch, model, vendor,
+	// features and topology.
+	CPUInfo CPUInfo `json:"-"`
+
+	// The current_workload is the number of tasks the hypervisor is responsible
+	// for. This will be equal or greater than the number of active VMs on the
+	// system (it can be greater when VMs are being deleted and the hypervisor is
+	// still cleaning up).
+	CurrentWorkload int `json:"current_workload"`
+
+	// Status of the hypervisor, either "enabled" or "disabled".
+	Status string `json:"status"`
+
+	// State of the hypervisor, either "up" or "down".
+	State string `json:"state"`
+
+	// DiskAvailableLeast is the actual free disk on this hypervisor,
+	// measured in GB.
+	DiskAvailableLeast int `json:"disk_available_least"`
+
+	// HostIP is the hypervisor's IP address.
+	HostIP string `json:"host_ip"`
+
+	// FreeDiskGB is the free disk remaining on the hypervisor, measured in GB.
+	FreeDiskGB int `json:"-"`
+
+	// FreeRAMMB is the free RAM in the hypervisor, measured in MB.
+	FreeRamMB int `json:"free_ram_mb"`
+
+	// HypervisorHostname is the hostname of the hypervisor.
+	HypervisorHostname string `json:"hypervisor_hostname"`
+
+	// HypervisorType is the type of hypervisor.
+	HypervisorType string `json:"hypervisor_type"`
+
+	// HypervisorVersion is the version of the hypervisor.
+	HypervisorVersion int `json:"-"`
+
+	// ID is the unique ID of the hypervisor.
+	ID string `json:"-"`
+
+	// LocalGB is the disk space in the hypervisor, measured in GB.
+	LocalGB int `json:"-"`
+
+	// LocalGBUsed is the used disk space of the  hypervisor, measured in GB.
+	LocalGBUsed int `json:"local_gb_used"`
+
+	// MemoryMB is the total memory of the hypervisor, measured in MB.
+	MemoryMB int `json:"memory_mb"`
+
+	// MemoryMBUsed is the used memory of the hypervisor, measured in MB.
+	MemoryMBUsed int `json:"memory_mb_used"`
+
+	// RunningVMs is the The number of running vms on the hypervisor.
+	RunningVMs int `json:"running_vms"`
+
+	// Service is the service this hypervisor represents.
+	Service Service `json:"service"`
+
+	// VCPUs is the total number of vcpus on the hypervisor.
+	VCPUs int `json:"vcpus"`
+
+	// VCPUsUsed is the number of used vcpus on the hypervisor.
+	VCPUsUsed int `json:"vcpus_used"`
+}
+
+func (r *Hypervisor) UnmarshalJSON(b []byte) error {
+	type tmp Hypervisor
+	var s struct {
+		tmp
+		ID                interface{} `json:"id"`
+		CPUInfo           interface{} `json:"cpu_info"`
+		HypervisorVersion interface{} `json:"hypervisor_version"`
+		FreeDiskGB        interface{} `json:"free_disk_gb"`
+		LocalGB           interface{} `json:"local_gb"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = Hypervisor(s.tmp)
+
+	// Newer versions return the CPU info as the correct type.
+	// Older versions return the CPU info as a string and need to be
+	// unmarshalled by the json parser.
+	var tmpb []byte
+
+	switch t := s.CPUInfo.(type) {
+	case string:
+		tmpb = []byte(t)
+	case map[string]interface{}:
+		tmpb, err = json.Marshal(t)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("CPUInfo has unexpected type: %T", t)
+	}
+
+	if len(tmpb) != 0 {
+		err = json.Unmarshal(tmpb, &r.CPUInfo)
+		if err != nil {
+			return err
+		}
+	}
+
+	// These fields may be returned as a scientific notation, so they need
+	// converted to int.
+	switch t := s.HypervisorVersion.(type) {
+	case int:
+		r.HypervisorVersion = t
+	case float64:
+		r.HypervisorVersion = int(t)
+	default:
+		return fmt.Errorf("Hypervisor version has unexpected type: %T", t)
+	}
+
+	switch t := s.FreeDiskGB.(type) {
+	case int:
+		r.FreeDiskGB = t
+	case float64:
+		r.FreeDiskGB = int(t)
+	default:
+		return fmt.Errorf("Free disk GB has unexpected type: %T", t)
+	}
+
+	switch t := s.LocalGB.(type) {
+	case int:
+		r.LocalGB = t
+	case float64:
+		r.LocalGB = int(t)
+	default:
+		return fmt.Errorf("Local GB has unexpected type: %T", t)
+	}
+
+	// OpenStack Compute service returns ID in string representation since
+	// 2.53 microversion API (Pike release).
+	switch t := s.ID.(type) {
+	case int:
+		r.ID = strconv.Itoa(t)
+	case float64:
+		r.ID = strconv.Itoa(int(t))
+	case string:
+		r.ID = t
+	default:
+		return fmt.Errorf("ID has unexpected type: %T", t)
+	}
+
+	return nil
+}
+
+// HypervisorPage represents a single page of all Hypervisors from a List
+// request.
+type HypervisorPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty determines whether or not a HypervisorPage is empty.
+func (page HypervisorPage) IsEmpty() (bool, error) {
+	va, err := ExtractHypervisors(page)
+	return len(va) == 0, err
+}
+
+// ExtractHypervisors interprets a page of results as a slice of Hypervisors.
+func ExtractHypervisors(p pagination.Page) ([]Hypervisor, error) {
+	var h struct {
+		Hypervisors []Hypervisor `json:"hypervisors"`
+	}
+	err := (p.(HypervisorPage)).ExtractInto(&h)
+	return h.Hypervisors, err
+}
+
+type HypervisorResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any HypervisorResult as a Hypervisor, if possible.
+func (r HypervisorResult) Extract() (*Hypervisor, error) {
+	var s struct {
+		Hypervisor Hypervisor `json:"hypervisor"`
+	}
+	err := r.ExtractInto(&s)
+	return &s.Hypervisor, err
+}
+
+// Statistics represents a summary statistics for all enabled
+// hypervisors over all compute nodes in the OpenStack cloud.
+type Statistics struct {
+	// The number of hypervisors.
+	Count int `json:"count"`
+
+	// The current_workload is the number of tasks the hypervisor is responsible for
+	CurrentWorkload int `json:"current_workload"`
+
+	// The actual free disk on this hypervisor(in GB).
+	DiskAvailableLeast int `json:"disk_available_least"`
+
+	// The free disk remaining on this hypervisor(in GB).
+	FreeDiskGB int `json:"free_disk_gb"`
+
+	// The free RAM in this hypervisor(in MB).
+	FreeRamMB int `json:"free_ram_mb"`
+
+	// The disk in this hypervisor(in GB).
+	LocalGB int `json:"local_gb"`
+
+	// The disk used in this hypervisor(in GB).
+	LocalGBUsed int `json:"local_gb_used"`
+
+	// The memory of this hypervisor(in MB).
+	MemoryMB int `json:"memory_mb"`
+
+	// The memory used in this hypervisor(in MB).
+	MemoryMBUsed int `json:"memory_mb_used"`
+
+	// The total number of running vms on all hypervisors.
+	RunningVMs int `json:"running_vms"`
+
+	// The number of vcpu in this hypervisor.
+	VCPUs int `json:"vcpus"`
+
+	// The number of vcpu used in this hypervisor.
+	VCPUsUsed int `json:"vcpus_used"`
+}
+
+type StatisticsResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any StatisticsResult as a Statistics, if possible.
+func (r StatisticsResult) Extract() (*Statistics, error) {
+	var s struct {
+		Stats Statistics `json:"hypervisor_statistics"`
+	}
+	err := r.ExtractInto(&s)
+	return &s.Stats, err
+}
+
+// Uptime represents uptime and additional info for a specific hypervisor.
+type Uptime struct {
+	// The hypervisor host name provided by the Nova virt driver.
+	// For the Ironic driver, it is the Ironic node uuid.
+	HypervisorHostname string `json:"hypervisor_hostname"`
+
+	// The id of the hypervisor.
+	ID string `json:"-"`
+
+	// The state of the hypervisor. One of up or down.
+	State string `json:"state"`
+
+	// The status of the hypervisor. One of enabled or disabled.
+	Status string `json:"status"`
+
+	// The total uptime of the hypervisor and information about average load.
+	Uptime string `json:"uptime"`
+}
+
+func (r *Uptime) UnmarshalJSON(b []byte) error {
+	type tmp Uptime
+	var s struct {
+		tmp
+		ID interface{} `json:"id"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = Uptime(s.tmp)
+
+	// OpenStack Compute service returns ID in string representation since
+	// 2.53 microversion API (Pike release).
+	switch t := s.ID.(type) {
+	case int:
+		r.ID = strconv.Itoa(t)
+	case float64:
+		r.ID = strconv.Itoa(int(t))
+	case string:
+		r.ID = t
+	default:
+		return fmt.Errorf("ID has unexpected type: %T", t)
+	}
+
+	return nil
+}
+
+type UptimeResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any UptimeResult as a Uptime, if possible.
+func (r UptimeResult) Extract() (*Uptime, error) {
+	var s struct {
+		Uptime Uptime `json:"hypervisor"`
+	}
+	err := r.ExtractInto(&s)
+	return &s.Uptime, err
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors/urls.go
@@ -1,0 +1,19 @@
+package hypervisors
+
+import "github.com/gophercloud/gophercloud"
+
+func hypervisorsListDetailURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("os-hypervisors", "detail")
+}
+
+func hypervisorsStatisticsURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("os-hypervisors", "statistics")
+}
+
+func hypervisorsGetURL(c *gophercloud.ServiceClient, hypervisorID string) string {
+	return c.ServiceURL("os-hypervisors", hypervisorID)
+}
+
+func hypervisorsUptimeURL(c *gophercloud.ServiceClient, hypervisorID string) string {
+	return c.ServiceURL("os-hypervisors", hypervisorID, "uptime")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -164,6 +164,7 @@ github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfa
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips
+github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/quotasets
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints

--- a/website/docs/d/compute_hypervisor_v2.html.markdown
+++ b/website/docs/d/compute_hypervisor_v2.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_compute_hypervisor_v2"
+sidebar_current: "docs-openstack-datasource-compute-hypervisor-v2"
+description: |-
+  Get information on Openstack Hypervisor
+---
+
+# openstack\_compute\_hypervisor\_v2
+
+Use this data source to get information about hypervisors
+by hostname.
+
+## Example Usage
+
+```hcl
+data "openstack_compute_hypervisor_v2" "host01" {
+  hostname = "host01"
+}
+```
+
+## Argument Reference
+
+* `hostname` - The hostname of the hypervisor
+
+## Attributes Reference
+
+`id` is set to the ID of the found Hypervisor. In addition, the
+following attributes are exported:
+
+* `hostname` - See Argument Reference above.
+* `host_ip` - The IP address of the Hypervisor
+* `state` - The state of the hypervisor (`up` or `down`)
+* `status` - The status of the hypervisor (`enabled` or `disabled`)
+* `type` - The type of the hypervisor (example: `QEMU`)
+* `vcpus` - The number of virtual CPUs the hypervisor can provide
+* `memory` - The number in MegaBytes of memory the hypervisor can provide
+* `disk` - The amount in GigaBytes of local storage the hypervisor can provide

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -407,6 +407,9 @@ the feature or bug you're testing:
 * `OS_SFS_ENVIRONMENT` - Required if your'e working on the `openstack_openstack_sharedfilesystem_*`
   resources. Set this value to "1" to enable testing these resources.
 
+* `OS_HYPERVISOR_HOSTNAME` - Required if you're working on the `openstack_compute_hypervisor_v2`
+  data source. Set this value to one valid hypervisor hostname to test this data source.
+
 We recommend only running the acceptance tests related to the feature or bug
 you're working on. To do this, run:
 


### PR DESCRIPTION
Support for Hypervisor data source.

Due to the nature of hypervisors (only LIST is available in the API), it's only possible to make data sources for hypervisors.
This data source aim is to provide information about cpu/memory/disk, so it's possible to auto-calculate quotas by listing every hypervisors in the system.

This backend is, as far as I know, only available for the admin user, so the test is restricted accordingly.