### PR TITLE
Refactor auth scope helpers

### DIFF
--- a/openstack/data_source_openstack_identity_auth_scope_v3.go
+++ b/openstack/data_source_openstack_identity_auth_scope_v3.go
@@ -154,29 +154,29 @@ func dataSourceIdentityAuthScopeV3Read(d *schema.ResourceData, meta interface{})
 
 	d.SetId(d.Get("name").(string))
 
-	user, domain, project, roles, catalog, err := GetTokenDetails(identityClient)
+	tokenDetails, err := getTokenDetails(identityClient)
 	if err != nil {
 		return err
 	}
 
-	d.Set("user_name", user.Name)
-	d.Set("user_id", user.ID)
-	d.Set("user_domain_name", user.Domain.Name)
-	d.Set("user_domain_id", user.Domain.ID)
+	d.Set("user_name", tokenDetails.user.Name)
+	d.Set("user_id", tokenDetails.user.ID)
+	d.Set("user_domain_name", tokenDetails.user.Domain.Name)
+	d.Set("user_domain_id", tokenDetails.user.Domain.ID)
 
-	if domain != nil {
-		d.Set("domain_name", domain.Name)
-		d.Set("domain_id", domain.ID)
+	if tokenDetails.domain != nil {
+		d.Set("domain_name", tokenDetails.domain.Name)
+		d.Set("domain_id", tokenDetails.domain.ID)
 	} else {
 		d.Set("domain_name", "")
 		d.Set("domain_id", "")
 	}
 
-	if project != nil {
-		d.Set("project_name", project.Name)
-		d.Set("project_id", project.ID)
-		d.Set("project_domain_name", project.Domain.Name)
-		d.Set("project_domain_id", project.Domain.ID)
+	if tokenDetails.project != nil {
+		d.Set("project_name", tokenDetails.project.Name)
+		d.Set("project_id", tokenDetails.project.ID)
+		d.Set("project_domain_name", tokenDetails.project.Domain.Name)
+		d.Set("project_domain_id", tokenDetails.project.Domain.ID)
 	} else {
 		d.Set("project_name", "")
 		d.Set("project_id", "")
@@ -184,13 +184,13 @@ func dataSourceIdentityAuthScopeV3Read(d *schema.ResourceData, meta interface{})
 		d.Set("project_domain_id", "")
 	}
 
-	allRoles := flattenIdentityAuthScopeV3Roles(roles)
+	allRoles := flattenIdentityAuthScopeV3Roles(tokenDetails.roles)
 	if err := d.Set("roles", allRoles); err != nil {
 		log.Printf("[DEBUG] Unable to set openstack_identity_auth_scope_v3 roles: %s", err)
 	}
 
-	if catalog != nil {
-		flatCatalog := flattenIdentityAuthScopeV3ServiceCatalog(catalog)
+	if tokenDetails.catalog != nil {
+		flatCatalog := flattenIdentityAuthScopeV3ServiceCatalog(tokenDetails.catalog)
 		if err := d.Set("service_catalog", flatCatalog); err != nil {
 			log.Printf("[DEBUG] Unable to set openstack_identity_auth_scope_v3 service_catalog: %s", err)
 		}

--- a/openstack/data_source_openstack_identity_project_v3.go
+++ b/openstack/data_source_openstack_identity_project_v3.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func dataSourceIdentityProjectV3() *schema.Resource {
@@ -100,10 +101,11 @@ func dataSourceIdentityProjectV3Read(d *schema.ResourceData, meta interface{}) e
 		userID := config.UserID
 		log.Printf("[DEBUG] Will try to find project with users.ListProjects as I am unable to query openstack_identity_project_v3: %s. Trying listing userprojects.", err)
 		if userID == "" {
-			userID, _, err = GetTokenInfo(identityClient)
-			if err != nil {
+			tokenInfo, tokenErr := getTokenInfo(identityClient)
+			if tokenErr != nil {
 				return fmt.Errorf("Error when getting token info: %s", err)
 			}
+			userID = tokenInfo.userID
 		}
 		// Search for all the projects using the users.ListProjects API call and filter them
 		allPages, err = users.ListProjects(identityClient, userID).AllPages()


### PR DESCRIPTION
Do not use exported functions.

Return structured token details and info instead of using lots of
returning values from helpers.

openstack/identity_auth_scope_v3.go.