### PR TITLE
openstack_lb_loadbalancer_v2: vip_port_id can be set for octavia

### DIFF
--- a/openstack/lb_v2_shared.go
+++ b/openstack/lb_v2_shared.go
@@ -1082,6 +1082,7 @@ func chooseLBV2LoadBalancerCreateOpts(d *schema.ResourceData, config *Config) ne
 			Description:  d.Get("description").(string),
 			VipNetworkID: d.Get("vip_network_id").(string),
 			VipSubnetID:  d.Get("vip_subnet_id").(string),
+			VipPortID:    d.Get("vip_port_id").(string),
 			ProjectID:    d.Get("tenant_id").(string),
 			VipAddress:   d.Get("vip_address").(string),
 			AdminStateUp: &adminStateUp,

--- a/openstack/resource_openstack_lb_loadbalancer_v2.go
+++ b/openstack/resource_openstack_lb_loadbalancer_v2.go
@@ -76,6 +76,8 @@ func resourceLoadBalancerV2() *schema.Resource {
 
 			"vip_port_id": {
 				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
 				Computed: true,
 			},
 

--- a/website/docs/r/lb_loadbalancer_v2.html.markdown
+++ b/website/docs/r/lb_loadbalancer_v2.html.markdown
@@ -32,12 +32,15 @@ The following arguments are supported:
     authorized by policy (e.g. networks that belong to them or networks that
     are shared).  Changing this creates a new loadbalancer.
     It is required to Neutron LBaaS but optional for Octavia.
-    
+
 * `vip_network_id` - (Optional) The network on which to allocate the
     Loadbalancer's address. A tenant can only create Loadbalancers on networks
     authorized by policy (e.g. networks that belong to them or networks that
     are shared).  Changing this creates a new loadbalancer.
     It is available only for Octavia.
+
+* `vip_port_id` - (Optional) The port UUID that the loadbalancer will use.
+  Changing this creates a new loadbalancer. It is available only for Octavia.
 
 * `name` - (Optional) Human-readable name for the Loadbalancer. Does not have
     to be unique.


### PR DESCRIPTION
Part of https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1090

This PR makes possible to define vip_port_id when creating a loadbalancer using octavia only. vip_port_id cannot be defined by user on neutron LBaaS