### PR TITLE
Expose database instance IP addresses

### DIFF
--- a/openstack/resource_openstack_db_instance_v1.go
+++ b/openstack/resource_openstack_db_instance_v1.go
@@ -165,6 +165,16 @@ func resourceDatabaseInstanceV1() *schema.Resource {
 				Computed: false,
 				ForceNew: false,
 			},
+
+			"addresses": {
+				Type:     schema.TypeList,
+				Optional: false,
+				Computed: true,
+				ForceNew: false,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }
@@ -267,6 +277,7 @@ func resourceDatabaseInstanceV1Read(d *schema.ResourceData, meta interface{}) er
 	d.Set("flavor_id", instance.Flavor)
 	d.Set("datastore", instance.Datastore)
 	d.Set("region", GetRegion(d, config))
+	d.Set("addresses", instance.IP)
 
 	return nil
 }

--- a/website/docs/r/db_instance_v1.html.markdown
+++ b/website/docs/r/db_instance_v1.html.markdown
@@ -98,7 +98,7 @@ The `user` block supports:
 * `host` - (Optional) An ip address or % sign indicating what ip addresses can connect with
     this user credentials. Changing this creates a new instance.
 
-* `databases` - (Optional) A list of databases that user will have access to. If not specified, 
+* `databases` - (Optional) A list of databases that user will have access to. If not specified,
      user has access to all databases on th einstance. Changing this creates a new instance.
 
 The `database` block supports:
@@ -134,3 +134,4 @@ The following attributes are exported:
 * `user/password` - See Argument Reference above.
 * `user/databases` - See Argument Reference above.
 * `user/host` - See Argument Reference above.
+* `addresses` - A list of IP addresses assigned to the instance.


### PR DESCRIPTION
When creating a database instance with only a network to attach to, Trove will automatically create a port on that network and have an IP address assigned. However, this can only be see on the query API in the `ip` or `addresses` attributes, you cannot see the network port uuid. (`ip` is deprecated, but the only attribute GopherCloud supports).

Expose the assigned addresses as a new exported list `addresses` which is just a straight copy of the `ip` attribute on the query response.

Tested against Trove Victoria.