### PR TITLE
blockstorage_quotaset_v2: Add volume type quota support

### DIFF
--- a/openstack/resource_openstack_blockstorage_quotaset_v2.go
+++ b/openstack/resource_openstack_blockstorage_quotaset_v2.go
@@ -81,6 +81,11 @@ func resourceBlockStorageQuotasetV2() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+
+			"volume_type_quota": {
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -101,6 +106,7 @@ func resourceBlockStorageQuotasetV2Create(d *schema.ResourceData, meta interface
 	backups := d.Get("backups").(int)
 	backupGigabytes := d.Get("backup_gigabytes").(int)
 	groups := d.Get("groups").(int)
+	volumeTypeQuota := d.Get("volume_type_quota").(map[string]interface{})
 
 	updateOpts := quotasets.UpdateOpts{
 		Volumes:            &volumes,
@@ -110,6 +116,7 @@ func resourceBlockStorageQuotasetV2Create(d *schema.ResourceData, meta interface
 		Backups:            &backups,
 		BackupGigabytes:    &backupGigabytes,
 		Groups:             &groups,
+		Extra:              volumeTypeQuota,
 	}
 
 	q, err := quotasets.Update(blockStorageClient, projectID, updateOpts).Extract()
@@ -154,6 +161,7 @@ func resourceBlockStorageQuotasetV2Read(d *schema.ResourceData, meta interface{}
 	d.Set("backups", q.Backups)
 	d.Set("backup_gigabytes", q.BackupGigabytes)
 	d.Set("groups", q.Groups)
+	d.Set("volume_type_quota", q.Extra)
 
 	return nil
 }
@@ -210,6 +218,12 @@ func resourceBlockStorageQuotasetV2Update(d *schema.ResourceData, meta interface
 		hasChange = true
 		groups := d.Get("groups").(int)
 		updateOpts.Groups = &groups
+	}
+
+	if d.HasChange("volume_type_quota") {
+		hasChange = true
+		volumeTypeQuota := d.Get("volume_type_quota").(map[string]interface{})
+		updateOpts.Extra = volumeTypeQuota
 	}
 
 	if hasChange {

--- a/openstack/resource_openstack_blockstorage_quotaset_v2_test.go
+++ b/openstack/resource_openstack_blockstorage_quotaset_v2_test.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets"
@@ -108,12 +109,14 @@ func testAccCheckBlockStorageQuotasetV2Exists(n string, quotaset *quotasets.Quot
 			return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
 		}
 
-		found, err := quotasets.Get(blockStorageClient, rs.Primary.ID).Extract()
+		projectID := strings.Split(rs.Primary.ID, "/")[0]
+
+		found, err := quotasets.Get(blockStorageClient, projectID).Extract()
 		if err != nil {
 			return err
 		}
 
-		if found.ID != rs.Primary.ID {
+		if found.ID != projectID {
 			return fmt.Errorf("Quotaset not found")
 		}
 

--- a/website/docs/r/blockstorage_quotaset_v2.html.markdown
+++ b/website/docs/r/blockstorage_quotaset_v2.html.markdown
@@ -16,7 +16,7 @@ Manages a V2 block storage quotaset resource within OpenStack.
     in case of delete call.
 
 ~> **Note:** This resource has all-in creation so all optional quota arguments that were not specified are
-    created with zero value.
+    created with zero value. This excludes volume type quota.
 
 ## Example Usage
 
@@ -34,6 +34,11 @@ resource "openstack_blockstorage_quotaset_v2" "quotaset_1" {
   backups = 4
   backup_gigabytes = 10
   groups = 100
+  volume_type_quota = {
+    volumes_ssd = 30
+    gigabytes_ssd = 500
+    snapshots_ssd = 10
+  }
 }
 ```
 
@@ -69,6 +74,10 @@ The following arguments are supported:
 * `groups` - (Optional) Quota value for groups. Changing this updates the
     existing quotaset.
 
+* `volume_type_quota` - (Optional)  Key/Value pairs for setting quota for
+    volumes types. Possible keys are `snapshots_<volume_type_name>`,
+    `volumes_<volume_type_name>` and `gigabytes_<volume_type_name>`.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -82,6 +91,7 @@ The following attributes are exported:
 * `backups` - See Argument Reference above.
 * `backup_gigabytes` - See Argument Reference above.
 * `groups` - See Argument Reference above.
+* `volume_type_quota` - See Argument Reference above.
 
 ## Import
 

--- a/website/docs/r/blockstorage_quotaset_v2.html.markdown
+++ b/website/docs/r/blockstorage_quotaset_v2.html.markdown
@@ -85,8 +85,8 @@ The following attributes are exported:
 
 ## Import
 
-Quotasets can be imported using the `project_id`, e.g.
+Quotasets can be imported using the `project_id/region`, e.g.
 
 ```
-$ terraform import openstack_blockstorage_quotaset_v2.quotaset_1 2a0f2240-c5e6-41de-896d-e80d97428d6b
+$ terraform import openstack_blockstorage_quotaset_v2.quotaset_1 2a0f2240-c5e6-41de-896d-e80d97428d6b/region_1
 ```


### PR DESCRIPTION
Close #979

Gophercloud added support for volume_type quota with: gophercloud/gophercloud#2109

This PR requires both #1180 and #1182 