### PR TITLE
Fix panic, when a token doesn't have a project scope

### DIFF
--- a/openstack/dns_zone_v2.go
+++ b/openstack/dns_zone_v2.go
@@ -60,7 +60,7 @@ func dnsClientSetAuthHeader(resourceData *schema.ResourceData, dnsClient *gopher
 	// If project_id is different from auth one, set AuthSudo header
 	if v, ok := resourceData.GetOk("project_id"); ok {
 		if projectID, ok := v.(string); ok {
-			if project.ID != projectID {
+			if project != nil && project.ID != projectID {
 				headers[headerAuthSudoTenantID] = projectID
 			}
 		} else {

--- a/openstack/identity_auth_scope_v3.go
+++ b/openstack/identity_auth_scope_v3.go
@@ -167,7 +167,9 @@ func getTokenInfoV3(t interface{}) (authScopeTokenInfo, error) {
 			return info, err
 		}
 		info.userID = user.ID
-		info.projectID = project.ID
+		if project != nil {
+			info.projectID = project.ID
+		}
 		return info, nil
 	case tokens3.GetResult:
 		user, err := r.ExtractUser()
@@ -179,7 +181,9 @@ func getTokenInfoV3(t interface{}) (authScopeTokenInfo, error) {
 			return info, err
 		}
 		info.userID = user.ID
-		info.projectID = project.ID
+		if project != nil {
+			info.projectID = project.ID
+		}
 		return info, nil
 	default:
 		return info, fmt.Errorf("got unexpected AuthResult type %t", r)


### PR DESCRIPTION
This fix handles an empty project scope. When a token is unscoped, or domain scoped, the project ID will be set to an empty string.

Fixes #1281