### PR TITLE
Remove lb_members ci check

### DIFF
--- a/openstack/import_openstack_lb_members_v2_test.go
+++ b/openstack/import_openstack_lb_members_v2_test.go
@@ -14,7 +14,7 @@ func TestAccLBV2Members_importBasic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
 			testAccPreCheckUseOctavia(t)
-			testAccPreCheckOctaviaBatchMembersEnv(t)
+			testAccSkipReleasesBelow(t, "stable/ussuri")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckLBV2MembersDestroy,

--- a/openstack/provider_test.go
+++ b/openstack/provider_test.go
@@ -16,36 +16,35 @@ import (
 )
 
 var (
-	osBranch                         = os.Getenv("OS_BRANCH")
-	osDBEnvironment                  = os.Getenv("OS_DB_ENVIRONMENT")
-	osDBDatastoreVersion             = os.Getenv("OS_DB_DATASTORE_VERSION")
-	osDBDatastoreType                = os.Getenv("OS_DB_DATASTORE_TYPE")
-	osDeprecatedEnvironment          = os.Getenv("OS_DEPRECATED_ENVIRONMENT")
-	osDNSEnvironment                 = os.Getenv("OS_DNS_ENVIRONMENT")
-	osExtGwID                        = os.Getenv("OS_EXTGW_ID")
-	osFlavorID                       = os.Getenv("OS_FLAVOR_ID")
-	osFlavorName                     = os.Getenv("OS_FLAVOR_NAME")
-	osImageID                        = os.Getenv("OS_IMAGE_ID")
-	osImageName                      = os.Getenv("OS_IMAGE_NAME")
-	osMagnumFlavor                   = os.Getenv("OS_MAGNUM_FLAVOR")
-	osMagnumImage                    = os.Getenv("OS_MAGNUM_IMAGE")
-	osNetworkID                      = os.Getenv("OS_NETWORK_ID")
-	osPoolName                       = os.Getenv("OS_POOL_NAME")
-	osRegionName                     = os.Getenv("OS_REGION_NAME")
-	osSwiftEnvironment               = os.Getenv("OS_SWIFT_ENVIRONMENT")
-	osLbEnvironment                  = os.Getenv("OS_LB_ENVIRONMENT")
-	osFwEnvironment                  = os.Getenv("OS_FW_ENVIRONMENT")
-	osVpnEnvironment                 = os.Getenv("OS_VPN_ENVIRONMENT")
-	osUseOctavia                     = os.Getenv("OS_USE_OCTAVIA")
-	osOctaviaBatchMembersEnvironment = os.Getenv("OS_OCTAVIA_BATCH_MEMBERS_ENVIRONMENT")
-	osContainerInfraEnvironment      = os.Getenv("OS_CONTAINER_INFRA_ENVIRONMENT")
-	osSfsEnvironment                 = os.Getenv("OS_SFS_ENVIRONMENT")
-	osTransparentVlanEnvironment     = os.Getenv("OS_TRANSPARENT_VLAN_ENVIRONMENT")
-	osKeymanagerEnvironment          = os.Getenv("OS_KEYMANAGER_ENVIRONMENT")
-	osGlanceimportEnvironment        = os.Getenv("OS_GLANCEIMPORT_ENVIRONMENT")
-	osHypervisorEnvironment          = os.Getenv("OS_HYPERVISOR_HOSTNAME")
-	osPortForwardingEnvironment      = os.Getenv("OS_PORT_FORWARDING_ENVIRONMENT")
-	osBlockStorageV2                 = os.Getenv("OS_BLOCKSTORAGE_V2")
+	osBranch                     = os.Getenv("OS_BRANCH")
+	osDBEnvironment              = os.Getenv("OS_DB_ENVIRONMENT")
+	osDBDatastoreVersion         = os.Getenv("OS_DB_DATASTORE_VERSION")
+	osDBDatastoreType            = os.Getenv("OS_DB_DATASTORE_TYPE")
+	osDeprecatedEnvironment      = os.Getenv("OS_DEPRECATED_ENVIRONMENT")
+	osDNSEnvironment             = os.Getenv("OS_DNS_ENVIRONMENT")
+	osExtGwID                    = os.Getenv("OS_EXTGW_ID")
+	osFlavorID                   = os.Getenv("OS_FLAVOR_ID")
+	osFlavorName                 = os.Getenv("OS_FLAVOR_NAME")
+	osImageID                    = os.Getenv("OS_IMAGE_ID")
+	osImageName                  = os.Getenv("OS_IMAGE_NAME")
+	osMagnumFlavor               = os.Getenv("OS_MAGNUM_FLAVOR")
+	osMagnumImage                = os.Getenv("OS_MAGNUM_IMAGE")
+	osNetworkID                  = os.Getenv("OS_NETWORK_ID")
+	osPoolName                   = os.Getenv("OS_POOL_NAME")
+	osRegionName                 = os.Getenv("OS_REGION_NAME")
+	osSwiftEnvironment           = os.Getenv("OS_SWIFT_ENVIRONMENT")
+	osLbEnvironment              = os.Getenv("OS_LB_ENVIRONMENT")
+	osFwEnvironment              = os.Getenv("OS_FW_ENVIRONMENT")
+	osVpnEnvironment             = os.Getenv("OS_VPN_ENVIRONMENT")
+	osUseOctavia                 = os.Getenv("OS_USE_OCTAVIA")
+	osContainerInfraEnvironment  = os.Getenv("OS_CONTAINER_INFRA_ENVIRONMENT")
+	osSfsEnvironment             = os.Getenv("OS_SFS_ENVIRONMENT")
+	osTransparentVlanEnvironment = os.Getenv("OS_TRANSPARENT_VLAN_ENVIRONMENT")
+	osKeymanagerEnvironment      = os.Getenv("OS_KEYMANAGER_ENVIRONMENT")
+	osGlanceimportEnvironment    = os.Getenv("OS_GLANCEIMPORT_ENVIRONMENT")
+	osHypervisorEnvironment      = os.Getenv("OS_HYPERVISOR_HOSTNAME")
+	osPortForwardingEnvironment  = os.Getenv("OS_PORT_FORWARDING_ENVIRONMENT")
+	osBlockStorageV2             = os.Getenv("OS_BLOCKSTORAGE_V2")
 )
 
 var (
@@ -151,14 +150,6 @@ func testAccPreCheckUseOctavia(t *testing.T) {
 
 	if osUseOctavia == "" {
 		t.Skip("This environment does not support Octavia tests")
-	}
-}
-
-func testAccPreCheckOctaviaBatchMembersEnv(t *testing.T) {
-	testAccPreCheckRequiredEnvVars(t)
-
-	if osOctaviaBatchMembersEnvironment == "" {
-		t.Skip("This environment does not support Octavia batch member update tests")
 	}
 }
 

--- a/openstack/resource_openstack_lb_members_v2_test.go
+++ b/openstack/resource_openstack_lb_members_v2_test.go
@@ -28,18 +28,6 @@ func testAccCheckLBV2MembersComputeHash(members *[]pools.Member, weight int, add
 	}
 }
 
-func testCheckResourceAttrWithIndexesAddr(name, format string, idx *int, value string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		return resource.TestCheckResourceAttr(name, fmt.Sprintf(format, *idx), value)(s)
-	}
-}
-
-func testCheckResourceAttrSetWithIndexesAddr(name, format string, idx *int) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		return resource.TestCheckResourceAttrSet(name, fmt.Sprintf(format, *idx))(s)
-	}
-}
-
 func TestAccLBV2Members_basic(t *testing.T) {
 	var members []pools.Member
 	var idx1 int
@@ -51,7 +39,7 @@ func TestAccLBV2Members_basic(t *testing.T) {
 			testAccPreCheckNonAdminOnly(t)
 			testAccPreCheckLB(t)
 			testAccPreCheckUseOctavia(t)
-			testAccPreCheckOctaviaBatchMembersEnv(t)
+			testAccSkipReleasesBelow(t, "stable/ussuri")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckLBV2MembersDestroy,
@@ -63,12 +51,10 @@ func TestAccLBV2Members_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("openstack_lb_members_v2.members_1", "member.#", "2"),
 					testAccCheckLBV2MembersComputeHash(&members, 0, "192.168.199.110", &idx1),
 					testAccCheckLBV2MembersComputeHash(&members, 1, "192.168.199.111", &idx2),
-					testCheckResourceAttrWithIndexesAddr("openstack_lb_members_v2.members_1", "member.%d.weight", &idx1, "0"),
-					testCheckResourceAttrWithIndexesAddr("openstack_lb_members_v2.members_1", "member.%d.weight", &idx2, "1"),
-					testCheckResourceAttrWithIndexesAddr("openstack_lb_members_v2.members_1", "member.%d.backup", &idx1, "false"),
-					testCheckResourceAttrWithIndexesAddr("openstack_lb_members_v2.members_1", "member.%d.backup", &idx2, "true"),
-					testCheckResourceAttrSetWithIndexesAddr("openstack_lb_members_v2.members_1", "member.%d.subnet_id", &idx1),
-					testCheckResourceAttrSetWithIndexesAddr("openstack_lb_members_v2.members_1", "member.%d.subnet_id", &idx2),
+					resource.TestCheckResourceAttr("openstack_lb_members_v2.members_1", "member.0.weight", "0"),
+					resource.TestCheckResourceAttr("openstack_lb_members_v2.members_1", "member.1.weight", "1"),
+					resource.TestCheckResourceAttr("openstack_lb_members_v2.members_1", "member.0.backup", "false"),
+					resource.TestCheckResourceAttr("openstack_lb_members_v2.members_1", "member.1.backup", "true"),
 				),
 			},
 			{
@@ -78,12 +64,10 @@ func TestAccLBV2Members_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("openstack_lb_members_v2.members_1", "member.#", "2"),
 					testAccCheckLBV2MembersComputeHash(&members, 10, "192.168.199.110", &idx1),
 					testAccCheckLBV2MembersComputeHash(&members, 15, "192.168.199.111", &idx2),
-					testCheckResourceAttrWithIndexesAddr("openstack_lb_members_v2.members_1", "member.%d.weight", &idx1, "10"),
-					testCheckResourceAttrWithIndexesAddr("openstack_lb_members_v2.members_1", "member.%d.weight", &idx2, "15"),
-					testCheckResourceAttrWithIndexesAddr("openstack_lb_members_v2.members_1", "member.%d.backup", &idx1, "true"),
-					testCheckResourceAttrWithIndexesAddr("openstack_lb_members_v2.members_1", "member.%d.backup", &idx2, "false"),
-					testCheckResourceAttrSetWithIndexesAddr("openstack_lb_members_v2.members_1", "member.%d.subnet_id", &idx1),
-					testCheckResourceAttrSetWithIndexesAddr("openstack_lb_members_v2.members_1", "member.%d.subnet_id", &idx2),
+					resource.TestCheckResourceAttr("openstack_lb_members_v2.members_1", "member.0.weight", "10"),
+					resource.TestCheckResourceAttr("openstack_lb_members_v2.members_1", "member.1.weight", "15"),
+					resource.TestCheckResourceAttr("openstack_lb_members_v2.members_1", "member.0.backup", "true"),
+					resource.TestCheckResourceAttr("openstack_lb_members_v2.members_1", "member.1.backup", "false"),
 				),
 			},
 			{
@@ -93,10 +77,10 @@ func TestAccLBV2Members_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("openstack_lb_members_v2.members_1", "member.#", "2"),
 					testAccCheckLBV2MembersComputeHash(&members, 10, "192.168.199.110", &idx1),
 					testAccCheckLBV2MembersComputeHash(&members, 15, "192.168.199.111", &idx2),
-					testCheckResourceAttrWithIndexesAddr("openstack_lb_members_v2.members_1", "member.%d.weight", &idx1, "10"),
-					testCheckResourceAttrWithIndexesAddr("openstack_lb_members_v2.members_1", "member.%d.weight", &idx2, "15"),
-					testCheckResourceAttrWithIndexesAddr("openstack_lb_members_v2.members_1", "member.%d.subnet_id", &idx1, ""),
-					testCheckResourceAttrWithIndexesAddr("openstack_lb_members_v2.members_1", "member.%d.subnet_id", &idx2, ""),
+					resource.TestCheckResourceAttr("openstack_lb_members_v2.members_1", "member.0.weight", "10"),
+					resource.TestCheckResourceAttr("openstack_lb_members_v2.members_1", "member.1.weight", "15"),
+					resource.TestCheckResourceAttr("openstack_lb_members_v2.members_1", "member.0.subnet_id", ""),
+					resource.TestCheckResourceAttr("openstack_lb_members_v2.members_1", "member.1.subnet_id", ""),
 				),
 			},
 			{


### PR DESCRIPTION
testAccPreCheckOctaviaBatchMembersEnv is no longer required
and can be removed from the ci checks.