### PR TITLE
Change ci user to admin for barbican tests

### DIFF
--- a/openstack/data_source_openstack_keymanager_container_v1_test.go
+++ b/openstack/data_source_openstack_keymanager_container_v1_test.go
@@ -10,7 +10,7 @@ func TestAccKeyManagerContainerV1DataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheckKeyManager(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckContainerV1Destroy,
@@ -36,7 +36,7 @@ func TestAccKeyManagerContainerV1DataSource_acls(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheckKeyManager(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckContainerV1Destroy,

--- a/openstack/data_source_openstack_keymanager_secret_v1_test.go
+++ b/openstack/data_source_openstack_keymanager_secret_v1_test.go
@@ -10,7 +10,7 @@ func TestAccKeyManagerSecretV1DataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheckKeyManager(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckSecretV1Destroy,
@@ -42,7 +42,7 @@ func TestAccKeyManagerSecretV1DataSource_acls(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheckKeyManager(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckSecretV1Destroy,

--- a/openstack/import_openstack_keymanager_container_v1_test.go
+++ b/openstack/import_openstack_keymanager_container_v1_test.go
@@ -12,7 +12,7 @@ func TestAccKeyManagerContainerV1_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 			testAccPreCheckKeyManager(t)
 		},
 		ProviderFactories: testAccProviders,
@@ -36,7 +36,7 @@ func TestAccKeyManagerContainerV1_importACLs(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 			testAccPreCheckKeyManager(t)
 		},
 		ProviderFactories: testAccProviders,

--- a/openstack/import_openstack_keymanager_order_v1_test.go
+++ b/openstack/import_openstack_keymanager_order_v1_test.go
@@ -12,7 +12,7 @@ func TestAccKeyManagerOrderV1_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 			testAccPreCheckKeyManager(t)
 		},
 		ProviderFactories: testAccProviders,

--- a/openstack/import_openstack_keymanager_secret_v1_test.go
+++ b/openstack/import_openstack_keymanager_secret_v1_test.go
@@ -12,7 +12,7 @@ func TestAccKeyManagerSecretV1_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 			testAccPreCheckKeyManager(t)
 		},
 		ProviderFactories: testAccProviders,
@@ -36,7 +36,7 @@ func TestAccKeyManagerSecretV1_importACLs(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 			testAccPreCheckKeyManager(t)
 		},
 		ProviderFactories: testAccProviders,

--- a/openstack/resource_openstack_keymanager_container_v1_test.go
+++ b/openstack/resource_openstack_keymanager_container_v1_test.go
@@ -16,7 +16,7 @@ func TestAccKeyManagerContainerV1_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 			testAccPreCheckKeyManager(t)
 		},
 		ProviderFactories: testAccProviders,
@@ -71,7 +71,7 @@ func TestAccKeyManagerContainerV1_acls(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 			testAccPreCheckKeyManager(t)
 		},
 		ProviderFactories: testAccProviders,
@@ -98,7 +98,7 @@ func TestAccKeyManagerContainerV1_certificate_type(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 			testAccPreCheckKeyManager(t)
 		},
 		ProviderFactories: testAccProviders,
@@ -123,7 +123,7 @@ func TestAccKeyManagerContainerV1_acls_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 			testAccPreCheckKeyManager(t)
 		},
 		ProviderFactories: testAccProviders,

--- a/openstack/resource_openstack_keymanager_order_v1_test.go
+++ b/openstack/resource_openstack_keymanager_order_v1_test.go
@@ -18,7 +18,7 @@ func TestAccKeyManagerOrderV1_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 			testAccPreCheckKeyManager(t)
 		},
 		ProviderFactories: testAccProviders,

--- a/openstack/resource_openstack_keymanager_secret_v1_test.go
+++ b/openstack/resource_openstack_keymanager_secret_v1_test.go
@@ -16,7 +16,7 @@ func TestAccKeyManagerSecretV1_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 			testAccPreCheckKeyManager(t)
 		},
 		ProviderFactories: testAccProviders,
@@ -41,7 +41,7 @@ func TestAccKeyManagerSecretV1_basicWithMetadata(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 			testAccPreCheckKeyManager(t)
 		},
 		ProviderFactories: testAccProviders,
@@ -65,7 +65,7 @@ func TestAccKeyManagerSecretV1_updateMetadata(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 			testAccPreCheckKeyManager(t)
 		},
 		ProviderFactories: testAccProviders,
@@ -100,7 +100,7 @@ func TestAccUpdateSecretV1_payload(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 			testAccPreCheckKeyManager(t)
 		},
 		ProviderFactories: testAccProviders,
@@ -155,7 +155,7 @@ func TestAccKeyManagerSecretV1_acls(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 			testAccPreCheckKeyManager(t)
 		},
 		ProviderFactories: testAccProviders,
@@ -183,7 +183,7 @@ func TestAccKeyManagerSecretV1_acls_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 			testAccPreCheckKeyManager(t)
 		},
 		ProviderFactories: testAccProviders,


### PR DESCRIPTION
Barbican has changed his default policies. Need to update
the user used in ci tests.

Close #1433 