### PR TITLE
networking_rbac_policy_v2: Add address_group as object_type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 example.tf
 terraform.tfplan
 terraform.tfstate
+.terraform.lock.hcl
 bin/
 modules-dev/
 /pkg/

--- a/openstack/resource_openstack_networking_rbac_policy_v2.go
+++ b/openstack/resource_openstack_networking_rbac_policy_v2.go
@@ -42,7 +42,7 @@ func resourceNetworkingRBACPolicyV2() *schema.Resource {
 				ForceNew: true,
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"address_scope", "network", "qos_policy", "security_group", "subnetpool",
+					"address_scope", "address_group", "network", "qos_policy", "security_group", "subnetpool",
 				}, false),
 			},
 

--- a/website/docs/r/networking_rbac_policy_v2.html.markdown
+++ b/website/docs/r/networking_rbac_policy_v2.html.markdown
@@ -55,7 +55,8 @@ The following arguments are supported:
    `qos_policy` returns a QoS ID.
 
 * `object_type` - (Required) The type of the object that the RBAC policy
-  affects. Can either be `qos-policy` or `network`.
+  affects. Can be one of the following: `address_scope`, `address_group`,
+  `network`, `qos_policy`, `security_group` or `subnetpool`.
 
 * `target_tenant` - (Required) The ID of the tenant to which the RBAC policy
   will be enforced.


### PR DESCRIPTION
Similar to #1086 this adds support for address_group.
Update docs are well

Also added `.terraform.lock.hcl` to `.gitignore` for when testing with tf >= 0.14