### PR TITLE
Skip trunk and qos acceptance tests

### DIFF
--- a/openstack/data_source_openstack_networking_qos_bandwidth_limit_rule_v2_test.go
+++ b/openstack/data_source_openstack_networking_qos_bandwidth_limit_rule_v2_test.go
@@ -13,6 +13,7 @@ func TestAccNetworkingV2QoSBandwidthLimitRuleDataSource_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{

--- a/openstack/data_source_openstack_networking_qos_dscp_marking_rule_v2_test.go
+++ b/openstack/data_source_openstack_networking_qos_dscp_marking_rule_v2_test.go
@@ -13,6 +13,7 @@ func TestAccNetworkingV2QoSDSCPMarkingRuleDataSource_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{

--- a/openstack/data_source_openstack_networking_qos_minimum_bandwidth_rule_v2_test.go
+++ b/openstack/data_source_openstack_networking_qos_minimum_bandwidth_rule_v2_test.go
@@ -13,6 +13,7 @@ func TestAccNetworkingV2QoSMinimumBandwidthRuleDataSource_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{

--- a/openstack/data_source_openstack_networking_qos_policy_v2_test.go
+++ b/openstack/data_source_openstack_networking_qos_policy_v2_test.go
@@ -13,6 +13,7 @@ func TestAccNetworkingV2QoSPolicyDataSource_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
@@ -38,6 +39,7 @@ func TestAccNetworkingV2QoSPolicyDataSource_description(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{

--- a/openstack/data_source_openstack_networking_trunk_v2_test.go
+++ b/openstack/data_source_openstack_networking_trunk_v2_test.go
@@ -12,6 +12,7 @@ func TestAccNetworkingV2TrunkDataSource_nosubports(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2TrunkDestroy,
@@ -39,6 +40,7 @@ func TestAccNetworkingV2TrunkDataSource_subports(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2TrunkDestroy,
@@ -68,6 +70,7 @@ func TestAccNetworkingV2TrunkDataSource_tags(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2TrunkDestroy,

--- a/openstack/import_openstack_networking_qos_bandwidth_limit_rule_v2_test.go
+++ b/openstack/import_openstack_networking_qos_bandwidth_limit_rule_v2_test.go
@@ -13,6 +13,7 @@ func TestAccNetworkingV2QoSBandwidthLimitRule_importBasic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2QoSBandwidthLimitRuleDestroy,

--- a/openstack/import_openstack_networking_qos_dscp_marking_rule_v2_test.go
+++ b/openstack/import_openstack_networking_qos_dscp_marking_rule_v2_test.go
@@ -13,6 +13,7 @@ func TestAccNetworkingV2QoSDSCPMarkingRule_importBasic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2QoSDSCPMarkingRuleDestroy,

--- a/openstack/import_openstack_networking_qos_policy_v2_test.go
+++ b/openstack/import_openstack_networking_qos_policy_v2_test.go
@@ -13,6 +13,7 @@ func TestAccNetworkingV2QoSPolicyImportBasic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2QoSPolicyDestroy,

--- a/openstack/resource_openstack_networking_network_v2_test.go
+++ b/openstack/resource_openstack_networking_network_v2_test.go
@@ -461,6 +461,7 @@ func TestAccNetworkingV2Network_qos_policy_create(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2NetworkDestroy,
@@ -490,6 +491,7 @@ func TestAccNetworkingV2Network_qos_policy_update(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2NetworkDestroy,

--- a/openstack/resource_openstack_networking_port_v2_test.go
+++ b/openstack/resource_openstack_networking_port_v2_test.go
@@ -945,6 +945,7 @@ func TestAccNetworkingV2Port_qos_policy_create(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2PortDestroy,
@@ -974,6 +975,7 @@ func TestAccNetworkingV2Port_qos_policy_update(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2PortDestroy,

--- a/openstack/resource_openstack_networking_qos_bandwidth_limit_rule_v2_test.go
+++ b/openstack/resource_openstack_networking_qos_bandwidth_limit_rule_v2_test.go
@@ -21,6 +21,7 @@ func TestAccNetworkingV2QoSBandwidthLimitRule_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2QoSBandwidthLimitRuleDestroy,

--- a/openstack/resource_openstack_networking_qos_dscp_marking_rule_v2_test.go
+++ b/openstack/resource_openstack_networking_qos_dscp_marking_rule_v2_test.go
@@ -21,6 +21,7 @@ func TestAccNetworkingV2QoSDSCPMarkingRule_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2QoSDSCPMarkingRuleDestroy,

--- a/openstack/resource_openstack_networking_qos_minimum_bandwidth_rule_v2_test.go
+++ b/openstack/resource_openstack_networking_qos_minimum_bandwidth_rule_v2_test.go
@@ -21,6 +21,7 @@ func TestAccNetworkingV2QoSMinimumBandwidthRule_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2QoSMinimumBandwidthRuleDestroy,

--- a/openstack/resource_openstack_networking_qos_policy_v2_test.go
+++ b/openstack/resource_openstack_networking_qos_policy_v2_test.go
@@ -17,6 +17,7 @@ func TestAccNetworkingV2QoSPolicyBasic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2QoSPolicyDestroy,

--- a/openstack/resource_openstack_networking_trunk_v2_test.go
+++ b/openstack/resource_openstack_networking_trunk_v2_test.go
@@ -20,6 +20,7 @@ func TestAccNetworkingV2Trunk_nosubports(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2TrunkDestroy,
@@ -47,6 +48,7 @@ func TestAccNetworkingV2Trunk_subports(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2TrunkDestroy,
@@ -72,6 +74,7 @@ func TestAccNetworkingV2Trunk_tags(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2TrunkDestroy,
@@ -204,6 +207,7 @@ func TestAccNetworkingV2Trunk_computeInstance(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
+			t.Skip("Currently failing in Openlab")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckComputeV2InstanceDestroy,


### PR DESCRIPTION
Qos and Trunk related accecptance tests are failing currently on
Openlab. Skip them for the time being

Relates to: #1323 