### PR TITLE
Bump Gophercloud

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/terraform-provider-openstack/terraform-provider-openstack
 go 1.17
 
 require (
-	github.com/gophercloud/gophercloud v0.17.1-0.20210517213536-0be823b69be8
-	github.com/gophercloud/utils v0.0.0-20210216074907-f6de111f2eae
+	github.com/gophercloud/gophercloud v0.23.0
+	github.com/gophercloud/utils v0.0.0-20210909165623-d7085207ff6d
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -154,11 +154,11 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
-github.com/gophercloud/gophercloud v0.15.1-0.20210202035223-633d73521055/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075O6i+LY+pXsKCBsb4=
-github.com/gophercloud/gophercloud v0.17.1-0.20210517213536-0be823b69be8 h1:E842tot70u3PP3V+GVs1wL04PHKE4ERoijACgQiIwdA=
-github.com/gophercloud/gophercloud v0.17.1-0.20210517213536-0be823b69be8/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075O6i+LY+pXsKCBsb4=
-github.com/gophercloud/utils v0.0.0-20210216074907-f6de111f2eae h1:Hi3IgB9RQDE15Kfovd8MTZrcana+UlQqNbOif8dLpA0=
-github.com/gophercloud/utils v0.0.0-20210216074907-f6de111f2eae/go.mod h1:wx8HMD8oQD0Ryhz6+6ykq75PJ79iPyEqYHfwZ4l7OsA=
+github.com/gophercloud/gophercloud v0.20.0/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075O6i+LY+pXsKCBsb4=
+github.com/gophercloud/gophercloud v0.23.0 h1:I3P10oKlGu3DHP9PrEWMr1ya+/+3Rc9uRHNkRZ9wO7g=
+github.com/gophercloud/gophercloud v0.23.0/go.mod h1:MRw6uyLj8uCGbIvBlqL7QW67t0QtNZnzydUzewo1Ioc=
+github.com/gophercloud/utils v0.0.0-20210909165623-d7085207ff6d h1:0Wsi5dvUuPF6dVn/CNfEA4xLxmaEtOt7tV2HD16xIf8=
+github.com/gophercloud/utils v0.0.0-20210909165623-d7085207ff6d/go.mod h1:qOGlfG6OIJ193/c3Xt/XjOfHataNZdQcVgiu93LxBUM=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=

--- a/openstack/data_source_openstack_compute_hypervisor_v2.go
+++ b/openstack/data_source_openstack_compute_hypervisor_v2.go
@@ -64,7 +64,7 @@ func dataSourceComputeHypervisorV2Read(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf("Error creating OpenStack compute client: %s", err)
 	}
 
-	allPages, err := hypervisors.List(computeClient).AllPages()
+	allPages, err := hypervisors.List(computeClient, hypervisors.ListOpts{}).AllPages()
 	if err != nil {
 		return diag.Errorf("Error listing compute hypervisors: %s", err)
 	}

--- a/openstack/data_source_openstack_compute_keypair_v2.go
+++ b/openstack/data_source_openstack_compute_keypair_v2.go
@@ -48,7 +48,7 @@ func dataSourceComputeKeypairV2Read(ctx context.Context, d *schema.ResourceData,
 	}
 
 	name := d.Get("name").(string)
-	kp, err := keypairs.Get(computeClient, name).Extract()
+	kp, err := keypairs.Get(computeClient, name, keypairs.GetOpts{}).Extract()
 	if err != nil {
 		return diag.Errorf("Error retrieving openstack_compute_keypair_v2 %s: %s", name, err)
 	}

--- a/openstack/resource_openstack_compute_keypair_v2.go
+++ b/openstack/resource_openstack_compute_keypair_v2.go
@@ -98,7 +98,7 @@ func resourceComputeKeypairV2Read(_ context.Context, d *schema.ResourceData, met
 		return diag.Errorf("Error creating OpenStack compute client: %s", err)
 	}
 
-	kp, err := keypairs.Get(computeClient, d.Id()).Extract()
+	kp, err := keypairs.Get(computeClient, d.Id(), keypairs.GetOpts{}).Extract()
 	if err != nil {
 		return diag.FromErr(CheckDeleted(d, err, "Error retrieving openstack_compute_keypair_v2"))
 	}
@@ -120,7 +120,7 @@ func resourceComputeKeypairV2Delete(_ context.Context, d *schema.ResourceData, m
 		return diag.Errorf("Error creating OpenStack compute client: %s", err)
 	}
 
-	err = keypairs.Delete(computeClient, d.Id()).ExtractErr()
+	err = keypairs.Delete(computeClient, d.Id(), keypairs.DeleteOpts{}).ExtractErr()
 	if err != nil {
 		return diag.FromErr(CheckDeleted(d, err, "Error deleting openstack_compute_keypair_v2"))
 	}

--- a/openstack/resource_openstack_compute_keypair_v2_test.go
+++ b/openstack/resource_openstack_compute_keypair_v2_test.go
@@ -72,7 +72,7 @@ func testAccCheckComputeV2KeypairDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := keypairs.Get(computeClient, rs.Primary.ID).Extract()
+		_, err := keypairs.Get(computeClient, rs.Primary.ID, keypairs.GetOpts{}).Extract()
 		if err == nil {
 			return fmt.Errorf("Keypair still exists")
 		}
@@ -98,7 +98,7 @@ func testAccCheckComputeV2KeypairExists(n string, kp *keypairs.KeyPair) resource
 			return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 		}
 
-		found, err := keypairs.Get(computeClient, rs.Primary.ID).Extract()
+		found, err := keypairs.Get(computeClient, rs.Primary.ID, keypairs.GetOpts{}).Extract()
 		if err != nil {
 			return err
 		}

--- a/openstack/resource_openstack_objectstorage_container_v1.go
+++ b/openstack/resource_openstack_objectstorage_container_v1.go
@@ -215,12 +215,18 @@ func resourceObjectStorageContainerV1Update(ctx context.Context, d *schema.Resou
 		return diag.Errorf("error creating OpenStack object storage client: %s", err)
 	}
 
+	containerRead := d.Get("container_read").(string)
+	containerSyncTo := d.Get("container_sync_to").(string)
+	containerSyncKey := d.Get("container_sync_key").(string)
+	containerWrite := d.Get("container_write").(string)
+	contentType := d.Get("content_type").(string)
+
 	updateOpts := containers.UpdateOpts{
-		ContainerRead:    d.Get("container_read").(string),
-		ContainerSyncTo:  d.Get("container_sync_to").(string),
-		ContainerSyncKey: d.Get("container_sync_key").(string),
-		ContainerWrite:   d.Get("container_write").(string),
-		ContentType:      d.Get("content_type").(string),
+		ContainerRead:    &containerRead,
+		ContainerSyncTo:  &containerSyncTo,
+		ContainerSyncKey: &containerSyncKey,
+		ContainerWrite:   &containerWrite,
+		ContentType:      &contentType,
 	}
 
 	if d.HasChange("versioning") {


### PR DESCRIPTION
Upgrade Gophercloud to [v0.23.0][1] and its `utils` library to the
latest version available.

This patch is supposed to pick up all the bugfixes introduced in the library since v0.17.1.

[1]: https://github.com/gophercloud/gophercloud/releases/tag/v0.23.0