### PR TITLE
Allow to disable status check in resource_openstack_dns_recordset_v2

### DIFF
--- a/openstack/import_openstack_dns_recordset_v2_test.go
+++ b/openstack/import_openstack_dns_recordset_v2_test.go
@@ -22,6 +22,9 @@ func TestAccDNSV2RecordSet_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"disable_status_check",
+				},
 			},
 		},
 	})

--- a/website/docs/r/dns_recordset_v2.html.markdown
+++ b/website/docs/r/dns_recordset_v2.html.markdown
@@ -61,6 +61,10 @@ The following arguments are supported:
 * `value_specs` - (Optional) Map of additional options. Changing this creates a
   new record set.
 
+* `disable_status_check` - (Optional) Disable wait for recordset to reach ACTIVE
+  status. This argumen is disabled by default. If it is set to true, the recordset
+  will be considered as created/updated/deleted if OpenStack request returned success.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
This change is similar to a498d03c3a50d9ac986010a34411655d15b4db9c.

If recordset is created in Designate, and even all the backends are down,
Designate will try to recover. If only one of the backends is down, the
recordset will be in ERROR state, but will be served by other backends.
In this case, waiting for ACTIVE state also doesn't make sense.