### PR TITLE
lb_pool_v2: Add support for SCTP and PROXYV2 prot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-provider-openstack/terraform-provider-openstack
 go 1.15
 
 require (
-	github.com/gophercloud/gophercloud v0.17.1-0.20210429172743-0fc2c97ff6da
+	github.com/gophercloud/gophercloud v0.17.1-0.20210517213536-0be823b69be8
 	github.com/gophercloud/utils v0.0.0-20210216074907-f6de111f2eae
 	github.com/hashicorp/terraform-plugin-sdk v1.17.2
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/gophercloud/gophercloud v0.15.1-0.20210202035223-633d73521055/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075O6i+LY+pXsKCBsb4=
 github.com/gophercloud/gophercloud v0.17.1-0.20210429172743-0fc2c97ff6da h1:QgVvYyRwAT/v8djG6yIBaINcP/X9POZN7mKzblkWqWw=
 github.com/gophercloud/gophercloud v0.17.1-0.20210429172743-0fc2c97ff6da/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075O6i+LY+pXsKCBsb4=
+github.com/gophercloud/gophercloud v0.17.1-0.20210517213536-0be823b69be8 h1:E842tot70u3PP3V+GVs1wL04PHKE4ERoijACgQiIwdA=
+github.com/gophercloud/gophercloud v0.17.1-0.20210517213536-0be823b69be8/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075O6i+LY+pXsKCBsb4=
 github.com/gophercloud/utils v0.0.0-20210216074907-f6de111f2eae h1:Hi3IgB9RQDE15Kfovd8MTZrcana+UlQqNbOif8dLpA0=
 github.com/gophercloud/utils v0.0.0-20210216074907-f6de111f2eae/go.mod h1:wx8HMD8oQD0Ryhz6+6ykq75PJ79iPyEqYHfwZ4l7OsA=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=

--- a/openstack/resource_openstack_lb_pool_v2.go
+++ b/openstack/resource_openstack_lb_pool_v2.go
@@ -59,7 +59,7 @@ func resourcePoolV2() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"TCP", "UDP", "HTTP", "HTTPS", "PROXY",
+					"TCP", "UDP", "HTTP", "HTTPS", "PROXY", "SCTP", "PROXYv2",
 				}, false),
 			},
 

--- a/website/docs/r/lb_pool_v2.html.markdown
+++ b/website/docs/r/lb_pool_v2.html.markdown
@@ -10,6 +10,9 @@ description: |-
 
 Manages a V2 pool resource within OpenStack.
 
+~> **Note:** This resource has attributes that depend on octavia minor versions.
+Please ensure your Openstack cloud supports the required [minor version](../#octavia-api-versioning).
+
 ## Example Usage
 
 ```hcl
@@ -42,8 +45,9 @@ The following arguments are supported:
 
 * `description` - (Optional) Human-readable description for the pool.
 
-* `protocol` - (Required) The protocol - can either be TCP, HTTP, HTTPS, PROXY
-  or UDP (supported only in Octavia). Changing this creates a new pool.
+* `protocol` - (Required) The protocol - can either be TCP, HTTP, HTTPS, PROXY,
+  UDP (supported only in Octavia), PROXYV2 (**Octavia minor version >= 2.22**)
+  or SCTP (**Octavia minor version >= 2.23**). Changing this creates a new pool.
 
 * `loadbalancer_id` - (Optional) The load balancer on which to provision this
     pool. Changing this creates a new pool.


### PR DESCRIPTION
Update gophercloud to include required changes.
Add SCTP and PROXYV2 to the list of allowed protocols for pool_v2.
Update docs with the required octavia minor version for these
protocols.

Requires: #1249 for the documentation link
Close: #1250