### PR TITLE
User can set role on containerinfra_nodegroup

### DIFF
--- a/openstack/resource_openstack_containerinfra_nodegroup_v1.go
+++ b/openstack/resource_openstack_containerinfra_nodegroup_v1.go
@@ -91,6 +91,7 @@ func resourceContainerInfraNodeGroupV1() *schema.Resource {
 
 			"role": {
 				Type:     schema.TypeString,
+				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},


### PR DESCRIPTION
Close #1427

This should allow users to set `role`. Unfortunately the api for nodegroup is not documented but it seems to be the case that setting `role` is allowed based on code and docs linked [here](https://github.com/gophercloud/gophercloud/issues/1767).

@ozerovandrei we currently cannot test this unfortunately due to #1413 but the change is rather small.