### PR TITLE
[GH-A] Add workflow for dns/designate

### DIFF
--- a/.github/workflows/functional-dns.yml
+++ b/.github/workflows/functional-dns.yml
@@ -1,0 +1,66 @@
+name: functional-dns
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/functional-dns.yml'
+      - '**dns**'
+      - 'CHANGELOG.md'
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  functional-dns:
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ["master"]
+        openstack_version: ["master"]
+        ubuntu_version: ["20.04"]
+        include:
+          - name: "yoga"
+            openstack_version: "stable/yoga"
+            ubuntu_version: "20.04"
+          - name: "xena"
+            openstack_version: "stable/xena"
+            ubuntu_version: "20.04"
+          - name: "wallaby"
+            openstack_version: "stable/wallaby"
+            ubuntu_version: "20.04"
+          - name: "victoria"
+            openstack_version: "stable/victoria"
+            ubuntu_version: "20.04"
+          - name: "ussuri"
+            openstack_version: "stable/ussuri"
+            ubuntu_version: "18.04"
+          - name: "train"
+            openstack_version: "stable/train"
+            ubuntu_version: "18.04"
+    runs-on: ubuntu-${{ matrix.ubuntu_version }}
+    name: dns on OpenStack ${{ matrix.name }} with Designate and run dns acceptance tests
+    steps:
+      - name: Checkout TPO
+        uses: actions/checkout@v3
+      - name: Deploy devstack
+        uses: EmilienM/devstack-action@v0.7
+        with:
+          branch: ${{ matrix.openstack_version }}
+          conf_overrides: |
+            enable_plugin designate https://opendev.org/openstack/designate ${{ matrix.openstack_version }}         
+          enabled_services: 'designate,designate-central,designate-api,designate-worker,designate-producer,designate-mdns'
+      - name: Checkout go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '^1.17'
+      - name: Run TPO acceptance tests
+        run: OS_DNS_ENVIRONMENT=True ./scripts/acceptancetest.sh
+        env:
+          DEVSTACK_PATH: ${{ github.workspace }}/devstack
+          ACCEPTANCE_TESTS_FILTER: "dns"
+      - name: Generate logs on failure
+        run: ./scripts/collectlogs.sh
+        if: failure()
+      - name: Upload logs artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: functional-dns-${{ matrix.name }}
+          path: /tmp/devstack-logs/*


### PR DESCRIPTION
Add new workflow for running functional tests for
dns/designate.

RelatesTo: https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1381
Requires: https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1391