### PR TITLE
Fix skipping not overridden labels uisng '--merge-labels'

### DIFF
--- a/openstack/containerinfra_shared_v1.go
+++ b/openstack/containerinfra_shared_v1.go
@@ -59,7 +59,7 @@ func expandContainerInfraV1LabelsString(v map[string]interface{}) (string, error
 	return formattedLabels, nil
 }
 
-func containerInfraV1GetLabelsMerged(labelsAdded map[string]string, labelsSkipped map[string]string, labelsOverridden map[string]string, labels map[string]string) map[string]string {
+func containerInfraV1GetLabelsMerged(labelsAdded map[string]string, labelsSkipped map[string]string, labelsOverridden map[string]string, labels map[string]string, resourceDataLabels map[string]string) map[string]string {
 	m := make(map[string]string)
 	for key, val := range labelsAdded {
 		m[key] = val
@@ -70,6 +70,12 @@ func containerInfraV1GetLabelsMerged(labelsAdded map[string]string, labelsSkippe
 	for key := range labelsOverridden {
 		// We have to get the actual value here, not the one overridden
 		m[key] = labels[key]
+	}
+	// If defined resource's labels don't override label (are the same)
+	for key, val := range resourceDataLabels {
+		if _, exist := m[key]; !exist {
+			m[key] = val
+		}
 	}
 	return m
 }

--- a/openstack/resource_openstack_containerinfra_cluster_v1.go
+++ b/openstack/resource_openstack_containerinfra_cluster_v1.go
@@ -355,7 +355,11 @@ func resourceContainerInfraClusterV1Read(_ context.Context, d *schema.ResourceDa
 
 	labels := s.Labels
 	if d.Get("merge_labels").(bool) {
-		labels = containerInfraV1GetLabelsMerged(s.LabelsAdded, s.LabelsSkipped, s.LabelsOverridden, s.Labels)
+		resourceDataLabels, err := expandContainerInfraV1LabelsMap(d.Get("labels").(map[string]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		labels = containerInfraV1GetLabelsMerged(s.LabelsAdded, s.LabelsSkipped, s.LabelsOverridden, s.Labels, resourceDataLabels)
 	}
 	if err := d.Set("labels", labels); err != nil {
 		return diag.Errorf("Unable to set openstack_containerinfra_cluster_v1 labels: %s", err)

--- a/openstack/resource_openstack_containerinfra_nodegroup_v1.go
+++ b/openstack/resource_openstack_containerinfra_nodegroup_v1.go
@@ -232,7 +232,11 @@ func resourceContainerInfraNodeGroupV1Read(_ context.Context, d *schema.Resource
 
 	labels := nodeGroup.Labels
 	if d.Get("merge_labels").(bool) {
-		labels = containerInfraV1GetLabelsMerged(nodeGroup.LabelsAdded, nodeGroup.LabelsSkipped, nodeGroup.LabelsOverridden, nodeGroup.Labels)
+		resourceDataLabels, err := expandContainerInfraV1LabelsMap(d.Get("labels").(map[string]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		labels = containerInfraV1GetLabelsMerged(nodeGroup.LabelsAdded, nodeGroup.LabelsSkipped, nodeGroup.LabelsOverridden, nodeGroup.Labels, resourceDataLabels)
 	}
 	if err := d.Set("labels", labels); err != nil {
 		return diag.Errorf("Unable to set openstack_containerinfra_nodegroup_v1 labels: %s", err)


### PR DESCRIPTION
Close #1327

This PR should fix issue when TF try to recreate the existing cluster every time even if there are no changes to the code using '--merge-labels option.