### PR TITLE
Add a service_catalog attribute to identity_auth_scope_v3 data

### DIFF
--- a/openstack/data_source_openstack_identity_auth_scope_v3.go
+++ b/openstack/data_source_openstack_identity_auth_scope_v3.go
@@ -92,6 +92,55 @@ func dataSourceIdentityAuthScopeV3() *schema.Resource {
 					},
 				},
 			},
+
+			"service_catalog": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"endpoints": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"region": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"region_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"interface": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"url": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -105,7 +154,7 @@ func dataSourceIdentityAuthScopeV3Read(d *schema.ResourceData, meta interface{})
 
 	d.SetId(d.Get("name").(string))
 
-	user, domain, project, roles, err := GetTokenDetails(identityClient)
+	user, domain, project, roles, catalog, err := GetTokenDetails(identityClient)
 	if err != nil {
 		return err
 	}
@@ -138,6 +187,13 @@ func dataSourceIdentityAuthScopeV3Read(d *schema.ResourceData, meta interface{})
 	allRoles := flattenIdentityAuthScopeV3Roles(roles)
 	if err := d.Set("roles", allRoles); err != nil {
 		log.Printf("[DEBUG] Unable to set openstack_identity_auth_scope_v3 roles: %s", err)
+	}
+
+	if catalog != nil {
+		flatCatalog := flattenIdentityAuthScopeV3ServiceCatalog(catalog)
+		if err := d.Set("service_catalog", flatCatalog); err != nil {
+			log.Printf("[DEBUG] Unable to set openstack_identity_auth_scope_v3 service_catalog: %s", err)
+		}
 	}
 
 	d.Set("region", GetRegion(d, config))

--- a/openstack/identity_auth_scope_v3_test.go
+++ b/openstack/identity_auth_scope_v3_test.go
@@ -33,3 +33,104 @@ func TestFlattenIdentityAuthScopeV3Roles(t *testing.T) {
 	actual := flattenIdentityAuthScopeV3Roles(roles)
 	assert.Equal(t, expected, actual)
 }
+
+func TestFlattenIdentityAuthScopeV3ServiceCatalog(t *testing.T) {
+	cinderEndpoints := []tokens.Endpoint{
+		{
+			ID:        "3",
+			Interface: "public",
+			Region:    "oakland",
+			RegionID:  "oak",
+			URL:       "http://oak.example.com/public_cinder",
+		},
+		{
+			ID:        "4",
+			Interface: "internal",
+			Region:    "oakland",
+			RegionID:  "oak",
+			URL:       "http://oak.example.com/internal_cinder",
+		},
+	}
+	keystoneEndpoints := []tokens.Endpoint{
+		{
+			ID:        "5",
+			Interface: "public",
+			Region:    "oakland",
+			RegionID:  "oak",
+			URL:       "http://oak.example.com/public_keystone",
+		},
+		{
+			ID:        "6",
+			Interface: "internal",
+			Region:    "oakland",
+			RegionID:  "oak",
+			URL:       "http://oak.example.com/internal_keystone",
+		},
+	}
+
+	catalogEntries := []tokens.CatalogEntry{
+		{
+			ID:        "1",
+			Name:      "cinderv2",
+			Type:      "volumev2",
+			Endpoints: cinderEndpoints,
+		},
+		{
+			ID:        "2",
+			Name:      "keystone",
+			Type:      "identity",
+			Endpoints: keystoneEndpoints,
+		},
+	}
+	catalog := tokens.ServiceCatalog{
+		Entries: catalogEntries,
+	}
+
+	expected := []map[string]interface{}{
+		{
+			"id":   "1",
+			"name": "cinderv2",
+			"type": "volumev2",
+			"endpoints": []map[string]string{
+				{
+					"id":        "3",
+					"interface": "public",
+					"region":    "oakland",
+					"region_id": "oak",
+					"url":       "http://oak.example.com/public_cinder",
+				},
+				{
+					"id":        "4",
+					"interface": "internal",
+					"region":    "oakland",
+					"region_id": "oak",
+					"url":       "http://oak.example.com/internal_cinder",
+				},
+			},
+		},
+		{
+			"id":   "2",
+			"name": "keystone",
+			"type": "identity",
+			"endpoints": []map[string]string{
+				{
+					"id":        "5",
+					"interface": "public",
+					"region":    "oakland",
+					"region_id": "oak",
+					"url":       "http://oak.example.com/public_keystone",
+				},
+				{
+					"id":        "6",
+					"interface": "internal",
+					"region":    "oakland",
+					"region_id": "oak",
+					"url":       "http://oak.example.com/internal_keystone",
+				},
+			},
+		},
+	}
+
+	actual := flattenIdentityAuthScopeV3ServiceCatalog(&catalog)
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
Keystone returns a service catalog along with the auth token.  That provides
useful information such as service endpoint URLs which may not otherwise be
available.  This change adds the service catalog to the
identity_auth_scope_v3 data source.