### PR TITLE
Add created/updated to compute instance

### DIFF
--- a/openstack/data_source_openstack_compute_instance_v2.go
+++ b/openstack/data_source_openstack_compute_instance_v2.go
@@ -121,6 +121,14 @@ func dataSourceComputeInstanceV2() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -145,6 +153,8 @@ func dataSourceComputeInstanceV2Read(ctx context.Context, d *schema.ResourceData
 	d.SetId(server.ID)
 
 	d.Set("name", server.Name)
+	d.Set("created", server.Created.String())
+	d.Set("updated", server.Updated.String())
 	d.Set("image_id", server.Image["ID"])
 
 	// Get the instance network and address information

--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -434,6 +434,14 @@ func resourceComputeInstanceV2() *schema.Resource {
 					},
 				},
 			},
+			"created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 		CustomizeDiff: customdiff.All(
 			// OpenStack cannot resize an instance, if its original flavor is deleted, that is why
@@ -659,6 +667,8 @@ func resourceComputeInstanceV2Read(_ context.Context, d *schema.ResourceData, me
 	log.Printf("[DEBUG] Retrieved Server %s: %+v", d.Id(), server)
 
 	d.Set("name", server.Name)
+	d.Set("created", server.Created.String())
+	d.Set("updated", server.Updated.String())
 
 	// Get the instance network and address information
 	networks, err := flattenInstanceNetworks(d, meta)

--- a/website/docs/d/compute_instance_v2.html.markdown
+++ b/website/docs/d/compute_instance_v2.html.markdown
@@ -56,6 +56,10 @@ In addition to the above, the following attributes are exported:
 
 * `metadata` - A set of key/value pairs made available to the server.
 
+* `created` - The creation time of the instance.
+
+* `updated` - The time when the instance was last updated.
+
 
 The `network` block is defined as:
 
@@ -70,3 +74,4 @@ The `network` block is defined as:
 * `port` - The port UUID for this network
 
 * `mac` - The MAC address assigned to this network interface.
+

--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -553,6 +553,8 @@ The following attributes are exported:
 * `tags` - See Argument Reference above.
 * `all_tags` - The collection of tags assigned on the instance, which have
     been explicitly and implicitly added.
+* `created` - The creation time of the instance.
+* `updated` - The time when the instance was last updated.
 
 ## Notes
 


### PR DESCRIPTION
Add created/updated attribute to compute instance. This is useful for us
to detecte and change another resource whenever an instance has been
updated.

Signed-off-by: Arthur Outhenin-Chalandre <arthur.outhenin-chalandre@cern.ch>