### PR TITLE
Update gophercloud/utils to fix MutexKV usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/gophercloud/gophercloud v0.15.0
-	github.com/gophercloud/utils v0.0.0-20210113034859-6f548432055a
+	github.com/gophercloud/utils v0.0.0-20210125092539-ef82cbe29e1f
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/gophercloud/gophercloud v0.6.1-0.20191122030953-d8ac278c1c9d/go.mod h1:ozGNgr9KYOVATV5jsgHl/ceCDXGuguqOZAzoQ/2vcNM=
 github.com/gophercloud/gophercloud v0.15.0 h1:jQeAWj0s1p83+TrUXhJhEOK4oe2g6YcBcFwEyMNIjEk=
 github.com/gophercloud/gophercloud v0.15.0/go.mod h1:VX0Ibx85B60B5XOrZr6kaNwrmPUzcmMpwxvQ1WQIIWM=
-github.com/gophercloud/utils v0.0.0-20210113034859-6f548432055a h1:mHU4E3kfxVUhfqjgxrWv4g0mjRF7qA4o5dkMRfS8gd8=
-github.com/gophercloud/utils v0.0.0-20210113034859-6f548432055a/go.mod h1:ehWUbLQJPqS0Ep+CxeD559hsm9pthPXadJNKwZkp43w=
+github.com/gophercloud/utils v0.0.0-20210125092539-ef82cbe29e1f h1:JiQuQls5uYRS93dmj+/uy+I/eDN20L6ZBp+QEjNwjLg=
+github.com/gophercloud/utils v0.0.0-20210125092539-ef82cbe29e1f/go.mod h1:ehWUbLQJPqS0Ep+CxeD559hsm9pthPXadJNKwZkp43w=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -510,7 +510,7 @@ func configureProvider(d *schema.ResourceData, terraformVersion string) (interfa
 			DisableNoCacheHeader:        d.Get("disable_no_cache_header").(bool),
 			TerraformVersion:            terraformVersion,
 			SDKVersion:                  meta.SDKVersionString(),
-			MutexKV:                     *(mutexkv.NewMutexKV()),
+			MutexKV:                     mutexkv.NewMutexKV(),
 		},
 	}
 

--- a/openstack/provider_test.go
+++ b/openstack/provider_test.go
@@ -416,7 +416,7 @@ func testAccAuthFromEnv() (*Config, error) {
 			UserDomainName:    os.Getenv("OS_USER_DOMAIN_NAME"),
 			Username:          os.Getenv("OS_USERNAME"),
 			UserID:            os.Getenv("OS_USER_ID"),
-			MutexKV:           *(mutexkv.NewMutexKV()),
+			MutexKV:           mutexkv.NewMutexKV(),
 		},
 	}
 

--- a/openstack/resource_openstack_networking_router_route_v2.go
+++ b/openstack/resource_openstack_networking_router_route_v2.go
@@ -55,9 +55,8 @@ func resourceNetworkingRouterRouteV2Create(d *schema.ResourceData, meta interfac
 	}
 
 	routerID := d.Get("router_id").(string)
-	mutex := config.MutexKV
-	mutex.Lock(routerID)
-	defer mutex.Unlock(routerID)
+	config.MutexKV.Lock(routerID)
+	defer config.MutexKV.Unlock(routerID)
 
 	r, err := routers.Get(networkingClient, routerID).Extract()
 	if err != nil {
@@ -147,9 +146,8 @@ func resourceNetworkingRouterRouteV2Delete(d *schema.ResourceData, meta interfac
 	}
 
 	routerID := d.Get("router_id").(string)
-	mutex := config.MutexKV
-	mutex.Lock(routerID)
-	defer mutex.Unlock(routerID)
+	config.MutexKV.Lock(routerID)
+	defer config.MutexKV.Unlock(routerID)
 
 	r, err := routers.Get(networkingClient, routerID).Extract()
 	if err != nil {

--- a/openstack/resource_openstack_networking_router_v2.go
+++ b/openstack/resource_openstack_networking_router_v2.go
@@ -347,9 +347,8 @@ func resourceNetworkingRouterV2Update(d *schema.ResourceData, meta interface{}) 
 	}
 
 	routerID := d.Id()
-	mutex := config.MutexKV
-	mutex.Lock(routerID)
-	defer mutex.Unlock(routerID)
+	config.MutexKV.Lock(routerID)
+	defer config.MutexKV.Unlock(routerID)
 
 	var hasChange bool
 	var updateOpts routers.UpdateOpts

--- a/openstack/resource_openstack_networking_secgroup_rule_v2.go
+++ b/openstack/resource_openstack_networking_secgroup_rule_v2.go
@@ -108,15 +108,14 @@ func resourceNetworkingSecGroupRuleV2() *schema.Resource {
 
 func resourceNetworkingSecGroupRuleV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	securityGroupID := d.Get("security_group_id").(string)
-	mutex := config.MutexKV
-	mutex.Lock(securityGroupID)
-	defer mutex.Unlock(securityGroupID)
-
 	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
+
+	securityGroupID := d.Get("security_group_id").(string)
+	config.MutexKV.Lock(securityGroupID)
+	defer config.MutexKV.Unlock(securityGroupID)
 
 	portRangeMin := d.Get("port_range_min").(int)
 	portRangeMax := d.Get("port_range_max").(int)
@@ -206,15 +205,14 @@ func resourceNetworkingSecGroupRuleV2Read(d *schema.ResourceData, meta interface
 
 func resourceNetworkingSecGroupRuleV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	securityGroupID := d.Get("security_group_id").(string)
-	mutex := config.MutexKV
-	mutex.Lock(securityGroupID)
-	defer mutex.Unlock(securityGroupID)
-
 	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
+
+	securityGroupID := d.Get("security_group_id").(string)
+	config.MutexKV.Lock(securityGroupID)
+	defer config.MutexKV.Unlock(securityGroupID)
 
 	if err := rules.Delete(networkingClient, d.Id()).ExtractErr(); err != nil {
 		return CheckDeleted(d, err, "Error deleting openstack_networking_secgroup_rule_v2")

--- a/openstack/resource_openstack_networking_subnet_route_v2.go
+++ b/openstack/resource_openstack_networking_subnet_route_v2.go
@@ -55,13 +55,9 @@ func resourceNetworkingSubnetRouteV2Create(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
-	destCIDR := d.Get("destination_cidr").(string)
-	nextHop := d.Get("next_hop").(string)
-
 	subnetID := d.Get("subnet_id").(string)
-	mutex := config.MutexKV
-	mutex.Lock(subnetID)
-	defer mutex.Unlock(subnetID)
+	config.MutexKV.Lock(subnetID)
+	defer config.MutexKV.Unlock(subnetID)
 
 	subnet, err := subnets.Get(networkingClient, subnetID).Extract()
 	if err != nil {
@@ -72,6 +68,9 @@ func resourceNetworkingSubnetRouteV2Create(d *schema.ResourceData, meta interfac
 
 		return fmt.Errorf("Error retrieving openstack_networking_subnet_v2: %s", err)
 	}
+
+	destCIDR := d.Get("destination_cidr").(string)
+	nextHop := d.Get("next_hop").(string)
 
 	for _, r := range subnet.HostRoutes {
 		if r.DestinationCIDR == destCIDR && r.NextHop == nextHop {
@@ -163,9 +162,8 @@ func resourceNetworkingSubnetRouteV2Delete(d *schema.ResourceData, meta interfac
 	}
 
 	subnetID := d.Get("subnet_id").(string)
-	mutex := config.MutexKV
-	mutex.Lock(subnetID)
-	defer mutex.Unlock(subnetID)
+	config.MutexKV.Lock(subnetID)
+	defer config.MutexKV.Unlock(subnetID)
 
 	subnet, err := subnets.Get(networkingClient, subnetID).Extract()
 	if err != nil {


### PR DESCRIPTION
Fix copying of the sync.Locker in the Config.

Do not use a separate variable and just use *Config.MutexKV directly in
all places.

Update MutexKV initialization.