### PR TITLE
updated gophercloud/utils dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.38.0 (Unreleased)
+
+IMPROVEMENTS
+
+* Updated gophercloud/utils, which now recognizes `clouds.yml` in addition to `clouds.yaml` and correctly applies per-region value overrides
+
 ## 1.37.0 (February 8, 2021)
 
 FEATURES

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/gophercloud/gophercloud v0.15.1-0.20210202035223-633d73521055
-	github.com/gophercloud/utils v0.0.0-20210202040619-eca783186fc4
+	github.com/gophercloud/utils v0.0.0-20210209042946-13abf2251886
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/gophercloud/gophercloud v0.15.1-0.20210202035223-633d73521055 h1:/wFA
 github.com/gophercloud/gophercloud v0.15.1-0.20210202035223-633d73521055/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075O6i+LY+pXsKCBsb4=
 github.com/gophercloud/utils v0.0.0-20210202040619-eca783186fc4 h1:cMAAW/VtHAO72V4r1qlLOJ0bCHPaQrZB8j5aK7XcpSg=
 github.com/gophercloud/utils v0.0.0-20210202040619-eca783186fc4/go.mod h1:wx8HMD8oQD0Ryhz6+6ykq75PJ79iPyEqYHfwZ4l7OsA=
+github.com/gophercloud/utils v0.0.0-20210209042946-13abf2251886 h1:6VH2sy8abNypW0rHltOkkiiSrNB5ElPlWIIRc57uUyk=
+github.com/gophercloud/utils v0.0.0-20210209042946-13abf2251886/go.mod h1:wx8HMD8oQD0Ryhz6+6ykq75PJ79iPyEqYHfwZ4l7OsA=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=


### PR DESCRIPTION
This pulls recently merged improvements from gophercloud/utils:
* `clouds.yml` handling (compatibility with Python counterpart) [#142](https://github.com/gophercloud/utils/pull/142) (this actually made it into v1.37.0)
* correct merging of per-region value overrides in clouds.yaml [#143](https://github.com/gophercloud/utils/pull/143)