### PR TITLE
ComputeV2: add "device_name" field

### DIFF
--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -280,6 +280,11 @@ func resourceComputeInstanceV2() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 						},
+						"device_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
 						"disk_bus": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -1178,6 +1183,7 @@ func resourceOpenStackComputeInstanceV2ImportState(ctx context.Context, d *schem
 					"disk_bus":              "",
 					"volume_type":           "",
 					"device_type":           "",
+					"device_name":           "",
 				}
 
 				if volMetaData.Bootable == "true" {
@@ -1213,6 +1219,7 @@ func resourceOpenStackComputeInstanceV2ImportState(ctx context.Context, d *schem
 					"disk_bus":              "",
 					"volume_type":           "",
 					"device_type":           "",
+					"device_name":           "",
 				}
 
 				if volMetaData.Bootable == "true" {
@@ -1281,6 +1288,7 @@ func resourceInstanceBlockDevicesV2(_ *schema.ResourceData, bds []interface{}) (
 			GuestFormat:         bdM["guest_format"].(string),
 			VolumeType:          bdM["volume_type"].(string),
 			DeviceType:          bdM["device_type"].(string),
+			DeviceName:          bdM["device_name"].(string),
 			DiskBus:             bdM["disk_bus"].(string),
 		}
 

--- a/openstack/resource_openstack_compute_instance_v2_test.go
+++ b/openstack/resource_openstack_compute_instance_v2_test.go
@@ -1225,6 +1225,7 @@ resource "openstack_compute_instance_v2" "instance_1" {
     boot_index = 0
 		delete_on_termination = true
 		device_type = "disk"
+		device_name = "/dev/sda"
 		disk_bus = "virtio"
   }
   block_device {
@@ -1234,6 +1235,7 @@ resource "openstack_compute_instance_v2" "instance_1" {
     boot_index = 1
 		delete_on_termination = true
 		device_type = "disk"
+		device_name = "/dev/sdb"
 		disk_bus = "virtio"
   }
   network {

--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -475,6 +475,9 @@ The `block_device` block supports:
 * `device_type` - (Optional) The low-level device type that will be used. Most
     common thing is to leave this empty. Changing this creates a new server.
 
+* `device_name` - (Optional) The low-level device name that will be used. Most
+    common thing is to leave this empty. Changing this creates a new server.
+
 * `disk_bus` - (Optional) The low-level disk bus that will be used. Most common
     thing is to leave this empty. Changing this creates a new server.
 


### PR DESCRIPTION
Add "device_name" field into the "block_device"
attribute of the Compute V2 Instance resource.