### PR TITLE
Fix segfault on invalid CIDR

### DIFF
--- a/openstack/resource_openstack_networking_subnet_v2.go
+++ b/openstack/resource_openstack_networking_subnet_v2.go
@@ -270,7 +270,10 @@ func resourceNetworkingSubnetV2Create(ctx context.Context, d *schema.ResourceDat
 	// Set CIDR if provided. Check if inferred subnet would match the provided cidr.
 	if v, ok := d.GetOk("cidr"); ok {
 		cidr := v.(string)
-		_, netAddr, _ := net.ParseCIDR(cidr)
+		_, netAddr, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return diag.Errorf("Invalid CIDR %s: %s", cidr, err)
+		}
 		if netAddr.String() != cidr {
 			return diag.Errorf("cidr %s doesn't match subnet address %s for openstack_networking_subnet_v2", cidr, netAddr.String())
 		}


### PR DESCRIPTION
If an invalid CIDR is passed to the subnet resource, for instance
because of a leading space, the plugin will crash:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x5b9aa0]

goroutine 101 [running]:
net.networkNumberAndMask(0x20)
        net/ip.go:498
net.(*IPNet).String(0xc00069ed38)
        net/ip.go:548 +0x2b
github.com/terraform-provider-openstack/terraform-provider-openstack/openstack.resourceNetworkingSubnetV2Create({0x10858e8, 0xc000428ea0}, 0xc00061f6c0, {0xef1fa0, 0xc0006a6b40})
        github.com/terraform-provider-openstack/terraform-provider-openstack/openstack/resource_openstack_networking_subnet_v2.go:274 +0x795
[…]
```

By handling the error and returning it, the crash is avoided and a
proper error message can be displayed by terraform.