### PR TITLE
Retry reading DNS zone and Compute instance state after creation

### DIFF
--- a/openstack/util.go
+++ b/openstack/util.go
@@ -71,13 +71,19 @@ func MapValueSpecs(d *schema.ResourceData) map[string]string {
 }
 
 func checkForRetryableError(err error) *resource.RetryError {
-	switch err.(type) {
+	switch e := err.(type) {
 	case gophercloud.ErrDefault500:
 		return resource.RetryableError(err)
 	case gophercloud.ErrDefault409:
 		return resource.RetryableError(err)
 	case gophercloud.ErrDefault503:
 		return resource.RetryableError(err)
+	case gophercloud.ErrUnexpectedResponseCode:
+		if e.GetStatusCode() == 504 || e.GetStatusCode() == 502 {
+			return resource.RetryableError(err)
+		} else {
+			return resource.NonRetryableError(err)
+		}
 	default:
 		return resource.NonRetryableError(err)
 	}


### PR DESCRIPTION
We had some issues with our cloud which buckled under a high load, which resulted in a bunch of 504 errors.

Provider didn't handle the errors during async operations with DNS zones and Compute instances, which resulted in mismatched states when cloud resources were actually created, but didn't go into ACTIVE state before an intermittent API error.

This change let's the provider keep refreshing the state through 502 and 504 errors, to prevent missing resources in state, that are already present on the cloud.