### PR TITLE
Flag tempurl url attribute as sensitive

### DIFF
--- a/openstack/resource_openstack_objectstorage_tempurl_v1.go
+++ b/openstack/resource_openstack_objectstorage_tempurl_v1.go
@@ -78,6 +78,7 @@ func resourceObjectstorageTempurlV1() *schema.Resource {
 			"url": {
 				Type:     schema.TypeString,
 				Computed: true,
+				Sensitive: true,
 			},
 		},
 	}

--- a/openstack/resource_openstack_objectstorage_tempurl_v1.go
+++ b/openstack/resource_openstack_objectstorage_tempurl_v1.go
@@ -76,8 +76,8 @@ func resourceObjectstorageTempurlV1() *schema.Resource {
 			},
 
 			"url": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
 				Sensitive: true,
 			},
 		},


### PR DESCRIPTION
Tempurl URL shouldn't be visible in plaintext by default.

URL should be known only by those who received it explicit rather than everyone with ability to see terraform plan.
Tempurl might point to object with sensitive content.

`nonsensitive()` function can be used in case someone prefer display tempurl in plaintext in terraform plan/output.