### PR TITLE
Data source for openstack_identity_domain_v3

### DIFF
--- a/openstack/data_source_openstack_identity_domain_v3.go
+++ b/openstack/data_source_openstack_identity_domain_v3.go
@@ -1,0 +1,88 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/domains"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceIdentityDomainV3() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceIdentityDomainV3Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+// dataSourceIdentityDomainV3Read performs the domain lookup.
+func dataSourceIdentityDomainV3Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack identity client: %s", err)
+	}
+
+	enabled := d.Get("enabled").(bool)
+	listOpts := domains.ListOpts{
+		Enabled: &enabled,
+		Name:    d.Get("name").(string),
+	}
+
+	log.Printf("[DEBUG] openstack_identity_domain_v3 list options: %#v", listOpts)
+
+	var domain domains.Domain
+	allPages, err := domains.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		return fmt.Errorf("Unable to query openstack_identity_domain_v3: %s", err)
+	}
+
+	allDomains, err := domains.ExtractDomains(allPages)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve openstack_identity_domain_v3: %s", err)
+	}
+
+	if len(allDomains) < 1 {
+		return fmt.Errorf("Your openstack_identity_domain_v3 query returned no results")
+	}
+
+	if len(allDomains) > 1 {
+		return fmt.Errorf("Your openstack_identity_domain_v3 query returned more than one result")
+	}
+
+	domain = allDomains[0]
+
+	return dataSourceIdentityDomainV3Attributes(d, config, &domain)
+}
+
+// dataSourceIdentityDomainV3Attributes populates the fields of an Domain resource.
+func dataSourceIdentityDomainV3Attributes(d *schema.ResourceData, config *Config, domain *domains.Domain) error {
+	log.Printf("[DEBUG] openstack_identity_domain_v3 details: %#v", domain)
+
+	d.SetId(domain.ID)
+	d.Set("name", domain.Name)
+	d.Set("domain_id", domain.ID)
+	d.Set("region", GetRegion(d, config))
+	d.Set("enabled", domain.Enabled)
+
+	return nil
+}

--- a/openstack/data_source_openstack_identity_domain_v3_test.go
+++ b/openstack/data_source_openstack_identity_domain_v3_test.go
@@ -1,0 +1,50 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccOpenStackIdentityV3DomainDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpenStackIdentityV3DomainDataSourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityV3DomainDataSourceID("data.openstack_identity_domain_v3.domain_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_identity_domain_v3.domain_1", "name", "Default"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIdentityV3DomainDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find domain data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Domain data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+const testAccOpenStackIdentityV3DomainDataSourceBasic = `
+data "openstack_identity_domain_v3" "domain_1" {
+    name = "Default"
+}
+`

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -261,6 +261,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_containerinfra_cluster_v1":                dataSourceContainerInfraCluster(),
 			"openstack_dns_zone_v2":                              dataSourceDNSZoneV2(),
 			"openstack_fw_policy_v1":                             dataSourceFWPolicyV1(),
+			"openstack_identity_domain_v3":                       dataSourceIdentityDomainV3(),
 			"openstack_identity_role_v3":                         dataSourceIdentityRoleV3(),
 			"openstack_identity_project_v3":                      dataSourceIdentityProjectV3(),
 			"openstack_identity_user_v3":                         dataSourceIdentityUserV3(),


### PR DESCRIPTION
Implements a new data source for openstack_identity_domain_v3.
Required to get ID of openstack keystone's domain.

WIP: Needs documentation and review.