### PR TITLE
Allow settings tags for lb_listener_v2

### DIFF
--- a/openstack/lb_v2_shared.go
+++ b/openstack/lb_v2_shared.go
@@ -189,6 +189,11 @@ func chooseLBV2ListenerCreateOpts(d *schema.ResourceData, config *Config) (neutr
 			opts.TimeoutTCPInspect = &timeoutTCPInspect
 		}
 
+		if v, ok := d.GetOk("tags"); ok {
+			tags := v.(*schema.Set).List()
+			opts.Tags = expandToStringSlice(tags)
+		}
+
 		// Get and check insert  headers map.
 		rawHeaders := d.Get("insert_headers").(map[string]interface{})
 		headers, err := expandLBV2ListenerHeadersMap(rawHeaders)
@@ -336,6 +341,17 @@ func chooseLBV2ListenerUpdateOpts(d *schema.ResourceData, config *Config) (neutr
 				}
 			}
 			opts.AllowedCIDRs = &allowedCidrs
+		}
+
+		if d.HasChange("tags") {
+			hasChange = true
+			if v, ok := d.GetOk("tags"); ok {
+				tags := v.(*schema.Set).List()
+				tagsToUpdate := expandToStringSlice(tags)
+				opts.Tags = &tagsToUpdate
+			} else {
+				opts.Tags = &[]string{}
+			}
 		}
 
 		if hasChange {

--- a/openstack/resource_openstack_lb_listener_v2.go
+++ b/openstack/resource_openstack_lb_listener_v2.go
@@ -141,6 +141,13 @@ func resourceListenerV2() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+
+			"tags": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
 		},
 	}
 }
@@ -223,6 +230,7 @@ func resourceListenerV2Read(ctx context.Context, d *schema.ResourceData, meta in
 		d.Set("default_tls_container_ref", listener.DefaultTlsContainerRef)
 		d.Set("allowed_cidrs", listener.AllowedCIDRs)
 		d.Set("region", GetRegion(d, config))
+		d.Set("tags", listener.Tags)
 
 		// Required by import.
 		if len(listener.Loadbalancers) > 0 {

--- a/openstack/resource_openstack_lb_listener_v2_test.go
+++ b/openstack/resource_openstack_lb_listener_v2_test.go
@@ -28,9 +28,8 @@ func TestAccLBV2Listener_basic(t *testing.T) {
 					testAccCheckLBV2ListenerExists("openstack_lb_listener_v2.listener_1", &listener),
 					resource.TestCheckResourceAttr(
 						"openstack_lb_listener_v2.listener_1", "connection_limit", "-1"),
-					/*testAccCheckLBV2ListenerHasTag("openstack_lb_loadbalancer_v2.loadbalancer_1", "tag1"),
+					testAccCheckLBV2ListenerHasTag("openstack_lb_loadbalancer_v2.loadbalancer_1", "tag1"),
 					testAccCheckLBV2ListenerTagCount("openstack_lb_loadbalancer_v2.loadbalancer_1", 1),
-					*/
 				),
 			},
 			{
@@ -221,10 +220,7 @@ func testAccCheckLBV2ListenerExists(n string, listener *listeners.Listener) reso
 	}
 }
 
-/**
- * gophercloud doesn't return the tags in the structure. Need to fix tghis first.
- */
-/*func testAccCheckLBV2ListenerHasTag(n, tag string) resource.TestCheckFunc {
+func testAccCheckLBV2ListenerHasTag(n, tag string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -259,12 +255,7 @@ func testAccCheckLBV2ListenerExists(n string, listener *listeners.Listener) reso
 		return fmt.Errorf("Tag not found: %s", tag)
 	}
 }
-*/
 
-/**
- * gophercloud doesn't return the tags in the structure. Need to fix tghis first.
- */
-/*
 func testAccCheckLBV2ListenerTagCount(n string, expected int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -298,7 +289,6 @@ func testAccCheckLBV2ListenerTagCount(n string, expected int) resource.TestCheck
 		return nil
 	}
 }
-*/
 
 const testAccLbV2ListenerConfigBasic = `
 resource "openstack_networking_network_v2" "network_1" {

--- a/openstack/resource_openstack_lb_listener_v2_test.go
+++ b/openstack/resource_openstack_lb_listener_v2_test.go
@@ -61,7 +61,7 @@ func TestAccLBV2Listener_octavia(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLBV2ListenerExists("openstack_lb_listener_v2.listener_1", &listener),
 					resource.TestCheckResourceAttr(
-						"openstack_lb_listener_v2.listener_1", "tags", "[\"tag1\"]"),
+						"openstack_lb_listener_v2.listener_1", "tags.#", "1"),
 					resource.TestCheckResourceAttr(
 						"openstack_lb_listener_v2.listener_1", "connection_limit", "5"),
 					resource.TestCheckResourceAttr(
@@ -79,6 +79,8 @@ func TestAccLBV2Listener_octavia(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"openstack_lb_listener_v2.listener_1", "name", "listener_1_updated"),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_listener_v2.listener_1", "tags.#", "2"),
 					resource.TestCheckResourceAttr(
 						"openstack_lb_listener_v2.listener_1", "connection_limit", "100"),
 					resource.TestCheckResourceAttr(
@@ -257,7 +259,6 @@ resource "openstack_lb_listener_v2" "listener_1" {
   protocol_port = 8080
   default_pool_id = "${openstack_lb_pool_v2.pool_1.id}"
   loadbalancer_id = "${openstack_lb_loadbalancer_v2.loadbalancer_1.id}"
-  tags = ["tag1"]
 
   timeouts {
     create = "5m"
@@ -349,6 +350,7 @@ resource "openstack_lb_listener_v2" "listener_1" {
   timeout_tcp_inspect = 4000
   default_pool_id = "${openstack_lb_pool_v2.pool_1.id}"
   loadbalancer_id = "${openstack_lb_loadbalancer_v2.loadbalancer_1.id}"
+  tags = ["tag1"]
 
   timeouts {
     create = "5m"
@@ -401,6 +403,7 @@ resource "openstack_lb_listener_v2" "listener_1" {
   admin_state_up = "true"
   default_pool_id = "${openstack_lb_pool_v2.pool_1.id}"
   loadbalancer_id = "${openstack_lb_loadbalancer_v2.loadbalancer_1.id}"
+  tags = ["tag1", "tag2"]
 
   timeouts {
     create = "5m"

--- a/openstack/resource_openstack_lb_listener_v2_test.go
+++ b/openstack/resource_openstack_lb_listener_v2_test.go
@@ -2,7 +2,6 @@ package openstack
 
 import (
 	"fmt"
-	octavialoadbalancers "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -29,8 +28,9 @@ func TestAccLBV2Listener_basic(t *testing.T) {
 					testAccCheckLBV2ListenerExists("openstack_lb_listener_v2.listener_1", &listener),
 					resource.TestCheckResourceAttr(
 						"openstack_lb_listener_v2.listener_1", "connection_limit", "-1"),
-					testAccCheckLBV2ListenerHasTag("openstack_lb_loadbalancer_v2.loadbalancer_1", "tag1"),
+					/*testAccCheckLBV2ListenerHasTag("openstack_lb_loadbalancer_v2.loadbalancer_1", "tag1"),
 					testAccCheckLBV2ListenerTagCount("openstack_lb_loadbalancer_v2.loadbalancer_1", 1),
+					*/
 				),
 			},
 			{
@@ -221,7 +221,10 @@ func testAccCheckLBV2ListenerExists(n string, listener *listeners.Listener) reso
 	}
 }
 
-func testAccCheckLBV2ListenerHasTag(n, tag string) resource.TestCheckFunc {
+/**
+ * gophercloud doesn't return the tags in the structure. Need to fix tghis first.
+ */
+/*func testAccCheckLBV2ListenerHasTag(n, tag string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -238,7 +241,7 @@ func testAccCheckLBV2ListenerHasTag(n, tag string) resource.TestCheckFunc {
 			return fmt.Errorf("Error creating OpenStack load balancing client: %s", err)
 		}
 
-		found, err := octavialoadbalancers.Get(lbClient, rs.Primary.ID).Extract()
+		found, err := listeners.Get(lbClient, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
@@ -256,7 +259,12 @@ func testAccCheckLBV2ListenerHasTag(n, tag string) resource.TestCheckFunc {
 		return fmt.Errorf("Tag not found: %s", tag)
 	}
 }
+*/
 
+/**
+ * gophercloud doesn't return the tags in the structure. Need to fix tghis first.
+ */
+/*
 func testAccCheckLBV2ListenerTagCount(n string, expected int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -274,7 +282,7 @@ func testAccCheckLBV2ListenerTagCount(n string, expected int) resource.TestCheck
 			return fmt.Errorf("Error creating OpenStack load balancing client: %s", err)
 		}
 
-		found, err := octavialoadbalancers.Get(lbClient, rs.Primary.ID).Extract()
+		found, err := listeners.Get(lbClient, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
@@ -290,6 +298,7 @@ func testAccCheckLBV2ListenerTagCount(n string, expected int) resource.TestCheck
 		return nil
 	}
 }
+*/
 
 const testAccLbV2ListenerConfigBasic = `
 resource "openstack_networking_network_v2" "network_1" {


### PR DESCRIPTION
This allows setting tags for listener when using octavia. 

The change is heavily "inspired" by the tag feature used in the loadbalancer resource and therefore uses the same approach.