### PR TITLE
Import openstack_networking_port_secgroup_associate_v2

### DIFF
--- a/openstack/import_openstack_networking_port_secgroup_associate_v2_test.go
+++ b/openstack/import_openstack_networking_port_secgroup_associate_v2_test.go
@@ -1,0 +1,40 @@
+package openstack
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccNetworkingV2PortSecgroupAssociate_import(t *testing.T) {
+	resourceName := "openstack_networking_port_secgroup_associate_v2.port_1"
+
+	if os.Getenv("TF_ACC") != "" {
+		hiddenPort, err := testAccCheckNetworkingV2PortSecGroupCreatePort(t, "hidden_port", true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer testAccCheckNetworkingV2PortSecGroupDeletePort(t, hiddenPort) //nolint:errcheck
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckNonAdminOnly(t)
+		},
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2PortSecGroupAssociateManifestUpdate0(),
+			},
+
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"security_group_ids"},
+			},
+		},
+	})
+}

--- a/openstack/resource_openstack_networking_port_secgroup_associate_v2.go
+++ b/openstack/resource_openstack_networking_port_secgroup_associate_v2.go
@@ -17,6 +17,9 @@ func resourceNetworkingPortSecGroupAssociateV2() *schema.Resource {
 		ReadContext:   resourceNetworkingPortSecGroupAssociateV2Read,
 		UpdateContext: resourceNetworkingPortSecGroupAssociateV2Update,
 		DeleteContext: resourceNetworkingPortSecGroupAssociateV2Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -110,7 +113,9 @@ func resourceNetworkingPortSecGroupAssociateV2Read(ctx context.Context, d *schem
 		return diag.FromErr(CheckDeleted(d, err, "Error fetching port security groups"))
 	}
 
-	var enforce bool
+	// We can assume enforce is `false` as it is defaulted to it. If user
+	// passes `true` it will be overwritten in the if clause
+	enforce := false
 	if v, ok := d.GetOkExists("enforce"); ok {
 		enforce = v.(bool)
 	}
@@ -128,6 +133,8 @@ func resourceNetworkingPortSecGroupAssociateV2Read(ctx context.Context, d *schem
 		}
 	}
 
+	d.Set("enforce", enforce)
+	d.Set("port_id", d.Id())
 	d.Set("region", GetRegion(d, config))
 
 	return nil

--- a/website/docs/r/networking_port_secgroup_associate_v2.html.markdown
+++ b/website/docs/r/networking_port_secgroup_associate_v2.html.markdown
@@ -99,3 +99,11 @@ The following attributes are exported:
 * `security_group_ids` - See Argument Reference above.
 * `all_security_group_ids` - The collection of Security Group IDs on the port
   which have been explicitly and implicitly added.
+
+## Import
+
+Port security group association can be imported using the `id` of the port, e.g.
+
+```
+$ terraform import openstack_networking_port_secgroup_associate_v2.port_1 eae26a3e-1c33-4cc1-9c31-0cd729c438a1
+```


### PR DESCRIPTION
Add test and documentation for importing a
openstack_networking_port_secgroup_associate_v2
resource.

Close #1353 