### PR TITLE
add compute limits as a data source

### DIFF
--- a/openstack/data_source_openstack_compute_limits_v2.go
+++ b/openstack/data_source_openstack_compute_limits_v2.go
@@ -15,6 +15,13 @@ func dataSourceComputeLimitsV2() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceComputeLimitsV2Read,
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
 			"project_id": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/openstack/data_source_openstack_compute_limits_v2.go
+++ b/openstack/data_source_openstack_compute_limits_v2.go
@@ -1,0 +1,168 @@
+package openstack
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/limits"
+)
+
+func dataSourceComputeLimitsV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceComputeLimitsV2Read,
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"max_total_cores": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"max_image_meta": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"max_server_meta": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"max_personality": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"max_personality_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"max_total_keypairs": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"max_security_groups": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"max_security_group_rules": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"max_server_groups": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"max_server_group_members": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"max_total_floating_ips": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"max_total_instances": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"max_total_ram_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"total_cores_used": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"total_instances_used": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"total_floating_ips_used": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"total_ram_used": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"total_security_groups_used": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"total_server_groups_used": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceComputeLimitsV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	region := GetRegion(d, config)
+	computeClient, err := config.ComputeV2Client(region)
+	if err != nil {
+		return diag.Errorf("Error creating OpenStack compute client: %s", err)
+	}
+
+	projectID := d.Get("project_id").(string)
+	getOpts := limits.GetOpts{
+		TenantID: projectID,
+	}
+
+	q, err := limits.Get(computeClient, getOpts).Extract()
+	if err != nil {
+		return diag.FromErr(CheckDeleted(d, err, "Error retrieving openstack_compute_limits_v2"))
+	}
+
+	log.Printf("[DEBUG] Retrieved openstack_compute_limits_v2 %s: %#v", d.Id(), q)
+
+	id := fmt.Sprintf("%s/%s", projectID, region)
+	d.SetId(id)
+	d.Set("region", region)
+	d.Set("project_id", projectID)
+
+	d.Set("max_total_cores", q.Absolute.MaxTotalCores)
+	d.Set("max_image_meta", q.Absolute.MaxImageMeta)
+	d.Set("max_server_meta", q.Absolute.MaxServerMeta)
+	d.Set("max_personality", q.Absolute.MaxPersonality)
+	d.Set("max_personality_size", q.Absolute.MaxPersonalitySize)
+	d.Set("max_total_keypairs", q.Absolute.MaxTotalKeypairs)
+	d.Set("max_security_groups", q.Absolute.MaxSecurityGroups)
+	d.Set("max_security_group_rules", q.Absolute.MaxSecurityGroupRules)
+	d.Set("max_server_groups", q.Absolute.MaxServerGroups)
+	d.Set("max_server_group_members", q.Absolute.MaxServerGroupMembers)
+	d.Set("max_total_floating_ips", q.Absolute.MaxTotalFloatingIps)
+	d.Set("max_total_instances", q.Absolute.MaxTotalInstances)
+	d.Set("max_total_ram_size", q.Absolute.MaxTotalRAMSize)
+	d.Set("total_cores_used", q.Absolute.TotalCoresUsed)
+	d.Set("total_instances_used", q.Absolute.TotalInstancesUsed)
+	d.Set("total_floating_ips_used", q.Absolute.TotalFloatingIpsUsed)
+	d.Set("total_ram_used", q.Absolute.TotalRAMUsed)
+	d.Set("total_security_groups_used", q.Absolute.TotalSecurityGroupsUsed)
+	d.Set("total_server_groups_used", q.Absolute.TotalServerGroupsUsed)
+
+	return nil
+}

--- a/openstack/data_source_openstack_compute_limits_v2_test.go
+++ b/openstack/data_source_openstack_compute_limits_v2_test.go
@@ -1,0 +1,80 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccComputeV2LimitsDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeV2LimitsDataSourceBasic,
+			},
+			{
+				Config: testAccComputeV2LimitsDataSourceSource(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeLimitsV2DataSourceID("data.openstack_compute_limits_v2.source"),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_limits_v2.source", "max_total_cores"),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_limits_v2.source", "max_image_meta"),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_limits_v2.source", "max_server_meta"),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_limits_v2.source", "max_personality"),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_limits_v2.source", "max_personality_size"),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_limits_v2.source", "max_total_keypairs"),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_limits_v2.source", "max_security_groups"),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_limits_v2.source", "max_security_group_rules"),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_limits_v2.source", "max_server_groups"),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_limits_v2.source", "max_server_group_members"),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_limits_v2.source", "max_total_floating_ips"),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_limits_v2.source", "max_total_instances"),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_limits_v2.source", "max_total_ram_size"),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_limits_v2.source", "total_cores_used"),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_limits_v2.source", "total_instances_used"),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_limits_v2.source", "total_floating_ips_used"),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_limits_v2.source", "total_ram_used"),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_limits_v2.source", "total_security_groups_used"),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_limits_v2.source", "total_server_groups_used"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckComputeLimitsV2DataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find compute limits data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Compute limits data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+const testAccComputeV2LimitsDataSourceBasic = `
+resource "openstack_identity_project_v3" "project" {
+  name = "test-limits-datasource"
+}
+`
+
+func testAccComputeV2LimitsDataSourceSource() string {
+	return fmt.Sprintf(`
+%s
+
+data "openstack_compute_limits_v2" "source" {
+  project_id = "${openstack_identity_project_v3.project.id}"
+}
+`, testAccComputeV2LimitsDataSourceBasic)
+}

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -270,6 +270,7 @@ func Provider() *schema.Provider {
 			"openstack_compute_hypervisor_v2":                    dataSourceComputeHypervisorV2(),
 			"openstack_compute_keypair_v2":                       dataSourceComputeKeypairV2(),
 			"openstack_compute_quotaset_v2":                      dataSourceComputeQuotasetV2(),
+			"openstack_compute_limits_v2":                        dataSourceComputeLimitsV2(),
 			"openstack_containerinfra_nodegroup_v1":              dataSourceContainerInfraNodeGroupV1(),
 			"openstack_containerinfra_clustertemplate_v1":        dataSourceContainerInfraClusterTemplateV1(),
 			"openstack_containerinfra_cluster_v1":                dataSourceContainerInfraCluster(),

--- a/website/docs/d/compute_limits_v2.html.markdown
+++ b/website/docs/d/compute_limits_v2.html.markdown
@@ -1,0 +1,52 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_compute_limits_v2"
+sidebar_current: "docs-openstack-datasource-compute-limits-v2"
+description: |-
+  Get information on a Compute Limits of a project.
+---
+
+# openstack\_compute\_limits\_v2
+
+Use this data source to get the compute limits of an OpenStack project.
+
+## Example Usage
+
+```hcl
+data "openstack_compute_limits_v2" "limits" {
+  project_id = "2e367a3d29f94fd988e6ec54e305ec9d"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional) The region in which to obtain the V2 Compute client.
+    If omitted, the `region` argument of the provider is used.
+
+* `project_id` - (Required) The id of the project to retrieve the limits.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `project_id` - See Argument Reference above.
+* `max_total_cores` - The number of allowed server cores for the tenant.
+* `max_image_meta` - The number of allowed metadata items for each image. Starting from version 2.39 this field is dropped from ‘os-limits’ response, because ‘image-metadata’ proxy API was deprecated. Available until version 2.38.
+* `max_server_meta` - The number of allowed server groups for the tenant.
+* `max_personality` - The number of allowed injected files for the tenant. Available until version 2.56.
+* `max_personality_size` - The number of allowed bytes of content for each injected file. Available until version 2.56.
+* `max_total_keypairs` - The number of allowed key pairs for the user.
+* `max_security_groups` - The number of allowed security groups for the tenant. Available until version 2.35.
+* `max_security_group_rules` - The number of allowed rules for each security group. Available until version 2.35.
+* `max_server_groups` - The number of allowed server groups for the tenant.
+* `max_server_group_members` - The number of allowed members for each server group.
+* `max_total_floating_ips` - The number of allowed floating IP addresses for each tenant. Available until version 2.35.
+* `max_total_instances` - The number of allowed servers for the tenant.
+* `max_total_ram_size` - The number of allowed floating IP addresses for the tenant. Available until version 2.35.
+* `total_cores_used` - The number of used server cores in the tenant.
+* `total_instances_used` - The number of used server cores in the tenant.
+* `total_floating_ips_used` - The number of used floating IP addresses in the tenant.
+* `total_ram_used` - The amount of used server RAM in the tenant.
+* `total_security_groups_used` - The number of used security groups in the tenant. Available until version 2.35.
+* `total_server_groups_used` - The number of used server groups in each tenant.

--- a/website/docs/d/compute_limits_v2.html.markdown
+++ b/website/docs/d/compute_limits_v2.html.markdown
@@ -31,6 +31,7 @@ data "openstack_compute_limits_v2" "limits" {
 The following attributes are exported:
 
 * `project_id` - See Argument Reference above.
+* `region` - See Argument Reference above.
 * `max_total_cores` - The number of allowed server cores for the tenant.
 * `max_image_meta` - The number of allowed metadata items for each image. Starting from version 2.39 this field is dropped from ‘os-limits’ response, because ‘image-metadata’ proxy API was deprecated. Available until version 2.38.
 * `max_server_meta` - The number of allowed server groups for the tenant.

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -43,6 +43,9 @@
             <li<%= sidebar_current("docs-openstack-datasource-compute-quotaset-v2") %>>
               <a href="/docs/providers/openstack/d/compute_quotaset_v2.html">openstack_compute_quotaset_v2</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-datasource-compute-limits-v2") %>>
+              <a href="/docs/providers/openstack/d/compute_limits_v2.html">openstack_compute_limits_v2</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-datasource-containerinfra-cluster-v1") %>>
               <a href="/docs/providers/openstack/d/containerinfra_cluster_v1.html">openstack_containerinfra_cluster_v1</a>
             </li>
@@ -51,7 +54,7 @@
             </li>
             <li<%= sidebar_current("docs-openstack-datasource-containerinfra-nodegroup-v1") %>>
               <a href="/docs/providers/openstack/d/containerinfra_nodegroup_v1.html">openstack_containerinfra_nodegroup_v1</a>
-            </li>            
+            </li>
             <li<%= sidebar_current("docs-openstack-datasource-dns-zone-v2") %>>
               <a href="/docs/providers/openstack/d/dns_zone_v2.html">openstack_dns_zone_v2</a>
             </li>
@@ -243,7 +246,7 @@
             </li>
             <li<%= sidebar_current("docs-openstack-resource-containerinfra-nodegroup-v1") %>>
               <a href="/docs/providers/openstack/r/containerinfra_nodegroup_v1.html">openstack_containerinfra_nodegroup_v1</a>
-            </li>            
+            </li>
           </ul>
         </li>
 


### PR DESCRIPTION
This address my comment in #1289

## Tested on a real OpenStack
`openstack` command:
```sh
$ o limits show --absolute --project 16c91b6234df4cebabbe704b4a6f2083
+--------------------------+-------+
| Name                     | Value |
+--------------------------+-------+
| maxServerMeta            |   128 |
| maxPersonality           |     5 |
| totalServerGroupsUsed    |     0 |
| maxImageMeta             |   128 |
| maxPersonalitySize       | 10240 |
| maxTotalKeypairs         |   100 |
| maxSecurityGroupRules    |    20 |
| maxServerGroups          |    10 |
| totalCoresUsed           |     8 |
| totalRAMUsed             | 16384 |
| totalInstancesUsed       |     3 |
| maxSecurityGroups        |    10 |
| totalFloatingIpsUsed     |     0 |
| maxTotalCores            |    20 |
| maxServerGroupMembers    |    10 |
| maxTotalFloatingIps      |    10 |
| totalSecurityGroupsUsed  |     1 |
| maxTotalInstances        |    10 |
| maxTotalRAMSize          | 51200 |
| totalSnapshotsUsed       |     0 |
| maxTotalBackups          |    50 |
| maxTotalVolumeGigabytes  |  1500 |
| maxTotalSnapshots        |    10 |
| maxTotalBackupGigabytes  |     0 |
| totalBackupGigabytesUsed |     0 |
| maxTotalVolumes          |   100 |
| totalVolumesUsed         |    35 |
| totalBackupsUsed         |     0 |
| totalGigabytesUsed       |  1238 |
+--------------------------+-------+
```
and tf:
```sh
brock@micro:~/os-test$ cat main.tf && tf plan
terraform {
  required_providers {
    openstack = {
      version = "0.1"
      source  = "registry.terraform.io/terraform-provider-openstack/openstack"
    }
  }
}
provider "openstack" { insecure = true }
data "openstack_compute_limits_v2" "source" { project_id = "16c91b6234df4cebabbe704b4a6f2083" }
output "info" { value = data.openstack_compute_limits_v2.source }

Changes to Outputs:
  + info = {
      + id                         = "16c91b6234df4cebabbe704b4a6f2083/regionOne"
      + max_image_meta             = 128
      + max_personality            = 5
      + max_personality_size       = 10240
      + max_security_group_rules   = 20
      + max_security_groups        = 10
      + max_server_group_members   = 10
      + max_server_groups          = 10
      + max_server_meta            = 128
      + max_total_cores            = 20
      + max_total_floating_ips     = 10
      + max_total_instances        = 10
      + max_total_keypairs         = 100
      + max_total_ram_size         = 51200
      + project_id                 = "16c91b6234df4cebabbe704b4a6f2083"
      + total_cores_used           = 8
      + total_floating_ips_used    = 0
      + total_instances_used       = 3
      + total_ram_used             = 16384
      + total_security_groups_used = 1
      + total_server_groups_used   = 0
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.

──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run
"terraform apply" now.
```
 I basically just copied the conventions in #1302, #1318, and #1319

This allows you to use [data source custom conditions](https://www.terraform.io/language/data-sources#custom-condition-checks) to make sure the target project has enough available quota for whatever you are about to deploy.
