### PR TITLE
ComputeV2: add optional ignore_volume_confirmation

### DIFF
--- a/openstack/compute_volume_attach_v2.go
+++ b/openstack/compute_volume_attach_v2.go
@@ -34,14 +34,18 @@ func computeVolumeAttachV2AttachFunc(computeClient *gophercloud.ServiceClient, b
 			return va, "", err
 		}
 
+		// Block Storage client will be empty if "ignore_volume_confirmation" == true.
+		if blockStorageClient == nil {
+			return va, "ATTACHED", nil
+		}
+
 		v, err := volumes.Get(blockStorageClient, volumeID).Extract()
 		if err != nil {
 			return va, "", err
 		}
 		if v.Status == "error" {
-			return va, "", fmt.Errorf("volume enter unexpected error status")
+			return va, "", fmt.Errorf("volume entered unexpected error status")
 		}
-
 		if v.Status != "in-use" {
 			return va, "ATTACHING", nil
 		}

--- a/openstack/resource_openstack_compute_volume_attach_v2.go
+++ b/openstack/resource_openstack_compute_volume_attach_v2.go
@@ -57,6 +57,22 @@ func resourceComputeVolumeAttachV2() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+
+			"vendor_options": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MinItems: 1,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ignore_volume_confirmation": {
+							Type:     schema.TypeBool,
+							Default:  false,
+							Optional: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -68,9 +84,22 @@ func resourceComputeVolumeAttachV2Create(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
 
-	blockStorageClient, err := config.BlockStorageV3Client(GetRegion(d, config))
-	if err != nil {
-		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
+	var (
+		blockStorageClient       *gophercloud.ServiceClient
+		ignoreVolumeConfirmation bool
+	)
+
+	// Get vendor_options and decide if BlockStorage V3 client should be initialized.
+	vendorOptionsRaw := d.Get("vendor_options").(*schema.Set)
+	if vendorOptionsRaw.Len() > 0 {
+		vendorOptions := expandVendorOptions(vendorOptionsRaw.List())
+		ignoreVolumeConfirmation = vendorOptions["ignore_volume_confirmation"].(bool)
+	}
+	if !ignoreVolumeConfirmation {
+		blockStorageClient, err = config.BlockStorageV3Client(GetRegion(d, config))
+		if err != nil {
+			return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
+		}
 	}
 
 	instanceID := d.Get("instance_id").(string)

--- a/openstack/resource_openstack_compute_volume_attach_v2.go
+++ b/openstack/resource_openstack_compute_volume_attach_v2.go
@@ -61,6 +61,7 @@ func resourceComputeVolumeAttachV2() *schema.Resource {
 			"vendor_options": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				ForceNew: true,
 				MinItems: 1,
 				MaxItems: 1,
 				Elem: &schema.Resource{

--- a/website/docs/r/compute_volume_attach_v2.html.markdown
+++ b/website/docs/r/compute_volume_attach_v2.html.markdown
@@ -155,6 +155,15 @@ The following arguments are supported:
 
 * `multiattach` - (Optional) Enable attachment of multiattach-capable volumes.
 
+* `vendor_options` - (Optional) Map of additional vendor-specific options.
+  Supported options are described below.
+
+The `vendor_options` block supports:
+
+* `ignore_volume_confirmation` - (Optional) Boolean to control whether
+  to ignore volume status confirmation of the attached volume. This can be helpful
+  to work with some OpenStack clouds which don't have the Block Storage V3 API available.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Do not initialize a Block Storage V3 client and do not check volume
status if "ignore_volume_confirmation" is set to true.

Update computeVolumeAttachV2AttachFunc error.

Use Block Storage V3 in old tests of openstack_compute_volume_attach_v2
tests.

Add a new tests to check that "ignore_volume_confirmation" at least do
not create any trouble with manifests.

Update docs.

For #1123 