### PR TITLE
Only use old client micro-version for old policies

### DIFF
--- a/openstack/compute_servergroup_v2.go
+++ b/openstack/compute_servergroup_v2.go
@@ -8,8 +8,6 @@ import (
 const (
 	antiAffinityPolicy = "anti-affinity"
 	affinityPolicy     = "affinity"
-	softAntiAffinityPolicy = "soft-anti-affinity"
-	softAffinityPolicy     = "soft-affinity"
 )
 
 // ServerGroupCreateOpts is a custom ServerGroup struct to include the

--- a/openstack/compute_servergroup_v2.go
+++ b/openstack/compute_servergroup_v2.go
@@ -6,6 +6,8 @@ import (
 )
 
 const (
+	antiAffinityPolicy = "anti-affinity"
+	affinityPolicy     = "affinity"
 	softAntiAffinityPolicy = "soft-anti-affinity"
 	softAffinityPolicy     = "soft-affinity"
 )
@@ -26,12 +28,14 @@ func (opts ComputeServerGroupV2CreateOpts) ToServerGroupCreateMap() (map[string]
 func expandComputeServerGroupV2Policies(client *gophercloud.ServiceClient, raw []interface{}) []string {
 	policies := make([]string, len(raw))
 	for i, v := range raw {
+		client.Microversion = "2.15"
+		
 		policy := v.(string)
 		policies[i] = policy
 
 		// Set microversion for new policies.
-		if policy == softAntiAffinityPolicy || policy == softAffinityPolicy {
-			client.Microversion = "2.15"
+		if policy == antiAffinityPolicy || policy == affinityPolicy {
+			client.Microversion = "2.1"
 		}
 	}
 

--- a/openstack/compute_servergroup_v2.go
+++ b/openstack/compute_servergroup_v2.go
@@ -27,7 +27,7 @@ func expandComputeServerGroupV2Policies(client *gophercloud.ServiceClient, raw [
 	policies := make([]string, len(raw))
 	for i, v := range raw {
 		client.Microversion = "2.15"
-		
+
 		policy := v.(string)
 		policies[i] = policy
 

--- a/openstack/compute_servergroup_v2.go
+++ b/openstack/compute_servergroup_v2.go
@@ -31,9 +31,9 @@ func expandComputeServerGroupV2Policies(client *gophercloud.ServiceClient, raw [
 		policy := v.(string)
 		policies[i] = policy
 
-		// Set microversion for new policies.
+		// Set microversion for legacy policies to empty to not change behaviour for those policies
 		if policy == antiAffinityPolicy || policy == affinityPolicy {
-			client.Microversion = "2.1"
+			client.Microversion = ""
 		}
 	}
 

--- a/openstack/compute_servergroup_v2_test.go
+++ b/openstack/compute_servergroup_v2_test.go
@@ -61,6 +61,7 @@ func TestExpandComputeServerGroupV2PoliciesMicroversions(t *testing.T) {
 		"affinity",
 		"soft-anti-affinity",
 		"soft-affinity",
+		"custom-policy",
 	}
 	client := thclient.ServiceClient()
 
@@ -68,8 +69,31 @@ func TestExpandComputeServerGroupV2PoliciesMicroversions(t *testing.T) {
 		"affinity",
 		"soft-anti-affinity",
 		"soft-affinity",
+		"custom-policy",
 	}
 	expectedMicroversion := "2.15"
+
+	actualPolicies := expandComputeServerGroupV2Policies(client, raw)
+	actualMicroversion := client.Microversion
+
+	assert.Equal(t, expectedMicroversion, actualMicroversion)
+	assert.Equal(t, expectedPolicies, actualPolicies)
+}
+
+func TestExpandComputeServerGroupV2PoliciesMicroversionsLegacy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	raw := []interface{}{
+		"anti-affinity",
+		"affinity",
+	}
+	client := thclient.ServiceClient()
+
+	expectedPolicies := []string{
+		"anti-affinity",
+		"affinity",
+	}
+	expectedMicroversion := "2.1"
 
 	actualPolicies := expandComputeServerGroupV2Policies(client, raw)
 	actualMicroversion := client.Microversion

--- a/openstack/compute_servergroup_v2_test.go
+++ b/openstack/compute_servergroup_v2_test.go
@@ -34,26 +34,6 @@ func TestComputeServerGroupV2CreateOpts(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-func TestExpandComputeServerGroupV2Policies(t *testing.T) {
-	th.SetupHTTP()
-	defer th.TeardownHTTP()
-	raw := []interface{}{
-		"affinity",
-	}
-	client := thclient.ServiceClient()
-
-	expectedPolicies := []string{
-		"affinity",
-	}
-	expectedMicroversion := ""
-
-	actualPolicies := expandComputeServerGroupV2Policies(client, raw)
-	actualMicroversion := client.Microversion
-
-	assert.Equal(t, expectedMicroversion, actualMicroversion)
-	assert.Equal(t, expectedPolicies, actualPolicies)
-}
-
 func TestExpandComputeServerGroupV2PoliciesMicroversions(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
@@ -93,7 +73,7 @@ func TestExpandComputeServerGroupV2PoliciesMicroversionsLegacy(t *testing.T) {
 		"anti-affinity",
 		"affinity",
 	}
-	expectedMicroversion := "2.1"
+	expectedMicroversion := ""
 
 	actualPolicies := expandComputeServerGroupV2Policies(client, raw)
 	actualMicroversion := client.Microversion


### PR DESCRIPTION
This should allow custom policies to be applied by using the more recent version of nova API which allow different policies then anti-affinity and affinity.

See https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1134 for more details