### PR TITLE
Enable stylecheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,7 @@ linters:
 #    - scopelint
     - staticcheck
     - structcheck
-#    - stylecheck
+    - stylecheck
     - typecheck
     - unconvert
     - unused
@@ -50,6 +50,9 @@ issues:
     - linters:
         - staticcheck
       text: "SA1019:"
+    - linters:
+        - stylecheck
+      text: "ST1005:"
 
     - linters:
         - errcheck

--- a/openstack/provider_test.go
+++ b/openstack/provider_test.go
@@ -15,9 +15,9 @@ import (
 )
 
 var (
-	osDbEnvironment                  = os.Getenv("OS_DB_ENVIRONMENT")
-	osDbDatastoreVersion             = os.Getenv("OS_DB_DATASTORE_VERSION")
-	osDbDatastoreType                = os.Getenv("OS_DB_DATASTORE_TYPE")
+	osDBEnvironment                  = os.Getenv("OS_DB_ENVIRONMENT")
+	osDBDatastoreVersion             = os.Getenv("OS_DB_DATASTORE_VERSION")
+	osDBDatastoreType                = os.Getenv("OS_DB_DATASTORE_TYPE")
 	osDeprecatedEnvironment          = os.Getenv("OS_DEPRECATED_ENVIRONMENT")
 	osDNSEnvironment                 = os.Getenv("OS_DNS_ENVIRONMENT")
 	osExtGwID                        = os.Getenv("OS_EXTGW_ID")
@@ -118,7 +118,7 @@ func testAccPreCheckSwift(t *testing.T) {
 func testAccPreCheckDatabase(t *testing.T) {
 	testAccPreCheckRequiredEnvVars(t)
 
-	if osDbEnvironment == "" {
+	if osDBEnvironment == "" {
 		t.Skip("This environment does not support Database tests")
 	}
 }

--- a/openstack/resource_openstack_db_configuration_v1_test.go
+++ b/openstack/resource_openstack_db_configuration_v1_test.go
@@ -115,5 +115,5 @@ resource "openstack_db_configuration_v1" "basic" {
     value = 200
   }
 }
-`, osDbDatastoreVersion, osDbDatastoreType)
+`, osDBDatastoreVersion, osDBDatastoreType)
 }

--- a/openstack/resource_openstack_db_database_v1_test.go
+++ b/openstack/resource_openstack_db_database_v1_test.go
@@ -142,5 +142,5 @@ resource "openstack_db_database_v1" "basic" {
   name        = "basic"
   instance_id = "${openstack_db_instance_v1.basic.id}"
 }
-`, osDbDatastoreVersion, osDbDatastoreType, osNetworkID)
+`, osDBDatastoreVersion, osDBDatastoreType, osNetworkID)
 }

--- a/openstack/resource_openstack_db_instance_v1_test.go
+++ b/openstack/resource_openstack_db_instance_v1_test.go
@@ -169,5 +169,5 @@ resource "openstack_db_configuration_v1" "basic" {
     value = 200
   }
 }
-`, osDbDatastoreVersion, osDbDatastoreType, osNetworkID)
+`, osDBDatastoreVersion, osDBDatastoreType, osNetworkID)
 }

--- a/openstack/resource_openstack_db_user_v1_test.go
+++ b/openstack/resource_openstack_db_user_v1_test.go
@@ -144,5 +144,5 @@ resource "openstack_db_user_v1" "basic" {
   password    = "password"
   databases   = ["testdb"]
 }
-`, osDbDatastoreVersion, osDbDatastoreType, osNetworkID)
+`, osDBDatastoreVersion, osDBDatastoreType, osNetworkID)
 }


### PR DESCRIPTION
For now ST1005 (capitalized errors) check is disabled as it is required to
change almost every error message. Will be done in different PR.
For #1063 