### PR TITLE
Properties of image are not returned

### DIFF
--- a/openstack/data_source_openstack_images_image_v2.go
+++ b/openstack/data_source_openstack_images_image_v2.go
@@ -283,6 +283,11 @@ func dataSourceImagesImageV2Read(ctx context.Context, d *schema.ResourceData, me
 	d.Set("schema", image.Schema)
 	d.Set("hidden", image.Hidden)
 
+	properties = resourceImagesImageV2ExpandProperties(image.Properties)
+	if err := d.Set("properties", properties); err != nil {
+		log.Printf("[WARN] unable to set properties for image %s: %s", image.ID, err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Currently when you fetch the image information using `openstack_images_image_v2`, the properties field is empty.

The goal of this PR is to resolve this issue.