### PR TITLE
Networking: expose subnets in network data source

### DIFF
--- a/openstack/data_source_openstack_networking_network_v2.go
+++ b/openstack/data_source_openstack_networking_network_v2.go
@@ -101,6 +101,12 @@ func dataSourceNetworkingNetworkV2() *schema.Resource {
 				Computed: true,
 			},
 
+			"subnets": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
 			"all_tags": {
 				Type:     schema.TypeSet,
 				Computed: true,
@@ -233,6 +239,7 @@ func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{})
 	d.Set("external", network.External)
 	d.Set("tenant_id", network.TenantID)
 	d.Set("transparent_vlan", network.VLANTransparent)
+	d.Set("subnets", network.Subnets)
 	d.Set("all_tags", network.Tags)
 	d.Set("mtu", network.MTU)
 	d.Set("dns_domain", network.DNSDomain)

--- a/website/docs/d/networking_network_v2.html.markdown
+++ b/website/docs/d/networking_network_v2.html.markdown
@@ -46,7 +46,7 @@ data "openstack_networking_network_v2" "network" {
 * `tags` - (Optional) The list of network tags to filter.
 
 * `mtu` - (Optional) The network MTU to filter. Available, when Neutron `net-mtu`
-    extension is enabled.
+  extension is enabled.
 
 ## Attributes Reference
 
@@ -62,7 +62,8 @@ are exported:
    tenant or not.
 * `availability_zone_hints` - The availability zone candidates for the network.
 * `transparent_vlan` - See Argument Reference above.
-* `all_tags` - The set of string tags applied on the network.
 * `mtu` - See Argument Reference above.
 * `dns_domain` - The network DNS domain. Available, when Neutron DNS extension
-   is enabled
+  is enabled
+* `subnets` - A list of subnet IDs belonging to the network.
+* `all_tags` - The set of string tags applied on the network.


### PR DESCRIPTION
Can be used to solve the #1150 issue. Less efficient way to list and filter external network subnets:

```hcl
variable "pattern" {}
  
data "openstack_networking_network_v2" "network" {
  name = "external-network"
}

data "openstack_networking_subnet_v2" "subnet" {
  count     = length(data.openstack_networking_network_v2.network.subnets)
  subnet_id = data.openstack_networking_network_v2.network.subnets[count.index]
}

output "subnet_ids" {
  value = [for x in data.openstack_networking_subnet_v2.subnet : x.id if length(regexall(var.pattern, x.name)) > 0]
}

output "subnet_names" {
  value = [for x in data.openstack_networking_subnet_v2.subnet : x.name if length(regexall(var.pattern, x.name)) > 0]
}
```