### PR TITLE
[GH-A] Add workflow for blockstorage_v2

### DIFF
--- a/.github/workflows/functional-blockstorage_v2.yml
+++ b/.github/workflows/functional-blockstorage_v2.yml
@@ -1,0 +1,45 @@
+# Functional testing for blockstorage_v2 which was deprecated on Pike
+# and completely removed on Xena
+name: functional-blockstorage_v2
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/functional-blockstorage_v2.yml'
+      - '**blockstorage**'
+      - '!**v3**'
+jobs:
+  functional-basic:
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ["wallaby"]
+        openstack_version: ["stable/wallaby"]
+        ubuntu_version: ["20.04"]
+    runs-on: ubuntu-${{ matrix.ubuntu_version }}
+    name: blockstorage_v2 on OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests
+    steps:
+      - name: Checkout TPO
+        uses: actions/checkout@v3
+      - name: Deploy devstack
+        uses: EmilienM/devstack-action@v0.7
+        with:
+          branch: ${{ matrix.openstack_version }}
+          enabled_services: 's-account,s-container,s-object,s-proxy'
+      - name: Checkout go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '^1.17'
+      - name: Run TPO acceptance tests
+        run: OS_BLOCKSTORAGE_V2=true ./scripts/acceptancetest.sh
+        env:
+          DEVSTACK_PATH: ${{ github.workspace }}/devstack
+          ACCEPTANCE_TESTS_FILTER: 'blockstorage.*v2|v2.*blockstorage'
+      - name: Generate logs on failure
+        run: ./scripts/collectlogs.sh
+        if: failure()
+      - name: Upload logs artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: functional-basic-${{ matrix.name }}
+          path: /tmp/devstack-logs/*

--- a/.github/workflows/functional-blockstorage_v3.yml
+++ b/.github/workflows/functional-blockstorage_v3.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - '.github/workflows/functional-blockstorage_v3.yml'
       - '**blockstorage**'
+      - '!**v2**'
+      - '!**v1**'
       - 'CHANGELOG.md'
   schedule:
     - cron: '0 0 * * *'

--- a/openstack/resource_openstack_blockstorage_quotaset_v2_test.go
+++ b/openstack/resource_openstack_blockstorage_quotaset_v2_test.go
@@ -9,15 +9,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets"
-	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
 )
 
 func TestAccBlockStorageQuotasetV2_basic(t *testing.T) {
 	var (
-		project    projects.Project
-		quotaset   quotasets.QuotaSet
-		volumeType volumetypes.VolumeType
+		project  projects.Project
+		quotaset quotasets.QuotaSet
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -54,7 +52,6 @@ func TestAccBlockStorageQuotasetV2_basic(t *testing.T) {
 				Config: testAccBlockStorageQuotasetV2Update1,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityV3ProjectExists("openstack_identity_project_v3.project_1", &project),
-					testAccCheckBlockStorageVolumeTypeV3Exists("openstack_blockstorage_volume_type_v3.volume_type_1", &volumeType),
 					testAccCheckBlockStorageQuotasetV2Exists("openstack_blockstorage_quotaset_v2.quotaset_1", &quotaset),
 					resource.TestCheckResourceAttr(
 						"openstack_blockstorage_quotaset_v2.quotaset_1", "volumes", "3"),
@@ -70,21 +67,12 @@ func TestAccBlockStorageQuotasetV2_basic(t *testing.T) {
 						"openstack_blockstorage_quotaset_v2.quotaset_1", "backup_gigabytes", "1"),
 					resource.TestCheckResourceAttr(
 						"openstack_blockstorage_quotaset_v2.quotaset_1", "groups", "1"),
-					resource.TestCheckResourceAttr(
-						"openstack_blockstorage_quotaset_v2.quotaset_1", "volume_type_quota.%", "3"),
-					resource.TestCheckResourceAttr(
-						"openstack_blockstorage_quotaset_v2.quotaset_1", "volume_type_quota.volumes_foo", "100"),
-					resource.TestCheckResourceAttr(
-						"openstack_blockstorage_quotaset_v2.quotaset_1", "volume_type_quota.snapshots_foo", "100"),
-					resource.TestCheckResourceAttr(
-						"openstack_blockstorage_quotaset_v2.quotaset_1", "volume_type_quota.gigabytes_foo", "100"),
 				),
 			},
 			{
 				Config: testAccBlockStorageQuotasetV2Update2,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityV3ProjectExists("openstack_identity_project_v3.project_1", &project),
-					testAccCheckBlockStorageVolumeTypeV3Exists("openstack_blockstorage_volume_type_v3.volume_type_1", &volumeType),
 					testAccCheckBlockStorageQuotasetV2Exists("openstack_blockstorage_quotaset_v2.quotaset_1", &quotaset),
 					resource.TestCheckResourceAttr(
 						"openstack_blockstorage_quotaset_v2.quotaset_1", "volumes", "3"),
@@ -100,10 +88,6 @@ func TestAccBlockStorageQuotasetV2_basic(t *testing.T) {
 						"openstack_blockstorage_quotaset_v2.quotaset_1", "backup_gigabytes", "4"),
 					resource.TestCheckResourceAttr(
 						"openstack_blockstorage_quotaset_v2.quotaset_1", "groups", "4"),
-					resource.TestCheckResourceAttr(
-						"openstack_blockstorage_quotaset_v2.quotaset_1", "volume_type_quota.%", "1"),
-					resource.TestCheckResourceAttr(
-						"openstack_blockstorage_quotaset_v2.quotaset_1", "volume_type_quota.volumes_foo", "10"),
 				),
 			},
 		},
@@ -150,11 +134,6 @@ func testAccCheckBlockStorageQuotasetV2Destroy(s *terraform.State) error {
 		return err
 	}
 
-	err = testAccCheckBlockStorageVolumeTypeV3Destroy(s)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -180,13 +159,6 @@ resource "openstack_identity_project_v3" "project_1" {
   name = "project_1"
 }
 
-resource "openstack_blockstorage_volume_type_v3" "volume_type_1" {
-  name = "foo"
-  description = "foo"
-  is_public = true
-}
-
-
 resource "openstack_blockstorage_quotaset_v2" "quotaset_1" {
   project_id           = "${openstack_identity_project_v3.project_1.id}"
   volumes              = 3
@@ -196,25 +168,12 @@ resource "openstack_blockstorage_quotaset_v2" "quotaset_1" {
   backups              = 2
   backup_gigabytes     = 1
   groups               = 1
-  volume_type_quota     = {
-	volumes_foo   = 100
-	snapshots_foo = 100
-	gigabytes_foo = 100
-  }
-
-  depends_on = [openstack_blockstorage_volume_type_v3.volume_type_1]
 }
 `
 
 const testAccBlockStorageQuotasetV2Update2 = `
 resource "openstack_identity_project_v3" "project_1" {
   name = "project_1"
-}
-
-resource "openstack_blockstorage_volume_type_v3" "volume_type_1" {
-  name = "foo"
-  description = "foo"
-  is_public = true
 }
 
 resource "openstack_blockstorage_quotaset_v2" "quotaset_1" {
@@ -226,10 +185,5 @@ resource "openstack_blockstorage_quotaset_v2" "quotaset_1" {
   backups              = 4
   backup_gigabytes     = 4
   groups               = 4
-  volume_type_quota     = {
-	volumes_foo   = 10
-  }
-
-  depends_on = [openstack_blockstorage_volume_type_v3.volume_type_1]
 }
 `


### PR DESCRIPTION
Functional testing for blockstorage_v2 which was deprecated on Pike
and completely removed on Xena.

RelatesTo: https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1381