### PR TITLE
Fix openstack_db_configuration_v1 type mismatch for bool and string type

### DIFF
--- a/openstack/db_configuration_v1.go
+++ b/openstack/db_configuration_v1.go
@@ -26,10 +26,16 @@ func expandDatabaseConfigurationV1Values(rawValues []interface{}) map[string]int
 		v := rawValue.(map[string]interface{})
 		name := v["name"].(string)
 		value := v["value"]
+		isStringType := v["string_type"].(bool)
 
-		// check if value can be converted into int
-		if valueInt, err := strconv.Atoi(value.(string)); err == nil {
-			value = valueInt
+		if !isStringType {
+			// check if value can be converted into int
+			if valueInt, err := strconv.Atoi(value.(string)); err == nil {
+				value = valueInt
+				// check if value can be converted into bool
+			} else if valueBool, err := strconv.ParseBool(value.(string)); err == nil {
+				value = valueBool
+			}
 		}
 
 		values[name] = value

--- a/openstack/resource_openstack_db_configuration_v1.go
+++ b/openstack/resource_openstack_db_configuration_v1.go
@@ -80,6 +80,11 @@ func resourceDatabaseConfigurationV1() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
+						"string_type": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+						},
 					},
 				},
 			},

--- a/website/docs/r/db_configuration_v1.html.markdown
+++ b/website/docs/r/db_configuration_v1.html.markdown
@@ -56,6 +56,7 @@ The `configuration` block supports:
 
 * `name` - (Optional) Configuration parameter name. Changing this creates a new resource.
 * `value` - (Optional) Configuration parameter value. Changing this creates a new resource.
+* `string_type` - (Optional) Whether or not to store configuration parameter value as string. Changing this creates a new resource. See the below note for more information.
 
 
 ## Attributes Reference
@@ -69,3 +70,12 @@ The following attributes are exported:
 * `datastore/version` - See Argument Reference above.
 * `configuration/name` - See Argument Reference above.
 * `configuration/value` - See Argument Reference above.
+* `configuration/string_type` - See Argument Reference above.
+
+## Types of configuration parameter values
+
+Openstack API requires to store some database configuration parameter's values as strings, even if they contain numbers.
+To force store their values as strings set `string_type` to `true`. Otherwise Terraform will try to store them as number what can cause error from Openstack API like below:
+```
+"The value provided for the configuration parameter log_min_duration_statement is not of type string."
+```


### PR DESCRIPTION
Close #776 

Add parameter's value conversion to bool type and new parameter that allows store parameter's value as string.