### PR TITLE
Remove Octavia microversions

### DIFF
--- a/openstack/resource_openstack_lb_listener_v2.go
+++ b/openstack/resource_openstack_lb_listener_v2.go
@@ -160,7 +160,7 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Choose either the Octavia or Neutron create options.
-	createOpts, err := chooseLBV2ListenerCreateOpts(d, config, lbClient)
+	createOpts, err := chooseLBV2ListenerCreateOpts(d, config)
 	if err != nil {
 		return fmt.Errorf("Error building openstack_lb_listener_v2 create options: %s", err)
 	}

--- a/openstack/resource_openstack_lb_loadbalancer_v2.go
+++ b/openstack/resource_openstack_lb_loadbalancer_v2.go
@@ -150,8 +150,9 @@ func resourceLoadBalancerV2Create(d *schema.ResourceData, meta interface{}) erro
 			FlavorID:     d.Get("flavor_id").(string),
 			Provider:     lbProvider,
 		}
+
+		// availability_zone requires octavia minor version 2.14. Only set when specified.
 		if v, ok := d.GetOk("availability_zone"); ok {
-			lbClient.Microversion = octaviaLBAvailabilityZoneMicroversion
 			aZ := v.(string)
 			createOpts.AvailabilityZone = aZ
 		}

--- a/openstack/resource_openstack_lb_quota_v2.go
+++ b/openstack/resource_openstack_lb_quota_v2.go
@@ -112,14 +112,14 @@ func resourceLoadBalancerQuotaV2Create(d *schema.ResourceData, meta interface{})
 		Healthmonitor: &healthmonitor,
 	}
 
+	// l7_policy requires octavia minor version 2.19. Only set when specified
 	if v, ok := d.GetOkExists("l7_policy"); ok {
-		lbClient.Microversion = octaviaLBQuotaRuleAndPolicyMicroversion
 		l7Policy := v.(int)
 		updateOpts.L7Policy = &l7Policy
 	}
 
+	// l7_rule requires octavia minor version 2.19. Only set when specified
 	if v, ok := d.GetOkExists("l7_rule"); ok {
-		lbClient.Microversion = octaviaLBQuotaRuleAndPolicyMicroversion
 		l7Rule := v.(int)
 		updateOpts.L7Rule = &l7Rule
 	}
@@ -220,14 +220,12 @@ func resourceLoadBalancerQuotaV2Update(d *schema.ResourceData, meta interface{})
 
 	if d.HasChange("l7_policy") {
 		hasChange = true
-		lbClient.Microversion = octaviaLBQuotaRuleAndPolicyMicroversion
 		l7Policy := d.Get("l7_policy").(int)
 		updateOpts.L7Policy = &l7Policy
 	}
 
 	if d.HasChange("l7_rule") {
 		hasChange = true
-		lbClient.Microversion = octaviaLBQuotaRuleAndPolicyMicroversion
 		l7Rule := d.Get("l7_rule").(int)
 		updateOpts.L7Rule = &l7Rule
 	}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -241,6 +241,22 @@ accommodate these modifications, but we can't guarantee this.
 We try to support _all_ releases of OpenStack when we can. If your OpenStack
 cloud is running an older release, we still should be able to support it.
 
+### Octavia api versioning
+
+[Octavia api](https://docs.openstack.org/api-ref/load-balancer/v2/) is using
+minor versions when adding new features and functionality. The required minor
+version of each feature are documented on the resource page. When using such a
+feature ensure that your Openstack cloud supports the required minor version.
+A simple way of checking which minor versions are supported on your Openstack
+cloud is the following:
+
+```shell
+export OS_TOKEN=`openstack token issue -c id -f value`
+curl -s -H "X-Auth-Token: $OS_TOKEN"  "https://example.com:9876/"
+```
+
+
+
 ### Rackspace Compatibility
 
 Using this OpenStack provider with Rackspace is not supported and not

--- a/website/docs/r/lb_listener_v2.html.markdown
+++ b/website/docs/r/lb_listener_v2.html.markdown
@@ -10,6 +10,9 @@ description: |-
 
 Manages a V2 listener resource within OpenStack.
 
+~> **Note:** This resource has attributes that depend on octavia minor versions.
+Please ensure your Openstack cloud supports the required [minor version](../#octavia-api-versioning).
+
 ## Example Usage
 
 ```hcl
@@ -35,7 +38,7 @@ The following arguments are supported:
 
 * `protocol` - (Required) The protocol - can either be TCP, HTTP, HTTPS,
   TERMINATED_HTTPS, UDP (supported only in Octavia) or SCTP (supported only
-  in Octavia microversion >= 2.23). Changing this creates a new Listener.
+  in **Octavia minor version >= 2.23**). Changing this creates a new Listener.
 
 * `protocol_port` - (Required) The port on which to listen for client traffic.
     Changing this creates a new Listener.

--- a/website/docs/r/lb_loadbalancer_v2.html.markdown
+++ b/website/docs/r/lb_loadbalancer_v2.html.markdown
@@ -10,6 +10,9 @@ description: |-
 
 Manages a V2 loadbalancer resource within OpenStack.
 
+~> **Note:** This resource has attributes that depend on octavia minor versions.
+Please ensure your Openstack cloud supports the required [minor version](../#octavia-api-versioning).
+
 ## Example Usage
 
 ```hcl
@@ -65,7 +68,7 @@ The following arguments are supported:
 
 * `availability_zone` - (Optional) The availability zone of the Loadbalancer.
   Changing this creates a new loadbalancer. Available only for Octavia
-  microversion 2.14 or later.
+  **minor version 2.14 or later**.
 
 * `security_group_ids` - (Optional) A list of security group IDs to apply to the
     loadbalancer. The security groups must be specified by ID and not name (as

--- a/website/docs/r/lb_members_v2.html.markdown
+++ b/website/docs/r/lb_members_v2.html.markdown
@@ -10,6 +10,9 @@ description: |-
 
 Manages a V2 members resource within OpenStack (batch members update).
 
+~> **Note:** This resource has attributes that depend on octavia minor versions.
+Please ensure your Openstack cloud supports the required [minor version](../#octavia-api-versioning).
+
 ~> **Note:** This resource works only within [Octavia API](../#use_octavia). For
 legacy Neutron LBaaS v2 extension please use
 [openstack_lb_member_v2](lb_member_v2.html) resource.
@@ -67,7 +70,7 @@ The `member` block supports:
   A valid value is true (UP) or false (DOWN). Defaults to true.
 
 * `backup` - (Optional) A bool that indicates whether the the member is
-  backup. Requires octavia microversion 2.1 or later.
+  backup. **Requires octavia minor version 2.1 or later**.
 
 ## Attributes Reference
 

--- a/website/docs/r/lb_quota_v2.html.markdown
+++ b/website/docs/r/lb_quota_v2.html.markdown
@@ -20,6 +20,9 @@ Manages a V2 load balancer quota resource within OpenStack.
 ~> **Note:** This resource has all-in creation so all optional quota arguments that were not specified are
    created with zero value.
 
+~> **Note:** This resource has attributes that depend on octavia minor versions.
+Please ensure your Openstack cloud supports the required [minor version](../#octavia-api-versioning).
+
 ## Example Usage
 
 ```hcl
@@ -66,11 +69,11 @@ The following arguments are supported:
 
 * `l7_policy` - (Optional) Quota value for l7_policies. Changing this
   updates the existing quota. Omitting it sets it to 0. Available in
-  Octavia 2.19.
+  **Octavia minor version 2.19**.
 
 * `l7_rule` - (Optional) Quota value for l7_rules. Changing this
   updates the existing quota. Omitting it sets it to 0. Available in
-  Octavia 2.19.
+  **Octavia minor version 2.19**.
 
 
 ## Attributes Reference


### PR DESCRIPTION
Octavia does not use microversions. Instead the api has minor versions.
Change existing implementations that assumed that microversions are in-use.

Add small documentation in index explaining how to fetch supported minor versions
of an Openstack cloud.
For every octavia resource that was using "microversions":
- Remove the setting of client microversion and set inline comment with the
	required minor version.
- Update docs with a note and highlighting the required minor version

Relates to: #1239 