### PR TITLE
Bump golangci-lint version to v1.42.1

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,4 +16,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.38
+          version: v1.42.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,16 @@
 run:
   deadline: 5m
 
+linters-settings:
+  staticcheck:
+    go: 1.17
+  stylecheck:
+    go: 1.17
+  gci:
+    local-prefixes: github.com/gophercloud
+  goimports:
+    local-prefixes: github.com/gophercloud
+
 linters:
   fast: false
   disable-all: true
@@ -13,29 +23,20 @@ linters:
     - errcheck
     - exhaustive
     - exportloopref
-#    - gochecknoglobals
-#    - goconst
-#    - gocritic
+    - gci
     - godot
     - gofmt
-#    - gofumpt
     - goheader
     - goimports
-    - golint
     - gomodguard
     - goprintffuncname
-#    - gosec
-#    - gosimple
     - govet
     - ineffassign
-    - interfacer
-    - maligned
     - misspell
     - nakedret
     - nolintlint
     - prealloc
     - rowserrcheck
-#    - scopelint
     - staticcheck
     - structcheck
     - stylecheck
@@ -44,6 +45,53 @@ linters:
     - unused
     - varcheck
     - whitespace
+#    - cyclop
+#    - dupl
+#    - durationcheck
+#    - errname
+#    - errorlint
+#    - exhaustivestruct
+#    - forbidigo
+#    - forcetypeassert
+#    - funlen
+#    - gochecknoglobals
+#    - gochecknoinits
+#    - gocognit
+#    - goconst
+#    - gocritic
+#    - gocyclo
+#    - godox
+#    - goerr113
+#    - gofumpt
+#    - golint
+#    - gomnd
+#    - gomoddirectives
+#    - gosec (gas)
+#    - gosimple (megacheck)
+#    - ifshort
+#    - importas
+#    - interfacer
+#    - lll
+#    - makezero
+#    - maligned
+#    - nestif
+#    - nilerr
+#    - nlreturn
+#    - noctx
+#    - paralleltest
+#    - predeclared
+#    - promlinter
+#    - revive
+#    - scopelint
+#    - sqlclosecheck
+#    - tagliatelle
+#    - testpackage
+#    - thelper
+#    - tparallel
+#    - unparam
+#    - wastedassign
+#    - wrapcheck
+#    - wsl
 
 issues:
   exclude-rules:

--- a/openstack/dns_transfer_accept_v2.go
+++ b/openstack/dns_transfer_accept_v2.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/transfer/accept"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 // TransferAcceptCreateOpts represents the attributes used when creating a new transfer accept.

--- a/openstack/networking_portforwarding_v2.go
+++ b/openstack/networking_portforwarding_v2.go
@@ -1,10 +1,10 @@
 package openstack
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/portforwarding"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func networkingPortForwardingV2StateRefreshFunc(client *gophercloud.ServiceClient, fipID, pfID string) resource.StateRefreshFunc {

--- a/openstack/resource_openstack_blockstorage_volume_type_access_v3.go
+++ b/openstack/resource_openstack_blockstorage_volume_type_access_v3.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes"

--- a/openstack/resource_openstack_blockstorage_volume_type_v3.go
+++ b/openstack/resource_openstack_blockstorage_volume_type_v3.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes"

--- a/openstack/resource_openstack_dns_transfer_accept_v2.go
+++ b/openstack/resource_openstack_dns_transfer_accept_v2.go
@@ -5,11 +5,11 @@ import (
 	"log"
 	"time"
 
-	"github.com/gophercloud/gophercloud/openstack/dns/v2/transfer/accept"
-	"github.com/gophercloud/gophercloud/openstack/dns/v2/transfer/request"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/gophercloud/gophercloud/openstack/dns/v2/transfer/accept"
+	"github.com/gophercloud/gophercloud/openstack/dns/v2/transfer/request"
 )
 
 func resourceDNSTransferAcceptV2() *schema.Resource {

--- a/openstack/resource_openstack_dns_transfer_request_v2.go
+++ b/openstack/resource_openstack_dns_transfer_request_v2.go
@@ -5,10 +5,10 @@ import (
 	"log"
 	"time"
 
-	"github.com/gophercloud/gophercloud/openstack/dns/v2/transfer/request"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/gophercloud/gophercloud/openstack/dns/v2/transfer/request"
 )
 
 func resourceDNSTransferRequestV2() *schema.Resource {

--- a/openstack/resource_openstack_lb_quota_v2.go
+++ b/openstack/resource_openstack_lb_quota_v2.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/quotas"


### PR DESCRIPTION
Update version in CI job.

Add local prefixes in config, remove deprecated linters, comment all
linters that are currently failing or not tested yet.