### PR TITLE
openstack_images_image_v2: don't set "hidden" field by default

### DIFF
--- a/openstack/resource_openstack_images_image_v2.go
+++ b/openstack/resource_openstack_images_image_v2.go
@@ -235,7 +235,6 @@ func resourceImagesImageV2Create(d *schema.ResourceData, meta interface{}) error
 	}
 
 	protected := d.Get("protected").(bool)
-	hidden := d.Get("hidden").(bool)
 	visibility := resourceImagesImageV2VisibilityFromString(d.Get("visibility").(string))
 
 	properties := d.Get("properties").(map[string]interface{})
@@ -249,9 +248,13 @@ func resourceImagesImageV2Create(d *schema.ResourceData, meta interface{}) error
 		MinRAM:          d.Get("min_ram_mb").(int),
 		ID:              d.Get("image_id").(string),
 		Protected:       &protected,
-		Hidden:          &hidden,
 		Visibility:      &visibility,
 		Properties:      imageProperties,
+	}
+
+	if d.Get("hidden").(bool) {
+		hidden := true
+		createOpts.Hidden = &hidden
 	}
 
 	if v, ok := d.GetOk("tags"); ok {


### PR DESCRIPTION
Change https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1186 has incidentally broken `openstack_images_image_v2` resource for all Glance servers with API before 2.7.

OpenStack releases before Rocky don't have a "hidden" field in the image schema. Setting it to anything will result in an API crash. Since the default value is "false" anyways, it is safe just to omit this field if it is set to false, to save some backward compatibility.

Example of failure message:
```
Error: Error updating image: Bad request with: [PATCH https://imageservice.local:9292/v2/images/5f8b8949-573c-4b0f-aa9e-42b909611f01], error message: {"message": "Provided object does not match schema 'image': True is not of type 'string'\n\nFailed validating 'type' in schema['additionalProperties']:\n    {'type': 'string'}\n\nOn instance[u'os_hidden']:\n    True<br /><br />\n\n\n", "code": "400 Bad Request", "title": "Bad Request"}
```

Signed-off-by: Renat Nurgaliyev <impleman@gmail.com>