### PR TITLE
[GH-A] Add new workflow for networing

### DIFF
--- a/.github/workflows/functional-networking.yml
+++ b/.github/workflows/functional-networking.yml
@@ -1,0 +1,81 @@
+# Functional testing for networking
+name: functional-networking
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/functional-networking.yml'
+      - '**networking**'
+      - 'CHANGELOG.md'
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  functional-basic:
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ["master"]
+        openstack_version: ["master"]
+        ubuntu_version: ["20.04"]
+        devstack_conf_overrides: ["enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing master"]
+        include:
+          - name: "yoga"
+            openstack_version: "stable/yoga"
+            ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/yoga
+          - name: "xena"
+            openstack_version: "stable/xena"
+            ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/xena
+          - name: "wallaby"
+            openstack_version: "stable/wallaby"
+            ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/wallaby
+          - name: "victoria"
+            openstack_version: "stable/victoria"
+            ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/victoria
+          - name: "ussuri"
+            openstack_version: "stable/ussuri"
+            ubuntu_version: "18.04"
+            devstack_conf_overrides: |
+              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/ussuri
+          - name: "train"
+            openstack_version: "stable/train"
+            ubuntu_version: "18.04"
+            devstack_conf_overrides: |
+              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing train-eol
+    runs-on: ubuntu-${{ matrix.ubuntu_version }}
+    name: networking on OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests
+    steps:
+      - name: Checkout TPO
+        uses: actions/checkout@v3
+      - name: Deploy devstack
+        uses: EmilienM/devstack-action@v0.7
+        with:
+          branch: ${{ matrix.openstack_version }}
+          conf_overrides: |
+            Q_ML2_PLUGIN_EXT_DRIVERS=qos,port_security,dns_domain_keywords
+            ${{ matrix.devstack_conf_overrides }}
+          enabled_services: 'neutron-dhcp,neutron-dns,neutron-qos,neutron-segments,neutron-trunk,neutron-uplink-status-propagation,neutron-network-segment-range,neutron-port-forwarding'
+      - name: Checkout go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '^1.17'
+      - name: Run TPO acceptance tests
+        run: ./scripts/acceptancetest.sh
+        env:
+          DEVSTACK_PATH: ${{ github.workspace }}/devstack
+          ACCEPTANCE_TESTS_FILTER: 'networking'
+      - name: Generate logs on failure
+        run: ./scripts/collectlogs.sh
+        if: failure()
+      - name: Upload logs artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: functional-basic-${{ matrix.name }}
+          path: /tmp/devstack-logs/*

--- a/openstack/data_source_openstack_fw_policy_v1_test.go
+++ b/openstack/data_source_openstack_fw_policy_v1_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccOpenStackNetworkingFWPolicyV1DataSource_basic(t *testing.T) {
+func TestAccFirewallPolicyV1DataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -17,12 +17,12 @@ func TestAccOpenStackNetworkingFWPolicyV1DataSource_basic(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOpenStackNetworkingFWPolicyV1DataSourceGroup,
+				Config: testAccFirewallPolicyV1DataSourceGroup,
 			},
 			{
-				Config: testAccOpenStackNetworkingFWPolicyV1DataSourceBasic(),
+				Config: testAccFirewallPolicyV1DataSourceBasic(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingFWPolicyV1DataSourceID("data.openstack_fw_policy_v1.policy_1"),
+					testAccCheckFirewallPolicyV1DataSourceID("data.openstack_fw_policy_v1.policy_1"),
 					resource.TestCheckResourceAttr(
 						"data.openstack_fw_policy_v1.policy_1", "name", "policy_1"),
 				),
@@ -30,7 +30,7 @@ func TestAccOpenStackNetworkingFWPolicyV1DataSource_basic(t *testing.T) {
 		},
 	})
 }
-func TestAccOpenStackNetworkingFWPolicyV1DataSource_FWPolicyID(t *testing.T) {
+func TestAccFirewallPolicyV1DataSource_FWPolicyID(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -39,12 +39,12 @@ func TestAccOpenStackNetworkingFWPolicyV1DataSource_FWPolicyID(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOpenStackNetworkingFWPolicyV1DataSourceGroup,
+				Config: testAccFirewallPolicyV1DataSourceGroup,
 			},
 			{
-				Config: testAccOpenStackNetworkingFWPolicyV1DataSourcePolicyID(),
+				Config: testAccFirewallPolicyV1DataSourcePolicyID(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingFWPolicyV1DataSourceID("data.openstack_fw_policy_v1.policy_1"),
+					testAccCheckFirewallPolicyV1DataSourceID("data.openstack_fw_policy_v1.policy_1"),
 					resource.TestCheckResourceAttr(
 						"data.openstack_fw_policy_v1.policy_1", "name", "policy_1"),
 				),
@@ -53,7 +53,7 @@ func TestAccOpenStackNetworkingFWPolicyV1DataSource_FWPolicyID(t *testing.T) {
 	})
 }
 
-func testAccCheckNetworkingFWPolicyV1DataSourceID(n string) resource.TestCheckFunc {
+func testAccCheckFirewallPolicyV1DataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -68,29 +68,29 @@ func testAccCheckNetworkingFWPolicyV1DataSourceID(n string) resource.TestCheckFu
 	}
 }
 
-const testAccOpenStackNetworkingFWPolicyV1DataSourceGroup = `
+const testAccFirewallPolicyV1DataSourceGroup = `
 resource "openstack_fw_policy_v1" "policy_1" {
-        name        = "policy_1"
+    name        = "policy_1"
 	description = "My firewall policy"
 }
 `
 
-func testAccOpenStackNetworkingFWPolicyV1DataSourceBasic() string {
+func testAccFirewallPolicyV1DataSourceBasic() string {
 	return fmt.Sprintf(`
 %s
 
 data "openstack_fw_policy_v1" "policy_1" {
 	name = "${openstack_fw_policy_v1.policy_1.name}"
 }
-`, testAccOpenStackNetworkingFWPolicyV1DataSourceGroup)
+`, testAccFirewallPolicyV1DataSourceGroup)
 }
 
-func testAccOpenStackNetworkingFWPolicyV1DataSourcePolicyID() string {
+func testAccFirewallPolicyV1DataSourcePolicyID() string {
 	return fmt.Sprintf(`
 %s
 
 data "openstack_fw_policy_v1" "policy_1" {
 	policy_id = "${openstack_fw_policy_v1.policy_1.id}"
 }
-`, testAccOpenStackNetworkingFWPolicyV1DataSourceGroup)
+`, testAccFirewallPolicyV1DataSourceGroup)
 }

--- a/openstack/data_source_openstack_networking_qos_bandwidth_limit_rule_v2_test.go
+++ b/openstack/data_source_openstack_networking_qos_bandwidth_limit_rule_v2_test.go
@@ -13,7 +13,7 @@ func TestAccNetworkingV2QoSBandwidthLimitRuleDataSource_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{

--- a/openstack/data_source_openstack_networking_qos_dscp_marking_rule_v2_test.go
+++ b/openstack/data_source_openstack_networking_qos_dscp_marking_rule_v2_test.go
@@ -13,7 +13,7 @@ func TestAccNetworkingV2QoSDSCPMarkingRuleDataSource_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{

--- a/openstack/data_source_openstack_networking_qos_minimum_bandwidth_rule_v2_test.go
+++ b/openstack/data_source_openstack_networking_qos_minimum_bandwidth_rule_v2_test.go
@@ -13,7 +13,7 @@ func TestAccNetworkingV2QoSMinimumBandwidthRuleDataSource_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{

--- a/openstack/data_source_openstack_networking_qos_policy_v2_test.go
+++ b/openstack/data_source_openstack_networking_qos_policy_v2_test.go
@@ -13,7 +13,7 @@ func TestAccNetworkingV2QoSPolicyDataSource_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
@@ -39,7 +39,7 @@ func TestAccNetworkingV2QoSPolicyDataSource_description(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{

--- a/openstack/data_source_openstack_networking_trunk_v2_test.go
+++ b/openstack/data_source_openstack_networking_trunk_v2_test.go
@@ -12,7 +12,7 @@ func TestAccNetworkingV2TrunkDataSource_nosubports(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2TrunkDestroy,
@@ -40,7 +40,7 @@ func TestAccNetworkingV2TrunkDataSource_subports(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2TrunkDestroy,
@@ -70,7 +70,7 @@ func TestAccNetworkingV2TrunkDataSource_tags(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2TrunkDestroy,

--- a/openstack/import_openstack_networking_qos_bandwidth_limit_rule_v2_test.go
+++ b/openstack/import_openstack_networking_qos_bandwidth_limit_rule_v2_test.go
@@ -13,7 +13,7 @@ func TestAccNetworkingV2QoSBandwidthLimitRule_importBasic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2QoSBandwidthLimitRuleDestroy,

--- a/openstack/import_openstack_networking_qos_dscp_marking_rule_v2_test.go
+++ b/openstack/import_openstack_networking_qos_dscp_marking_rule_v2_test.go
@@ -13,7 +13,7 @@ func TestAccNetworkingV2QoSDSCPMarkingRule_importBasic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2QoSDSCPMarkingRuleDestroy,

--- a/openstack/import_openstack_networking_qos_policy_v2_test.go
+++ b/openstack/import_openstack_networking_qos_policy_v2_test.go
@@ -13,7 +13,7 @@ func TestAccNetworkingV2QoSPolicyImportBasic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2QoSPolicyDestroy,

--- a/openstack/resource_openstack_networking_network_v2_test.go
+++ b/openstack/resource_openstack_networking_network_v2_test.go
@@ -141,6 +141,7 @@ func TestAccNetworkingV2Network_multipleSegmentMappings(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
+			t.Skip("Currently failing in GH-A: cant enable vxlan")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2NetworkDestroy,
@@ -461,7 +462,7 @@ func TestAccNetworkingV2Network_qos_policy_create(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2NetworkDestroy,
@@ -491,7 +492,7 @@ func TestAccNetworkingV2Network_qos_policy_update(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2NetworkDestroy,
@@ -730,7 +731,7 @@ resource "openstack_networking_network_v2" "network_1" {
   admin_state_up = "true"
 
   segments {
-    segmentation_id = 2
+	segmentation_id = 2
     network_type = "vxlan"
   }
 }

--- a/openstack/resource_openstack_networking_port_v2_test.go
+++ b/openstack/resource_openstack_networking_port_v2_test.go
@@ -594,8 +594,8 @@ func TestAccNetworkingV2Port_updateExtraDHCPOpts(t *testing.T) {
 					testAccCheckNetworkingV2SubnetExists("openstack_networking_subnet_v2.subnet_1", &subnet),
 					testAccCheckNetworkingV2NetworkExists("openstack_networking_network_v2.network_1", &network),
 					testAccCheckNetworkingV2PortExists("openstack_networking_port_v2.port_1", &port),
-					resource.TestCheckNoResourceAttr(
-						"openstack_networking_port_v2.port_1", "extra_dhcp_option"),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_port_v2.port_1", "extra_dhcp_option.#", "0"),
 				),
 			},
 		},
@@ -945,7 +945,7 @@ func TestAccNetworkingV2Port_qos_policy_create(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2PortDestroy,
@@ -975,7 +975,7 @@ func TestAccNetworkingV2Port_qos_policy_update(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2PortDestroy,

--- a/openstack/resource_openstack_networking_qos_bandwidth_limit_rule_v2_test.go
+++ b/openstack/resource_openstack_networking_qos_bandwidth_limit_rule_v2_test.go
@@ -21,7 +21,7 @@ func TestAccNetworkingV2QoSBandwidthLimitRule_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2QoSBandwidthLimitRuleDestroy,

--- a/openstack/resource_openstack_networking_qos_dscp_marking_rule_v2_test.go
+++ b/openstack/resource_openstack_networking_qos_dscp_marking_rule_v2_test.go
@@ -21,7 +21,7 @@ func TestAccNetworkingV2QoSDSCPMarkingRule_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2QoSDSCPMarkingRuleDestroy,

--- a/openstack/resource_openstack_networking_qos_minimum_bandwidth_rule_v2_test.go
+++ b/openstack/resource_openstack_networking_qos_minimum_bandwidth_rule_v2_test.go
@@ -21,7 +21,7 @@ func TestAccNetworkingV2QoSMinimumBandwidthRule_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2QoSMinimumBandwidthRuleDestroy,

--- a/openstack/resource_openstack_networking_qos_policy_v2_test.go
+++ b/openstack/resource_openstack_networking_qos_policy_v2_test.go
@@ -17,7 +17,7 @@ func TestAccNetworkingV2QoSPolicyBasic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2QoSPolicyDestroy,

--- a/openstack/resource_openstack_networking_router_v2_test.go
+++ b/openstack/resource_openstack_networking_router_v2_test.go
@@ -101,6 +101,7 @@ func TestAccNetworkingV2Router_vendor_opts_no_snat(t *testing.T) {
 			testAccPreCheck(t)
 			// (rule:create_router and rule:create_router:distributed) is disallowed by policy
 			testAccPreCheckAdminOnly(t)
+			t.Skip("Currently failing in GH-A: Cannot enable DVR + OVN on devstack")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2RouterDestroy,

--- a/openstack/resource_openstack_networking_trunk_v2_test.go
+++ b/openstack/resource_openstack_networking_trunk_v2_test.go
@@ -20,7 +20,7 @@ func TestAccNetworkingV2Trunk_nosubports(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2TrunkDestroy,
@@ -48,7 +48,7 @@ func TestAccNetworkingV2Trunk_subports(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2TrunkDestroy,
@@ -74,7 +74,7 @@ func TestAccNetworkingV2Trunk_tags(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2TrunkDestroy,
@@ -207,7 +207,7 @@ func TestAccNetworkingV2Trunk_computeInstance(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
-			t.Skip("Currently failing in Openlab")
+			testAccSkipReleasesBelow(t, "stable/yoga")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckComputeV2InstanceDestroy,


### PR DESCRIPTION
Add new workflow for networking/neutron.
Rename a couple of FWaaS tests to be excluded from the search.
"Un-skip" tests that were failing on OpenLab but should be
passing on GH-A.

RelatesTo: https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1381
Requires: https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1391

Close #1323 ( the extensions are enabled again and tests are passing )