### PR TITLE
VPNaaS endpoint group resource: use schema.TypeSet for endpoints (V2)

### DIFF
--- a/openstack/resource_openstack_vpnaas_endpoint_group_v2.go
+++ b/openstack/resource_openstack_vpnaas_endpoint_group_v2.go
@@ -59,6 +59,7 @@ func resourceEndpointGroupV2() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
 			},
 			"value_specs": {
 				Type:     schema.TypeMap,
@@ -79,11 +80,7 @@ func resourceEndpointGroupV2Create(d *schema.ResourceData, meta interface{}) err
 	var createOpts endpointgroups.CreateOptsBuilder
 
 	endpointType := resourceEndpointGroupV2EndpointType(d.Get("type").(string))
-	v := d.Get("endpoints").([]interface{})
-	endpoints := make([]string, len(v))
-	for i, v := range v {
-		endpoints[i] = v.(string)
-	}
+	endpoints := expandToStringSlice(d.Get("endpoints").(*schema.Set).List())
 
 	createOpts = EndpointGroupCreateOpts{
 		endpointgroups.CreateOpts{

--- a/openstack/resource_openstack_vpnaas_endpoint_group_v2.go
+++ b/openstack/resource_openstack_vpnaas_endpoint_group_v2.go
@@ -55,7 +55,7 @@ func resourceEndpointGroupV2() *schema.Resource {
 				ForceNew: true,
 			},
 			"endpoints": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},

--- a/openstack/resource_openstack_vpnaas_endpoint_group_v2_test.go
+++ b/openstack/resource_openstack_vpnaas_endpoint_group_v2_test.go
@@ -2,6 +2,8 @@ package openstack
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/gophercloud/gophercloud"
@@ -28,7 +30,7 @@ func TestAccGroupV2_basic(t *testing.T) {
 						"openstack_vpnaas_endpoint_group_v2.group_1", &group),
 					resource.TestCheckResourceAttrPtr("openstack_vpnaas_endpoint_group_v2.group_1", "name", &group.Name),
 					resource.TestCheckResourceAttrPtr("openstack_vpnaas_endpoint_group_v2.group_1", "type", &group.Type),
-					//testAccCheckEndpoints("openstack_vpnaas_endpoint_group_v2.group_1", &group.Endpoints),
+					testAccCheckEndpoints("openstack_vpnaas_endpoint_group_v2.group_1", &group.Endpoints),
 				),
 			},
 		},
@@ -53,7 +55,7 @@ func TestAccGroupV2_update(t *testing.T) {
 						"openstack_vpnaas_endpoint_group_v2.group_1", &group),
 					resource.TestCheckResourceAttrPtr("openstack_vpnaas_endpoint_group_v2.group_1", "name", &group.Name),
 					resource.TestCheckResourceAttrPtr("openstack_vpnaas_endpoint_group_v2.group_1", "type", &group.Type),
-					//testAccCheckEndpoints("openstack_vpnaas_endpoint_group_v2.group_1", &group.Endpoints),
+					testAccCheckEndpoints("openstack_vpnaas_endpoint_group_v2.group_1", &group.Endpoints),
 				),
 			},
 			{
@@ -63,7 +65,7 @@ func TestAccGroupV2_update(t *testing.T) {
 						"openstack_vpnaas_endpoint_group_v2.group_1", &group),
 					resource.TestCheckResourceAttrPtr("openstack_vpnaas_endpoint_group_v2.group_1", "name", &group.Name),
 					resource.TestCheckResourceAttrPtr("openstack_vpnaas_endpoint_group_v2.group_1", "type", &group.Type),
-					//testAccCheckEndpoints("openstack_vpnaas_endpoint_group_v2.group_1", &group.Endpoints),
+					testAccCheckEndpoints("openstack_vpnaas_endpoint_group_v2.group_1", &group.Endpoints),
 				),
 			},
 		},
@@ -120,11 +122,6 @@ func testAccCheckEndpointGroupV2Exists(n string, group *endpointgroups.EndpointG
 	}
 }
 
-/*
-NOTE: this test is currently disabled since flatmap is deprecated.
-Since VPNaaS is not actively tested, we don't have a way of confidently
-creating an alernative test. Once we can, we can revisit this.
-
 func testAccCheckEndpoints(n string, actual *[]string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -135,19 +132,31 @@ func testAccCheckEndpoints(n string, actual *[]string) resource.TestCheckFunc {
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No ID is set")
 		}
-		endpoints := flatmap.Expand(rs.Primary.Attributes, "endpoints")
-		i := 0
-		for _, raw := range endpoints.([]interface{}) {
-			endpoint := raw.(string)
-			if endpoint != (*actual)[i] {
-				return fmt.Errorf("The endpoints did not match. Expected: %v but got %v", endpoint, (*actual)[i])
+		var endpointsList []string
+		// Find all "endpoints.<number>" keys and collect the values.
+		// The <number> values are seemingly random and very large.
+		for k, v := range rs.Primary.Attributes {
+			println("[DEBUG] key:", k, "value:", v)
+			if strings.HasPrefix(k, "endpoints.") && k[10] >= '0' && k[10] <= '9' {
+				endpointsList = append(endpointsList, v)
 			}
-			i++
+		}
+
+		if len(*actual) != len(endpointsList) {
+			return fmt.Errorf("The number of endpoints did not match. Expected: %v but got %v", len(*actual), len(endpointsList))
+		}
+
+		sort.Strings(endpointsList)
+		sort.Strings(*actual)
+
+		for i, endpoint := range endpointsList {
+			if endpoint != (*actual)[i] {
+				return fmt.Errorf("The endpoints did not match. Expected: '%v' but got '%v'", endpoint, (*actual)[i])
+			}
 		}
 		return nil
 	}
 }
-*/
 
 const testAccEndpointGroupV2Basic = `
 	resource "openstack_vpnaas_endpoint_group_v2" "group_1" {

--- a/openstack/resource_openstack_vpnaas_ipsec_policy_v2_test.go
+++ b/openstack/resource_openstack_vpnaas_ipsec_policy_v2_test.go
@@ -2,6 +2,8 @@ package openstack
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/gophercloud/gophercloud"
@@ -56,7 +58,7 @@ func TestAccIPSecPolicyV2_withLifetime(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIPSecPolicyV2Exists(
 						"openstack_vpnaas_ipsec_policy_v2.policy_1", &policy),
-					//testAccCheckLifetime("openstack_vpnaas_ipsec_policy_v2.policy_1", &policy.Lifetime.Units, &policy.Lifetime.Value),
+					testAccCheckLifetime("openstack_vpnaas_ipsec_policy_v2.policy_1", &policy.Lifetime.Units, &policy.Lifetime.Value),
 				),
 			},
 		},
@@ -110,7 +112,7 @@ func TestAccIPSecPolicyV2_withLifetimeUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIPSecPolicyV2Exists(
 						"openstack_vpnaas_ipsec_policy_v2.policy_1", &policy),
-					//testAccCheckLifetime("openstack_vpnaas_ipsec_policy_v2.policy_1", &policy.Lifetime.Units, &policy.Lifetime.Value),
+					testAccCheckLifetime("openstack_vpnaas_ipsec_policy_v2.policy_1", &policy.Lifetime.Units, &policy.Lifetime.Value),
 					resource.TestCheckResourceAttrPtr("openstack_vpnaas_ipsec_policy_v2.policy_1", "auth_algorithm", &policy.AuthAlgorithm),
 					resource.TestCheckResourceAttrPtr("openstack_vpnaas_ipsec_policy_v2.policy_1", "pfs", &policy.PFS),
 				),
@@ -120,7 +122,7 @@ func TestAccIPSecPolicyV2_withLifetimeUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIPSecPolicyV2Exists(
 						"openstack_vpnaas_ipsec_policy_v2.policy_1", &policy),
-					//testAccCheckLifetime("openstack_vpnaas_ipsec_policy_v2.policy_1", &policy.Lifetime.Units, &policy.Lifetime.Value),
+					testAccCheckLifetime("openstack_vpnaas_ipsec_policy_v2.policy_1", &policy.Lifetime.Units, &policy.Lifetime.Value),
 				),
 			},
 		},
@@ -175,34 +177,39 @@ func testAccCheckIPSecPolicyV2Exists(n string, policy *ipsecpolicies.Policy) res
 	}
 }
 
-/*
-NOTE: this test is currently disabled since flatmap is deprecated.
-Since VPNaaS is not actively tested, we don't have a way of confidently
-creating an alernative test. Once we can, we can revisit this.
-
 func testAccCheckLifetime(n string, unit *string, value *int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
-		lifetime := flatmap.Expand(rs.Primary.Attributes, "lifetime")
-		for _, raw := range lifetime.([]interface{}) {
-			rawMap := raw.(map[string]interface{})
+		// [DEBUG] key: lifetime.452086442.units value: seconds
+		// [DEBUG] key: lifetime.452086442.value value: 1200
+		// [DEBUG] key: lifetime.# value: 1
+		for k, v := range rs.Primary.Attributes {
+			println("[DEBUG] key:", k, "value:", v)
+			// Do one check for each time a key like "lifetime.<number>.units" is seen.
+			// If more than one exists they apparently must all have the same values.
+			if strings.HasPrefix(k, "lifetime.") && k[9] >= '0' && k[9] <= '9' && strings.HasSuffix(k, ".units") {
+				// Find "lifetime.<number>" so we can append ".value"
+				index := strings.LastIndex(k, ".")
+				base := k[:index]
+				expectedValue := rs.Primary.Attributes[base+".value"]
+				expectedUnit := rs.Primary.Attributes[k]
+				println("[DEBUG] expectedValue:", expectedValue, "expectedUnit:", expectedUnit)
 
-			expectedValue := rawMap["value"]
-			expectedUnit := rawMap["units"]
-			if expectedUnit != *unit {
-				return fmt.Errorf("Expected lifetime unit %v but found %v", expectedUnit, *unit)
-			}
-			if expectedValue != strconv.Itoa(*value) {
-				return fmt.Errorf("Expected lifetime value %v but found %v", expectedValue, *value)
+				if expectedUnit != *unit {
+					return fmt.Errorf("Expected lifetime unit %v but found %v", expectedUnit, *unit)
+				}
+				if expectedValue != strconv.Itoa(*value) {
+					return fmt.Errorf("Expected lifetime value %v but found %v", expectedValue, *value)
+				}
 			}
 		}
+
 		return nil
 	}
 }
-*/
 
 const testAccIPSecPolicyV2Basic = `
 resource "openstack_vpnaas_ipsec_policy_v2" "policy_1" {


### PR DESCRIPTION
Hi! I'm trying to improve on merge request !1089.

After some to-and-fro to get the tests running locally (I don't mess with a devstack, I have a real cloud at hand; but my test user wasn't called `demo` of course), it seems that what I think is the relevant test `TestAccGroupV2_basic` passes.

I triggered a recheck of !1089 because the logs seem to have expired, but when I looked, that specific test seems to be skipped.
```
2021-05-14 15:09:42.193729 | ubuntu-bionic | === RUN   TestAccGroupV2_basic
2021-05-14 15:09:42.193739 | ubuntu-bionic |     TestAccGroupV2_basic: provider_test.go:163: This environment does not support VPN tests
2021-05-14 15:09:42.193749 | ubuntu-bionic | --- SKIP: TestAccGroupV2_basic (0.00s)
2021-05-14 15:09:42.193759 | ubuntu-bionic | === RUN   TestAccGroupV2_update
2021-05-14 15:09:42.193769 | ubuntu-bionic |     TestAccGroupV2_update: provider_test.go:163: This environment does not support VPN tests
```

So let's see what happens.