### PR TITLE
Use Go 1.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
Use latest Go version for builds.

It will also enable `darwin/arm64` binaries.

For #1192