### PR TITLE
Fix docs  for containerinfra_nodegroup_v1

### DIFF
--- a/website/docs/r/containerinfra_nodegroup_v1.html.markdown
+++ b/website/docs/r/containerinfra_nodegroup_v1.html.markdown
@@ -82,8 +82,8 @@ The following attributes are exported:
 * `updated_at` - The time at which cluster was created.
 * `docker_volume_size` - See Argument Reference above.
 * `role` - See Argument Reference above.
-* `image` - See Argument Reference above.
-* `flavor` - See Argument Reference above.
+* `image_id` - See Argument Reference above.
+* `flavor_id` - See Argument Reference above.
 * `labels` - See Argument Reference above.
 * `node_count` - See Argument Reference above.
 * `min_node_count` - See Argument Reference above.

--- a/website/docs/r/containerinfra_nodegroup_v1.html.markdown
+++ b/website/docs/r/containerinfra_nodegroup_v1.html.markdown
@@ -44,11 +44,11 @@ The following arguments are supported:
 * `docker_volume_size` - (Optional) The size (in GB) of the Docker volume.
     Changing this creates a new node group.
 
-* `image` - (Required) The reference to an image that is used for nodes of the
+* `image_id` - (Required) The reference to an image that is used for nodes of the
     node group. Can be set via the `OS_MAGNUM_IMAGE` environment variable.
     Changing this updates the image attribute of the existing node group.
 
-* `flavor` - (Optional) The flavor for the nodes of the node group. Can be set
+* `flavor_id` - (Optional) The flavor for the nodes of the node group. Can be set
     via the `OS_MAGNUM_FLAVOR` environment variable. Changing this creates a new
     node group.
 


### PR DESCRIPTION
Field names were incorrect.
flavor -> flavor_id,
image -> image_id