### PR TITLE
networking_quota_v2: Manage quota by region

### DIFF
--- a/openstack/networking_v2_shared.go
+++ b/openstack/networking_v2_shared.go
@@ -2,7 +2,9 @@ package openstack
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
+	"strings"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -72,4 +74,17 @@ func decodeNeutronError(body []byte) (*neutronError, error) {
 	}
 
 	return &e.NeutronError, nil
+}
+
+func parseNetworkingQuotaID(id string) (string, string, error) {
+	// Use SplitN as it is possible for a region name to contain "/"
+	idParts := strings.SplitN(id, "/", 2)
+	if len(idParts) < 2 {
+		return "", "", fmt.Errorf("Unable to determine networking quota ID %s", id)
+	}
+
+	projectID := idParts[0]
+	region := idParts[1]
+
+	return projectID, region, nil
 }

--- a/openstack/networking_v2_shared_test.go
+++ b/openstack/networking_v2_shared_test.go
@@ -1,0 +1,29 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseNetworkingQuotaID(t *testing.T) {
+	networkingQuotaID := "557f2600ca3b40a0b8c8621a1e7ba559/region/1"
+	expectedProjectID := "557f2600ca3b40a0b8c8621a1e7ba559"
+	expectedRegion := "region/1"
+
+	actualProjectID, actualRegion, err := parseNetworkingQuotaID(networkingQuotaID)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedProjectID, actualProjectID)
+	assert.Equal(t, expectedRegion, actualRegion)
+}
+
+func TestParseNetworkingQuotaID_err(t *testing.T) {
+	wrongNetworkingQuotaID := "foo42"
+
+	actualProjectID, actualRegion, err := parseNetworkingQuotaID(wrongNetworkingQuotaID)
+
+	assert.Error(t, err)
+	assert.Empty(t, actualProjectID)
+	assert.Empty(t, actualRegion)
+}

--- a/website/docs/r/networking_quota_v2.html.markdown
+++ b/website/docs/r/networking_quota_v2.html.markdown
@@ -95,8 +95,8 @@ The following attributes are exported:
 
 ## Import
 
-Quotas can be imported using the `project_id`, e.g.
+Quotas can be imported using the `project_id/region_name`, e.g.
 
 ```
-$ terraform import openstack_networking_quota_v2.quota_1 2a0f2240-c5e6-41de-896d-e80d97428d6b
+$ terraform import openstack_networking_quota_v2.quota_1 2a0f2240-c5e6-41de-896d-e80d97428d6b/region_1
 ```


### PR DESCRIPTION
Close #1104 

Appends region to networking_quota_v2 resource ID. This allows to manage quotas across regions for the same project.

