### PR TITLE
blockstorage_quotaset_v2/3: volume_type_quota to TypeInt

### DIFF
--- a/openstack/resource_openstack_blockstorage_quotaset_v2.go
+++ b/openstack/resource_openstack_blockstorage_quotaset_v2.go
@@ -84,6 +84,7 @@ func resourceBlockStorageQuotasetV2() *schema.Resource {
 
 			"volume_type_quota": {
 				Type:     schema.TypeMap,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
 				Optional: true,
 			},
 		},
@@ -161,7 +162,16 @@ func resourceBlockStorageQuotasetV2Read(d *schema.ResourceData, meta interface{}
 	d.Set("backups", q.Backups)
 	d.Set("backup_gigabytes", q.BackupGigabytes)
 	d.Set("groups", q.Groups)
-	d.Set("volume_type_quota", q.Extra)
+
+	// We only volume_type_quota when user is defining them to avoid unnecessary updates on every run
+	// and not introduce breaking changes
+	volumeTypeQuota := d.Get("volume_type_quota").(map[string]interface{})
+	if len(volumeTypeQuota) > 0 {
+		if err := d.Set("volume_type_quota", q.Extra); err != nil {
+			log.Printf(
+				"[WARN] Unable to set openstack_blockstorage_quotaset_v3 %s volume_type_quotas: %s", d.Id(), err)
+		}
+	}
 
 	return nil
 }
@@ -221,9 +231,17 @@ func resourceBlockStorageQuotasetV2Update(d *schema.ResourceData, meta interface
 	}
 
 	if d.HasChange("volume_type_quota") {
-		hasChange = true
-		volumeTypeQuota := d.Get("volume_type_quota").(map[string]interface{})
-		updateOpts.Extra = volumeTypeQuota
+		_, newVTQRaw := d.GetChange("volume_type_quota")
+		newVTQ := newVTQRaw.(map[string]interface{})
+
+		// if len(newVTQ) == 0 it can lead to error when trying to do an update with
+		// zero attributes. Not updating when a user removes all attributes is acceptable
+		// as this attributes are not removed anyways
+		if len(newVTQ) > 0 {
+			hasChange = true
+			volumeTypeQuota := d.Get("volume_type_quota").(map[string]interface{})
+			updateOpts.Extra = volumeTypeQuota
+		}
 	}
 
 	if hasChange {


### PR DESCRIPTION
Elements of volume_type_quota are TypeInt. This ensures that
the request sent to Openstack is not malformed.
Read func on both resources has been updated to set volume_type_quota
only when user is defining them. This is to avoid breaking_changes and
unnecessary updates during apply.

Unortunately, when a user defines volume_type_quota then he needs to define all keys for all volume types to avoid unnecessary 
updates. This is a bit unfriendly. I'll upload a POC with explicit type conversion that doesnt introduce this.

For: #1193