### PR TITLE
Octavia by default as Neutron LBAAS is deprecated

### DIFF
--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -201,7 +201,7 @@ func Provider() *schema.Provider {
 			"use_octavia": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_USE_OCTAVIA", false),
+				DefaultFunc: schema.EnvDefaultFunc("OS_USE_OCTAVIA", true),
 				Description: descriptions["use_octavia"],
 			},
 


### PR DESCRIPTION
The Neutron LBAAS is deprecated :
https://wiki.openstack.org/wiki/Neutron/LBaaS/Deprecation
It has been replaced by Octavia, so set Octavia to the default one

This can be confusing since the error returned by the provider is not
very clear even if you put the provider in TRACE ( it will try to
contact neutron for creation the loadbalancer )