### PR TITLE
Remove `ForceNew` from network segments

### DIFF
--- a/openstack/resource_openstack_networking_network_v2.go
+++ b/openstack/resource_openstack_networking_network_v2.go
@@ -89,26 +89,22 @@ func resourceNetworkingNetworkV2() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"physical_network": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
-							ForceNew: true,
 						},
 						"network_type": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
-							ForceNew: true,
 						},
 						"segmentation_id": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
-							ForceNew: true,
 						},
 					},
 				},


### PR DESCRIPTION
Use the same logic as in `physical_network`, `network_type`,
`segmentation_id` arguments.