### PR TITLE
doc: use local provider

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -17,6 +17,17 @@ Use the navigation to the left to read about the available resources.
 ## Example Usage
 
 ```hcl
+# Define required providers
+terraform {
+required_version = ">= 0.14.0"
+  required_providers {
+    openstack = {
+      source  = "terraform-provider-openstack/openstack"
+      version = "~> 1.35.0"
+    }
+  }
+}
+
 # Configure the OpenStack Provider
 provider "openstack" {
   user_name   = "admin"


### PR DESCRIPTION
openstack provider has moved to terraform-provider-openstack namespace,
and we can't use that as the local name directly, instead we define a
local name in the provider configuration block. This is required for newer terraform
version (maybe > 0.13.0).

[1]https://www.terraform.io/docs/configuration/provider-requirements.html#local-names