### PR TITLE
Add links to containerinfra_nodegroup docs

### DIFF
--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -49,6 +49,9 @@
             <li<%= sidebar_current("docs-openstack-datasource-containerinfra-clustertemplate-v1") %>>
               <a href="/docs/providers/openstack/d/containerinfra_clustertemplate_v1.html">openstack_containerinfra_clustertemplate_v1</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-datasource-containerinfra-nodegroup-v1") %>>
+              <a href="/docs/providers/openstack/d/containerinfra_nodegroup_v1.html">openstack_containerinfra_nodegroup_v1</a>
+            </li>            
             <li<%= sidebar_current("docs-openstack-datasource-dns-zone-v2") %>>
               <a href="/docs/providers/openstack/d/dns_zone_v2.html">openstack_dns_zone_v2</a>
             </li>
@@ -238,6 +241,9 @@
             <li<%= sidebar_current("docs-openstack-resource-containerinfra-clustertemplate-v1") %>>
               <a href="/docs/providers/openstack/r/containerinfra_clustertemplate_v1.html">openstack_containerinfra_clustertemplate_v1</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-resource-containerinfra-nodegroup-v1") %>>
+              <a href="/docs/providers/openstack/r/containerinfra_nodegroup_v1.html">openstack_containerinfra_nodegroup_v1</a>
+            </li>            
           </ul>
         </li>
 


### PR DESCRIPTION
Nit fix with missing links for docs.
Follow-up from: https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1364