### PR TITLE
Fix openstack_lb_loadbalancer_v2 flavor_id

### DIFF
--- a/openstack/resource_openstack_lb_loadbalancer_v2.go
+++ b/openstack/resource_openstack_lb_loadbalancer_v2.go
@@ -88,8 +88,8 @@ func resourceLoadBalancerV2() *schema.Resource {
 			"flavor_id": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 				Computed: true,
+				ForceNew: true,
 			},
 
 			"loadbalancer_provider": {

--- a/openstack/resource_openstack_lb_loadbalancer_v2.go
+++ b/openstack/resource_openstack_lb_loadbalancer_v2.go
@@ -89,6 +89,7 @@ func resourceLoadBalancerV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 
 			"loadbalancer_provider": {


### PR DESCRIPTION
Fixes #1146 

Before:
```
  # openstack_lb_loadbalancer_v2.infrastructure must be replaced
-/+ resource "openstack_lb_loadbalancer_v2" "infrastructure" {
      - flavor_id             = "69b842e1-5476-4420-96f7-d8ea826eece0" -> null # forces replacement
      ...
    }
```

After:
```
openstack_lb_loadbalancer_v2.infrastructure: Refreshing state... [id=791dfb94-e634-44ec-b1a5-caeedeb88e20]

No changes. Infrastructure is up-to-date.
```

🎉 