### PR TITLE
Correctly delete openstack_networking_router_interface_v2 resources

### DIFF
--- a/openstack/networking_router_interface_v2.go
+++ b/openstack/networking_router_interface_v2.go
@@ -38,6 +38,12 @@ func resourceNetworkingRouterInterfaceV2DeleteRefreshFunc(networkingClient *goph
 			PortID:   d.Get("port_id").(string),
 		}
 
+		if removeOpts.SubnetID != "" {
+			// We need to make sure to only send subnet_id, because the port may have multiple
+			// openstack_networking_router_interface_v2 attached. Otherwise openstack would delete them too.
+			removeOpts.PortID = ""
+		}
+
 		r, err := ports.Get(networkingClient, routerInterfaceID).Extract()
 		if err != nil {
 			if _, ok := err.(gophercloud.ErrDefault404); ok {


### PR DESCRIPTION
When creating multiple `openstack_networking_router_interface_v2`
resources for different IPv6 subnets in the same network, openstack will
attach these to the same port on the router.

On destroy the current implementation will pass the `port_id` to
`routers.RemoveInterface`, which will trigger the deletion of the whole
port, including other `openstack_networking_router_interface_v2` resources
on the same port.

This commit changes this behaviour (so that only the correct router interface
gets deleted) and adds a test case that ensures this does not break
again in the future.

Note: We were affected by this bug. In our case we deleted an `openstack_networking_router_interface_v2` via `terraform destroy -target …`, but terraform-provider-openstack silently deleted the whole port including another, important `openstack_networking_router_interface_v2` resource which was crucial for our production setup.