### PR TITLE
Networking: introduce openstack_networking_subnet_ids_v2 data source

### DIFF
--- a/openstack/data_source_openstack_images_image_ids_v2.go
+++ b/openstack/data_source_openstack_images_image_ids_v2.go
@@ -208,6 +208,7 @@ func dataSourceImagesImageIdsV2Read(d *schema.ResourceData, meta interface{}) er
 
 	d.SetId(fmt.Sprintf("%d", hashcode.String(strings.Join(imageIDs, ","))))
 	d.Set("ids", imageIDs)
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }

--- a/openstack/data_source_openstack_images_image_v2.go
+++ b/openstack/data_source_openstack_images_image_v2.go
@@ -256,6 +256,7 @@ func dataSourceImagesImageV2Read(d *schema.ResourceData, meta interface{}) error
 
 	d.SetId(image.ID)
 	d.Set("name", image.Name)
+	d.Set("region", GetRegion(d, config))
 	d.Set("tags", image.Tags)
 	d.Set("container_format", image.ContainerFormat)
 	d.Set("disk_format", image.DiskFormat)

--- a/openstack/data_source_openstack_networking_port_ids_v2.go
+++ b/openstack/data_source_openstack_networking_port_ids_v2.go
@@ -266,6 +266,7 @@ func dataSourceNetworkingPortIDsV2Read(d *schema.ResourceData, meta interface{})
 
 	d.SetId(fmt.Sprintf("%d", hashcode.String(strings.Join(portIDs, ""))))
 	d.Set("ids", portIDs)
+	d.Set("region", GetRegion(d, config))
 
 	return nil
 }

--- a/openstack/data_source_openstack_networking_subnet_ids_v2.go
+++ b/openstack/data_source_openstack_networking_subnet_ids_v2.go
@@ -1,0 +1,251 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
+)
+
+func dataSourceNetworkingSubnetIDsV2() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNetworkingSubnetIDsV2Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name_regex"},
+			},
+
+			"name_regex": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ValidateFunc:  validation.StringIsValidRegExp,
+				ConflictsWith: []string{"name"},
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"dhcp_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"network_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"tenant_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: descriptions["tenant_id"],
+			},
+
+			"ip_version": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntInSlice([]int{4, 6}),
+			},
+
+			"gateway_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"cidr": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"ipv6_address_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"slaac", "dhcpv6-stateful", "dhcpv6-stateless",
+				}, false),
+			},
+
+			"ipv6_ra_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"slaac", "dhcpv6-stateful", "dhcpv6-stateless",
+				}, false),
+			},
+
+			"subnetpool_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"tags": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"sort_direction": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"asc", "desc",
+				}, true),
+			},
+
+			"ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceNetworkingSubnetIDsV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+	}
+
+	listOpts := subnets.ListOpts{}
+
+	if v, ok := d.GetOk("name"); ok {
+		listOpts.Name = v.(string)
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		listOpts.Description = v.(string)
+	}
+
+	if v, ok := d.GetOkExists("dhcp_enabled"); ok {
+		enableDHCP := v.(bool)
+		listOpts.EnableDHCP = &enableDHCP
+	}
+
+	if v, ok := d.GetOk("network_id"); ok {
+		listOpts.NetworkID = v.(string)
+	}
+
+	if v, ok := d.GetOk("tenant_id"); ok {
+		listOpts.TenantID = v.(string)
+	}
+
+	if v, ok := d.GetOk("ip_version"); ok {
+		listOpts.IPVersion = v.(int)
+	}
+
+	if v, ok := d.GetOk("gateway_ip"); ok {
+		listOpts.GatewayIP = v.(string)
+	}
+
+	if v, ok := d.GetOk("cidr"); ok {
+		listOpts.CIDR = v.(string)
+	}
+
+	if v, ok := d.GetOk("ipv6_address_mode"); ok {
+		listOpts.IPv6AddressMode = v.(string)
+	}
+
+	if v, ok := d.GetOk("ipv6_ra_mode"); ok {
+		listOpts.IPv6RAMode = v.(string)
+	}
+
+	if v, ok := d.GetOk("subnetpool_id"); ok {
+		listOpts.SubnetPoolID = v.(string)
+	}
+
+	tags := networkingV2AttributesTags(d)
+	if len(tags) > 0 {
+		listOpts.Tags = strings.Join(tags, ",")
+	}
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		listOpts.SortKey = v.(string)
+	}
+
+	if v, ok := d.GetOk("sort_direction"); ok {
+		listOpts.SortDir = v.(string)
+	}
+
+	pages, err := subnets.List(networkingClient, listOpts).AllPages()
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve openstack_networking_subnet_ids_v2: %s", err)
+	}
+
+	allSubnets, err := subnets.ExtractSubnets(pages)
+	if err != nil {
+		return fmt.Errorf("Unable to extract openstack_networking_subnet_ids_v2: %s", err)
+	}
+
+	log.Printf("[DEBUG] Retrieved %d subnets in openstack_networking_subnet_ids_v2: %+v", len(allSubnets), allSubnets)
+
+	var subnetIDs []string
+	if nameRegex, ok := d.GetOk("name_regex"); !ok {
+		subnetIDs = make([]string, len(allSubnets))
+		for i, subnet := range allSubnets {
+			subnetIDs[i] = subnet.ID
+		}
+	} else {
+		r := regexp.MustCompile(nameRegex.(string))
+		for _, subnet := range allSubnets {
+			// Check for a very rare case where the response would include no
+			// subnet name. No name means nothing to attempt a match against,
+			// therefore we are skipping such subnet.
+			if subnet.Name == "" {
+				log.Printf("[WARN] Unable to find subnet name to match against "+
+					"for %q subnet ID, nothing to do.",
+					subnet.ID)
+				continue
+			}
+			if r.MatchString(subnet.Name) {
+				subnetIDs = append(subnetIDs, subnet.ID)
+			}
+		}
+
+		log.Printf("[DEBUG] Subnet list filtered by regex: %s", d.Get("name_regex"))
+		log.Printf("[DEBUG] Retrieved %d subnet IDs after filtering in openstack_networking_subnet_ids_v2: %+v", len(subnetIDs), subnetIDs)
+	}
+
+	d.SetId(fmt.Sprintf("%d", hashcode.String(strings.Join(subnetIDs, ","))))
+	d.Set("ids", subnetIDs)
+	d.Set("region", GetRegion(d, config))
+
+	return nil
+}

--- a/openstack/data_source_openstack_networking_subnet_ids_v2_test.go
+++ b/openstack/data_source_openstack_networking_subnet_ids_v2_test.go
@@ -1,0 +1,153 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccOpenStackSubnetsV2SubnetIDsDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpenStackSubnetsV2SubnetIDsDataSourceEmpty(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_subnet_ids_v2.subnets_empty", "ids.#", "0"),
+				),
+			},
+			{
+				Config: testAccOpenStackSubnetsV2SubnetIDsDataSourceName(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_subnet_ids_v2.subnets_by_name", "ids.#", "1"),
+					resource.TestCheckResourceAttrPair(
+						"data.openstack_networking_subnet_ids_v2.subnets_by_name", "ids.0",
+						"openstack_networking_subnet_v2.subnet_1", "id"),
+				),
+			},
+			{
+				Config: testAccOpenStackSubnetsV2SubnetIDsDataSourceRegex(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_subnet_ids_v2.subnets_by_name_regex", "ids.#", "1"),
+					resource.TestCheckResourceAttrPair(
+						"data.openstack_networking_subnet_ids_v2.subnets_by_name_regex", "ids.0",
+						"openstack_networking_subnet_v2.subnet_2", "id"),
+				),
+			},
+			{
+				Config: testAccOpenStackSubnetsV2SubnetIDsDataSourceTag(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_subnet_ids_v2.subnets_by_tag", "ids.#", "2"),
+					resource.TestCheckResourceAttrPair(
+						"data.openstack_networking_subnet_ids_v2.subnets_by_tag", "ids.0",
+						"openstack_networking_subnet_v2.subnet_1", "id"),
+					resource.TestCheckResourceAttrPair(
+						"data.openstack_networking_subnet_ids_v2.subnets_by_tag", "ids.1",
+						"openstack_networking_subnet_v2.subnet_2", "id"),
+				),
+			},
+			{
+				Config: testAccOpenStackSubnetsV2SubnetIDsDataSourceProperties(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_subnet_ids_v2.subnets_by_tags", "ids.#", "1"),
+					resource.TestCheckResourceAttrPair(
+						"data.openstack_networking_subnet_ids_v2.subnets_by_tags", "ids.0",
+						"openstack_networking_subnet_v2.subnet_2", "id"),
+				),
+			},
+		},
+	})
+}
+
+const testAccOpenStackSubnetsV2SubnetIDsDataSource = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  name = "subnet_one"
+  description = "my subnet description"
+  cidr = "192.168.198.0/24"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+  tags = [
+    "foo",
+  ]
+}
+
+resource "openstack_networking_subnet_v2" "subnet_2" {
+  name = "subnet_two"
+  description = "my subnet description"
+  cidr = "192.168.199.0/24"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+  tags = [
+    "foo",
+    "bar",
+  ]
+}
+`
+
+func testAccOpenStackSubnetsV2SubnetIDsDataSourceEmpty() string {
+	return fmt.Sprintf(`
+%s
+
+data "openstack_networking_subnet_ids_v2" "subnets_empty" {
+    name = "non-existed-subnet"
+}
+`, testAccOpenStackSubnetsV2SubnetIDsDataSource)
+}
+
+func testAccOpenStackSubnetsV2SubnetIDsDataSourceName() string {
+	return fmt.Sprintf(`
+%s
+
+data "openstack_networking_subnet_ids_v2" "subnets_by_name" {
+    name = "${openstack_networking_subnet_v2.subnet_1.name}"
+    description = "${openstack_networking_subnet_v2.subnet_2.description}" # to avoid race condition for further tests
+}
+`, testAccOpenStackSubnetsV2SubnetIDsDataSource)
+}
+
+func testAccOpenStackSubnetsV2SubnetIDsDataSourceRegex() string {
+	return fmt.Sprintf(`
+%s
+
+data "openstack_networking_subnet_ids_v2" "subnets_by_name_regex" {
+    name_regex = "two$"
+}
+`, testAccOpenStackSubnetsV2SubnetIDsDataSource)
+}
+
+func testAccOpenStackSubnetsV2SubnetIDsDataSourceTag() string {
+	return fmt.Sprintf(`
+%s
+
+data "openstack_networking_subnet_ids_v2" "subnets_by_tag" {
+    sort_key = "name"
+    sort_direction = "asc"
+    tags = [
+      "foo",
+    ]
+}
+`, testAccOpenStackSubnetsV2SubnetIDsDataSource)
+}
+
+func testAccOpenStackSubnetsV2SubnetIDsDataSourceProperties() string {
+	return fmt.Sprintf(`
+%s
+
+data "openstack_networking_subnet_ids_v2" "subnets_by_tags" {
+    tags = [
+      "bar",
+      "foo",
+    ]
+}
+`, testAccOpenStackSubnetsV2SubnetIDsDataSource)
+}

--- a/openstack/data_source_openstack_networking_subnet_v2.go
+++ b/openstack/data_source_openstack_networking_subnet_v2.go
@@ -45,6 +45,7 @@ func dataSourceNetworkingSubnetV2() *schema.Resource {
 				Type:          schema.TypeBool,
 				ConflictsWith: []string{"dhcp_enabled"},
 				Optional:      true,
+				Deprecated:    "use dhcp_enabled instead",
 			},
 
 			"network_id": {
@@ -189,13 +190,13 @@ func dataSourceNetworkingSubnetV2Read(d *schema.ResourceData, meta interface{}) 
 		listOpts.Description = v.(string)
 	}
 
-	if _, ok := d.GetOk("dhcp_enabled"); ok {
-		enableDHCP := true
+	if v, ok := d.GetOkExists("dhcp_enabled"); ok {
+		enableDHCP := v.(bool)
 		listOpts.EnableDHCP = &enableDHCP
 	}
 
-	if _, ok := d.GetOk("dhcp_disabled"); ok {
-		enableDHCP := false
+	if v, ok := d.GetOkExists("dhcp_disabled"); ok {
+		enableDHCP := !v.(bool)
 		listOpts.EnableDHCP = &enableDHCP
 	}
 

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -277,6 +277,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_networking_qos_minimum_bandwidth_rule_v2": dataSourceNetworkingQoSMinimumBandwidthRuleV2(),
 			"openstack_networking_qos_policy_v2":                 dataSourceNetworkingQoSPolicyV2(),
 			"openstack_networking_subnet_v2":                     dataSourceNetworkingSubnetV2(),
+			"openstack_networking_subnet_ids_v2":                 dataSourceNetworkingSubnetIDsV2(),
 			"openstack_networking_secgroup_v2":                   dataSourceNetworkingSecGroupV2(),
 			"openstack_networking_subnetpool_v2":                 dataSourceNetworkingSubnetPoolV2(),
 			"openstack_networking_floatingip_v2":                 dataSourceNetworkingFloatingIPV2(),

--- a/website/docs/d/networking_port_ids_v2.html.markdown
+++ b/website/docs/d/networking_port_ids_v2.html.markdown
@@ -52,7 +52,7 @@ data "openstack_networking_port_ids_v2" "ports" {
 * `sort_key` - (Optional) Sort ports based on a certain key. Defaults to none.
 
 * `sort_direction` - (Optional) Order the results in either `asc` or `desc`.
-    Defaults to none.
+  Defaults to none.
 
 ## Attributes Reference
 

--- a/website/docs/d/networking_subnet_ids_v2.html.markdown
+++ b/website/docs/d/networking_subnet_ids_v2.html.markdown
@@ -1,20 +1,24 @@
 ---
 layout: "openstack"
-page_title: "OpenStack: openstack_networking_subnet_v2"
-sidebar_current: "docs-openstack-datasource-networking-subnet-v2"
+page_title: "OpenStack: openstack_networking_subnet_ids_v2"
+sidebar_current: "docs-openstack-datasource-networking-subnet-ids-v2"
 description: |-
-  Get information on an OpenStack Subnet.
+  Provides a list of Openstack Subnet IDs.
 ---
 
-# openstack\_networking\_subnet\_v2
+# openstack\_networking\_subnet\_ids\_v2
 
-Use this data source to get the ID of an available OpenStack subnet.
+Use this data source to get a list of Openstack Subnet IDs matching the
+specified criteria.
 
 ## Example Usage
 
 ```hcl
-data "openstack_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
+data "openstack_networking_subnet_ids_v2" "subnets" {
+  name_regex = "public"
+  tags = [
+    "public"
+  ]
 }
 ```
 
@@ -40,8 +44,6 @@ data "openstack_networking_subnet_v2" "subnet_1" {
 
 * `cidr` - (Optional) The CIDR of the subnet.
 
-* `subnet_id` - (Optional) The ID of the subnet.
-
 * `ipv6_address_mode` - (Optional) The IPv6 address mode. Valid values are
   `dhcpv6-stateful`, `dhcpv6-stateless`, or `slaac`.
 
@@ -52,14 +54,11 @@ data "openstack_networking_subnet_v2" "subnet_1" {
 
 * `tags` - (Optional) The list of subnet tags to filter.
 
+* `sort_key` - (Optional) Sort subnets based on a certain key. Defaults to none.
+
+* `sort_direction` - (Optional) Order the results in either `asc` or `desc`.
+  Defaults to none.
+
 ## Attributes Reference
 
-`id` is set to the ID of the found subnet. In addition, the following attributes
-are exported:
-
-* `allocation_pools` - Allocation pools of the subnet.
-* `enable_dhcp` - Whether the subnet has DHCP enabled or not.
-* `dns_nameservers` - DNS Nameservers of the subnet.
-* `host_routes` - Host Routes of the subnet.
-* `region` - See Argument Reference above.
-* `all_tags` - A set of string tags applied on the subnet.
+`ids` is set to the list of Openstack Subnet IDs.

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -106,6 +106,9 @@
             <li<%= sidebar_current("docs-openstack-datasource-networking-subnet-v2") %>>
               <a href="/docs/providers/openstack/d/networking_subnet_v2.html">openstack_networking_subnet_v2</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-datasource-networking-subnet-ids-v2") %>>
+              <a href="/docs/providers/openstack/d/networking_subnet_ids_v2.html">openstack_networking_subnet_ids_v2</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-datasource-networking-subnetpool-v2") %>>
               <a href="/docs/providers/openstack/d/networking_subnetpool_v2.html">openstack_networking_subnetpool_v2</a>
             </li>


### PR DESCRIPTION
This is an efficient way (comparing to #1152) to filter out network subnet IDs by a certain criteria. See a #1150  for a reference.

P.S. Fixed a couple of tiny bugs and docs typos while worked on the PR. I also deprecated `dhcp_disabled` in `data.openstack_networking_subnet_v2`, because it was introduced before Terraform SDK started to support the `GetOkExists` method.