### PR TITLE
Fix train and ussuri vpnaas jobs

### DIFF
--- a/.github/workflows/functional-vpnaas.yml
+++ b/.github/workflows/functional-vpnaas.yml
@@ -15,41 +15,49 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["master"]
-        openstack_version: ["master"]
-        ubuntu_version: ["20.04"]
-        devstack_conf_overrides: ["enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing master"]
         include:
+          - name: "master"
+            openstack_version: "master"
+            ubuntu_version: "20.04"
+            devstack_conf_overrides: |
+              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing master
+              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas master
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
               enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/yoga
+              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas stable/yoga
           - name: "xena"
             openstack_version: "stable/xena"
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
               enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/xena
+              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas stable/xena
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
               enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/wallaby
+              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas stable/wallaby
           - name: "victoria"
             openstack_version: "stable/victoria"
             ubuntu_version: "20.04"
             devstack_conf_overrides: |
               enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/victoria
+              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas stable/victoria
           - name: "ussuri"
             openstack_version: "stable/ussuri"
             ubuntu_version: "18.04"
             devstack_conf_overrides: |
               enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/ussuri
+              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas ussuri-eol
           - name: "train"
             openstack_version: "stable/train"
             ubuntu_version: "18.04"
             devstack_conf_overrides: |
               enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing train-eol
+              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas train-eol
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Neutron and run vpnaas acceptance tests
     steps:
@@ -61,7 +69,6 @@ jobs:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
             Q_ML2_PLUGIN_EXT_DRIVERS=qos,port_security,dns_domain_keywords
-            enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas ${{ matrix.openstack_version }}
             ${{ matrix.devstack_conf_overrides }}
           enabled_services: 'neutron-dns,neutron-qos,neutron-segments,neutron-trunk,neutron-uplink-status-propagation,neutron-network-segment-range,neutron-port-forwarding'
       - name: Checkout go


### PR DESCRIPTION
neutron-vpnaas recently removed stable/ussuri and stable/train branches.
We now need to use the ussuri-eol and train-eol tags instead when pulling
from the project.