### PR TITLE
fix: networking quota region option

### DIFF
--- a/openstack/data_source_openstack_networking_quota_v2.go
+++ b/openstack/data_source_openstack_networking_quota_v2.go
@@ -14,10 +14,11 @@ import (
 func dataSourceNetworkingQuotaV2() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceNetworkingQuotaV2Read,
+
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type: schema.TypeString,
-
+				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
 				ForceNew: true,
 			},
@@ -96,7 +97,7 @@ func dataSourceNetworkingQuotaV2Read(ctx context.Context, d *schema.ResourceData
 	id := fmt.Sprintf("%s/%s", projectID, region)
 	d.SetId(id)
 	d.Set("project_id", projectID)
-	d.Set("region", region)
+	d.Set("region", GetRegion(d, config))
 	d.Set("floatingip", q.FloatingIP)
 	d.Set("network", q.Network)
 	d.Set("port", q.Port)


### PR DESCRIPTION
According documentation the ```region``` parameter can be optional:

But I've got an error in this case:

```
data "openstack_networking_quota_v2" "quota" {
  region     = "MyRegion"
  project_id = "2e367a3d29f94fd988e6ec54e305ec9d"
}
```