### PR TITLE
Update github workflows with concurrency

### DIFF
--- a/.github/workflows/functional-blockstorage_v2.yml
+++ b/.github/workflows/functional-blockstorage_v2.yml
@@ -1,6 +1,9 @@
 # Functional testing for blockstorage_v2 which was deprecated on Pike
 # and completely removed on Xena
 name: functional-blockstorage_v2
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request:
     paths:

--- a/.github/workflows/functional-blockstorage_v3.yml
+++ b/.github/workflows/functional-blockstorage_v3.yml
@@ -1,5 +1,8 @@
 # Functional testing for blockstorage_v3
 name: functional-blockstorage_v3
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request:
     paths:

--- a/.github/workflows/functional-compute.yml
+++ b/.github/workflows/functional-compute.yml
@@ -1,5 +1,8 @@
 # Functional testing for compute
 name: functional-compute
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request:
     paths:

--- a/.github/workflows/functional-dns.yml
+++ b/.github/workflows/functional-dns.yml
@@ -1,4 +1,7 @@
 name: functional-dns
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request:
     paths:

--- a/.github/workflows/functional-identity.yml
+++ b/.github/workflows/functional-identity.yml
@@ -1,5 +1,8 @@
 # Functional testing for identity
 name: functional-identity
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request:
     paths:

--- a/.github/workflows/functional-images.yml
+++ b/.github/workflows/functional-images.yml
@@ -1,5 +1,8 @@
 # Functional testing for images
 name: functional-images
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request:
     paths:

--- a/.github/workflows/functional-keymanager.yml
+++ b/.github/workflows/functional-keymanager.yml
@@ -2,6 +2,9 @@
 # due to barbican's default policies changing completely
 # on wallaby
 name: functional-keymanager
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request:
     paths:

--- a/.github/workflows/functional-loadbalancer.yml
+++ b/.github/workflows/functional-loadbalancer.yml
@@ -1,4 +1,7 @@
 name: functional-loadbalancer
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request:
     paths:

--- a/.github/workflows/functional-networking.yml
+++ b/.github/workflows/functional-networking.yml
@@ -1,5 +1,8 @@
 # Functional testing for networking
 name: functional-networking
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request:
     paths:

--- a/.github/workflows/functional-objectstorage.yml
+++ b/.github/workflows/functional-objectstorage.yml
@@ -1,4 +1,7 @@
 name: functional-objectstorage
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request:
     paths:

--- a/.github/workflows/functional-orchestration.yml
+++ b/.github/workflows/functional-orchestration.yml
@@ -1,4 +1,7 @@
 name: functional-orchestration
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request:
     paths:

--- a/.github/workflows/functional-sharedfilesystem.yml
+++ b/.github/workflows/functional-sharedfilesystem.yml
@@ -1,4 +1,7 @@
 name: functional-sharedfilesystem
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request:
     paths:

--- a/.github/workflows/functional-vpnaas.yml
+++ b/.github/workflows/functional-vpnaas.yml
@@ -1,4 +1,7 @@
 name: functional-vpnaas
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Add concurrency on github worklows that will cancel
running jobs of the same workflow and github-reference.
We often re-push changes before the jobs finish due to
minor fixes, running jobs should be cancelled and new
ones triggered