### PR TITLE
Docs: Use names in `security_groups` in openstack_compute_instance_v2

### DIFF
--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -348,10 +348,11 @@ The following arguments are supported:
     Changing this creates a new server.
 
 * `security_groups` - (Optional) An array of one or more security group names
-    or ids to associate with the server. Changing this results in adding/removing
+    to associate with the server. Changing this results in adding/removing
     security groups from the existing server. *Note*: When attaching the
     instance to networks using Ports, place the security groups on the Port
-    and not the instance.
+    and not the instance. *Note*: Names should be used and not ids, as ids
+    trigger unnecessary updates.
 
 * `availability_zone_hints` - (Optional) The availability zone in which to
     create the server. This argument is preferred to `availability_zone`, when


### PR DESCRIPTION
Related to: https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1173

Update docs to inform users to only use names in security_groups