### PR TITLE
Add servergroup policy and rules field support

### DIFF
--- a/openstack/compute_servergroup_v2.go
+++ b/openstack/compute_servergroup_v2.go
@@ -39,3 +39,19 @@ func expandComputeServerGroupV2Policies(client *gophercloud.ServiceClient, raw [
 
 	return policies
 }
+
+func expandComputeServerGroupV2RulesMaxServerPerHost(raw []interface{}) int {
+	for _, raw := range raw {
+		raw, ok := raw.(map[string]interface{})
+		if !ok {
+			return 0
+		}
+		v, ok := raw["max_server_per_host"].(int)
+		if !ok {
+			return 0
+		}
+		//nolint:staticcheck // we need the first element
+		return v
+	}
+	return 0
+}

--- a/openstack/resource_openstack_compute_servergroup_v2.go
+++ b/openstack/resource_openstack_compute_servergroup_v2.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
 )
@@ -41,6 +42,32 @@ func resourceComputeServerGroupV2() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
+			"policy": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"policies"},
+			},
+
+			"rules": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"policies"},
+				MinItems:      1,
+				MaxItems:      1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"max_server_per_host": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.IntAtLeast(1),
+						},
+					},
+				},
+			},
+
 			"members": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -68,12 +95,50 @@ func resourceComputeServerGroupV2Create(ctx context.Context, d *schema.ResourceD
 	rawPolicies := d.Get("policies").([]interface{})
 	policies := expandComputeServerGroupV2Policies(computeClient, rawPolicies)
 
-	createOpts := ComputeServerGroupV2CreateOpts{
-		servergroups.CreateOpts{
-			Name:     name,
-			Policies: policies,
-		},
-		MapValueSpecs(d),
+	policy := d.Get("policy").(string)
+	rulesVal, rulesPresent := d.GetOk("rules")
+
+	var createOpts ComputeServerGroupV2CreateOpts
+
+	// "policies" is replaced with "policy" and optional "rules" since microversion 2.64
+	if policy == "" {
+		createOpts = ComputeServerGroupV2CreateOpts{
+			servergroups.CreateOpts{
+				Name:     name,
+				Policies: policies,
+			},
+			MapValueSpecs(d),
+		}
+	} else {
+		computeClient.Microversion = "2.64"
+
+		if policy == "anti-affinity" && rulesPresent {
+			rules := rulesVal.([]map[string]interface{})
+
+			var MaxServerPerHost int
+			if v, ok := rules[0]["max_server_per_host"]; ok {
+				MaxServerPerHost = v.(int)
+			}
+
+			createOpts = ComputeServerGroupV2CreateOpts{
+				servergroups.CreateOpts{
+					Name:   name,
+					Policy: policy,
+					Rules: &servergroups.Rules{
+						MaxServerPerHost: MaxServerPerHost,
+					},
+				},
+				MapValueSpecs(d),
+			}
+		} else {
+			createOpts = ComputeServerGroupV2CreateOpts{
+				servergroups.CreateOpts{
+					Name:   name,
+					Policy: policy,
+				},
+				MapValueSpecs(d),
+			}
+		}
 	}
 
 	log.Printf("[DEBUG] openstack_compute_servergroup_v2 create options: %#v", createOpts)
@@ -94,18 +159,39 @@ func resourceComputeServerGroupV2Read(_ context.Context, d *schema.ResourceData,
 		return diag.Errorf("Error creating OpenStack compute client: %s", err)
 	}
 
+	// Attempt to read with unset microversion
+	computeClient.Microversion = ""
+
 	sg, err := servergroups.Get(computeClient, d.Id()).Extract()
+	if err == nil {
+		log.Printf("[DEBUG] Retrieved openstack_compute_servergroup_v2 %s: %#v", d.Id(), sg)
+
+		d.Set("name", sg.Name)
+		d.Set("members", sg.Members)
+		d.Set("region", GetRegion(d, config))
+		d.Set("policies", sg.Policies)
+
+		return nil
+	}
+
+	// Attempt to read with microversion 2.64
+	computeClient.Microversion = "2.64"
+
+	sg, err = servergroups.Get(computeClient, d.Id()).Extract()
 	if err != nil {
 		return diag.FromErr(CheckDeleted(d, err, "Error retrieving openstack_compute_servergroup_v2"))
 	}
-
 	log.Printf("[DEBUG] Retrieved openstack_compute_servergroup_v2 %s: %#v", d.Id(), sg)
 
 	d.Set("name", sg.Name)
-	d.Set("policies", sg.Policies)
 	d.Set("members", sg.Members)
-
 	d.Set("region", GetRegion(d, config))
+	d.Set("policy", sg.Policy)
+
+	rules := make(map[string]interface{})
+	rules["max_server_per_host"] = sg.Rules.MaxServerPerHost
+	rulesList := []map[string]interface{}{rules}
+	d.Set("rules", rulesList)
 
 	return nil
 }

--- a/openstack/resource_openstack_compute_servergroup_v2.go
+++ b/openstack/resource_openstack_compute_servergroup_v2.go
@@ -113,19 +113,13 @@ func resourceComputeServerGroupV2Create(ctx context.Context, d *schema.ResourceD
 		computeClient.Microversion = "2.64"
 
 		if policy == "anti-affinity" && rulesPresent {
-			rules := rulesVal.([]map[string]interface{})
-
-			var MaxServerPerHost int
-			if v, ok := rules[0]["max_server_per_host"]; ok {
-				MaxServerPerHost = v.(int)
-			}
-
+			maxServerPerHost := expandComputeServerGroupV2RulesMaxServerPerHost(rulesVal.([]interface{}))
 			createOpts = ComputeServerGroupV2CreateOpts{
 				servergroups.CreateOpts{
 					Name:   name,
 					Policy: policy,
 					Rules: &servergroups.Rules{
-						MaxServerPerHost: MaxServerPerHost,
+						MaxServerPerHost: maxServerPerHost,
 					},
 				},
 				MapValueSpecs(d),

--- a/openstack/resource_openstack_compute_servergroup_v2_test.go
+++ b/openstack/resource_openstack_compute_servergroup_v2_test.go
@@ -53,7 +53,7 @@ func TestAccComputeV2ServerGroup_basic_v2_64(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2ServerGroupExists("openstack_compute_servergroup_v2.sg_1", &sg),
 					resource.TestCheckResourceAttr(
-						"openstack_compute_servergroup_v2.sg_1", "policy", "affinity"),
+						"openstack_compute_servergroup_v2.sg_1", "policies.0", "affinity"),
 				),
 			},
 		},
@@ -76,7 +76,7 @@ func TestAccComputeV2ServerGroup_v2_64_anti_affinity(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2ServerGroupExists("openstack_compute_servergroup_v2.sg_1", &sg),
 					resource.TestCheckResourceAttr(
-						"openstack_compute_servergroup_v2.sg_1", "policy", "anti-affinity"),
+						"openstack_compute_servergroup_v2.sg_1", "policies.0", "anti-affinity"),
 				),
 			},
 		},
@@ -99,9 +99,9 @@ func TestAccComputeV2ServerGroup_v2_64_with_rules(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2ServerGroupExists("openstack_compute_servergroup_v2.sg_1", &sg),
 					resource.TestCheckResourceAttr(
-						"openstack_compute_servergroup_v2.sg_1", "policy", "anti-affinity"),
+						"openstack_compute_servergroup_v2.sg_1", "policies.0", "anti-affinity"),
 					resource.TestCheckResourceAttr(
-						"openstack_compute_servergroup_v2.sg_1", "rules.max_server_per_host", "2"),
+						"openstack_compute_servergroup_v2.sg_1", "rules.0.max_server_per_host", "2"),
 				),
 			},
 		},
@@ -119,7 +119,7 @@ func TestAccComputeV2ServerGroup_v2_64_with_invalid_rules(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccComputeV2ServerGroupV264InvalidPolicyRules,
-				ExpectError: regexp.MustCompile(`expected max_server_per_host to be at least 1, got .*`),
+				ExpectError: regexp.MustCompile(`expected rules\.0\.max_server_per_host to be at least \(1\), got .*`),
 			},
 		},
 	})
@@ -172,7 +172,7 @@ func TestAccComputeV2ServerGroup_affinity_v2_64(t *testing.T) {
 					testAccCheckComputeV2InstanceExists("openstack_compute_instance_v2.instance_1", &instance),
 					testAccCheckComputeV2InstanceInServerGroup(&instance, &sg),
 					resource.TestCheckResourceAttr(
-						"openstack_compute_servergroup_v2.sg_1", "policy", "affinity"),
+						"openstack_compute_servergroup_v2.sg_1", "policies.0", "affinity"),
 				),
 			},
 		},
@@ -284,21 +284,21 @@ resource "openstack_compute_servergroup_v2" "sg_1" {
 const testAccComputeV2ServerGroupV264Policy = `
 resource "openstack_compute_servergroup_v2" "sg_1" {
   name = "sg_1"
-  policy = "affinity"
+  policies = ["affinity"]
 }
 `
 
 const testAccComputeV2ServerGroupV264PolicyAntiAffinity = `
 resource "openstack_compute_servergroup_v2" "sg_1" {
   name = "sg_1"
-  policy = "anti-affinity"
+  policies = ["anti-affinity"]
 }
 `
 
 const testAccComputeV2ServerGroupV264PolicyRules = `
 resource "openstack_compute_servergroup_v2" "sg_1" {
   name = "sg_1"
-  policy = "anti-affinity"
+  policies = ["anti-affinity"]
   rules {
     max_server_per_host = 2
   }
@@ -308,7 +308,7 @@ resource "openstack_compute_servergroup_v2" "sg_1" {
 const testAccComputeV2ServerGroupV264InvalidPolicyRules = `
 resource "openstack_compute_servergroup_v2" "sg_1" {
   name = "sg_1"
-  policy = "anti-affinity"
+  policies = ["anti-affinity"]
   rules {
     max_server_per_host = -1
   }
@@ -359,7 +359,7 @@ func testAccComputeV2ServerGroupAffinityV264() string {
 	return fmt.Sprintf(`
 resource "openstack_compute_servergroup_v2" "sg_1" {
   name = "sg_1"
-  policy = "affinity"
+  policies = ["affinity"]
 }
 
 resource "openstack_compute_instance_v2" "instance_1" {

--- a/website/docs/r/compute_servergroup_v2.html.markdown
+++ b/website/docs/r/compute_servergroup_v2.html.markdown
@@ -12,10 +12,24 @@ Manages a V2 Server Group resource within OpenStack.
 
 ## Example Usage
 
+### Compute service API version 2.63 or below:
+
 ```hcl
 resource "openstack_compute_servergroup_v2" "test-sg" {
   name     = "my-sg"
   policies = ["anti-affinity"]
+}
+```
+
+### Compute service API version 2.64 or above:
+
+```hcl
+resource "openstack_compute_servergroup_v2" "test-sg" {
+  name     = "my-sg"
+  policy   = "anti-affinity"
+  rules {
+      max_server_per_host = 3
+  }
 }
 ```
 
@@ -30,11 +44,19 @@ The following arguments are supported:
 * `name` - (Required) A unique name for the server group. Changing this creates
     a new server group.
 
-* `policies` - (Required) The set of policies for the server group. All policies
+* `policies` - (Optional) The set of policies for the server group. All policies
     are mutually exclusive. See the Policies section for more information.
-    Changing this creates a new server group.
+    Changing this creates a new server group. This field should only be used
+    with Compute service API 2.63 or below.
 
 * `value_specs` - (Optional) Map of additional options.
+
+* `policy` - (Optional) The policy to be applied to the server group. This argument
+    replaces the `policies` argument (the `policies` and `policy` fields are mutually 
+    exclusive), and should only be used with Compute service API 2.64 or above.
+
+* `rules` - (Optional) The rules which are applied to specified `policy`. Currently, 
+    only the `max_server_per_host` rule is supported for the `anti-affinity` policy.
 
 ## Policies
 
@@ -62,6 +84,8 @@ The following attributes are exported:
 * `name` - See Argument Reference above.
 * `policies` - See Argument Reference above.
 * `members` - The instances that are part of this server group.
+* `policy` - See Argument Reference above.
+* `rules` - See Argument Reference above.
 
 ## Import
 

--- a/website/docs/r/compute_servergroup_v2.html.markdown
+++ b/website/docs/r/compute_servergroup_v2.html.markdown
@@ -26,7 +26,7 @@ resource "openstack_compute_servergroup_v2" "test-sg" {
 ```hcl
 resource "openstack_compute_servergroup_v2" "test-sg" {
   name     = "my-sg"
-  policy   = "anti-affinity"
+  policies = ["anti-affinity"]
   rules {
       max_server_per_host = 3
   }
@@ -38,25 +38,20 @@ resource "openstack_compute_servergroup_v2" "test-sg" {
 The following arguments are supported:
 
 * `region` - (Optional) The region in which to obtain the V2 Compute client.
-    If omitted, the `region` argument of the provider is used. Changing
-    this creates a new server group.
+  If omitted, the `region` argument of the provider is used. Changing
+  this creates a new server group.
 
 * `name` - (Required) A unique name for the server group. Changing this creates
-    a new server group.
+  a new server group.
 
-* `policies` - (Optional) The set of policies for the server group. All policies
-    are mutually exclusive. See the Policies section for more information.
-    Changing this creates a new server group. This field should only be used
-    with Compute service API 2.63 or below.
+* `policies` - (Optional) A list of exactly one policy name to associate with
+  the server group. See the Policies section for more information. Changing this
+  creates a new server group.
 
 * `value_specs` - (Optional) Map of additional options.
 
-* `policy` - (Optional) The policy to be applied to the server group. This argument
-    replaces the `policies` argument (the `policies` and `policy` fields are mutually 
-    exclusive), and should only be used with Compute service API 2.64 or above.
-
-* `rules` - (Optional) The rules which are applied to specified `policy`. Currently, 
-    only the `max_server_per_host` rule is supported for the `anti-affinity` policy.
+* `rules` - (Optional) The rules which are applied to specified `policy`. Currently,
+  only the `max_server_per_host` rule is supported for the `anti-affinity` policy.
 
 ## Policies
 
@@ -84,7 +79,6 @@ The following attributes are exported:
 * `name` - See Argument Reference above.
 * `policies` - See Argument Reference above.
 * `members` - The instances that are part of this server group.
-* `policy` - See Argument Reference above.
 * `rules` - See Argument Reference above.
 
 ## Import


### PR DESCRIPTION
Should resolve #1143. 

Addition of `policy` and `rules` fields, which replace the `policies` field since API microversion 2.64. Support for the fields has already been added to Gophercloud.