### PR TITLE
Fetch volume os-vol-host-attr from OpenStack API

### DIFF
--- a/website/docs/d/blockstorage_volume_v3.html.markdown
+++ b/website/docs/d/blockstorage_volume_v3.html.markdown
@@ -43,3 +43,4 @@ are exported:
 * `size` - The size of the volume in GBs.
 * `source_volume_id` - The ID of the volume from which the current volume was created.
 * `multiattach` - Indicates if the volume can be attached to more then one server.
+* `host` - The OpenStack host on which the volume is located.


### PR DESCRIPTION
Getting the host attribute of a volume works now
using the gophercloud library; let's collect it.

Closes https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1292.