### PR TITLE
Add service types to subnet resource and data source

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-provider-openstack/terraform-provider-openstack
 go 1.17
 
 require (
-	github.com/gophercloud/gophercloud v1.0.1-0.20220908162354-a75271e0e3ad
+	github.com/gophercloud/gophercloud v1.0.1-0.20220927110532-5c912b0995dc
 	github.com/gophercloud/utils v0.0.0-20220307143606-8e7800759d16
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.17.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/gophercloud/gophercloud v0.25.0 h1:C3Oae7y0fUVQGSsBrb3zliAjdX+riCSEh4
 github.com/gophercloud/gophercloud v0.25.0/go.mod h1:Q8fZtyi5zZxPS/j9aj3sSxtvj41AdQMDwyo1myduD5c=
 github.com/gophercloud/gophercloud v1.0.1-0.20220908162354-a75271e0e3ad h1:SJD7B4bV7RveZya0Lp3zRagOlC8B47xTgZ91/OhLQ7c=
 github.com/gophercloud/gophercloud v1.0.1-0.20220908162354-a75271e0e3ad/go.mod h1:Q8fZtyi5zZxPS/j9aj3sSxtvj41AdQMDwyo1myduD5c=
+github.com/gophercloud/gophercloud v1.0.1-0.20220927110532-5c912b0995dc h1:sP3Vvq6K7Ql2HjD5svT9q5GfzvIbwSuAYhECS/ktLxU=
+github.com/gophercloud/gophercloud v1.0.1-0.20220927110532-5c912b0995dc/go.mod h1:Q8fZtyi5zZxPS/j9aj3sSxtvj41AdQMDwyo1myduD5c=
 github.com/gophercloud/utils v0.0.0-20220307143606-8e7800759d16 h1:slt/exMiitZNY+5OrKJ6ZvSogqN+SyzeYzAtyI6db9A=
 github.com/gophercloud/utils v0.0.0-20220307143606-8e7800759d16/go.mod h1:qOGlfG6OIJ193/c3Xt/XjOfHataNZdQcVgiu93LxBUM=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=

--- a/openstack/data_source_openstack_networking_subnet_v2.go
+++ b/openstack/data_source_openstack_networking_subnet_v2.go
@@ -116,6 +116,12 @@ func dataSourceNetworkingSubnetV2() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
+			"service_types": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
 			"host_routes": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -283,6 +289,10 @@ func dataSourceNetworkingSubnetV2Read(ctx context.Context, d *schema.ResourceDat
 
 	if err := d.Set("dns_nameservers", subnet.DNSNameservers); err != nil {
 		log.Printf("[DEBUG] Unable to set openstack_networking_subnet_v2 dns_nameservers: %s", err)
+	}
+
+	if err := d.Set("service_types", subnet.ServiceTypes); err != nil {
+		log.Printf("[DEBUG] Unable to set openstack_networking_subnet_v2 service_types: %s", err)
 	}
 
 	if err := d.Set("host_routes", subnet.HostRoutes); err != nil {

--- a/openstack/resource_openstack_networking_subnet_v2.go
+++ b/openstack/resource_openstack_networking_subnet_v2.go
@@ -218,6 +218,14 @@ func resourceNetworkingSubnetV2() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
+			"service_types": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
 			"all_tags": {
 				Type:     schema.TypeSet,
 				Computed: true,
@@ -260,6 +268,7 @@ func resourceNetworkingSubnetV2Create(ctx context.Context, d *schema.ResourceDat
 			IPv6RAMode:      d.Get("ipv6_ra_mode").(string),
 			AllocationPools: expandNetworkingSubnetV2AllocationPools(allocationPool),
 			DNSNameservers:  expandToStringSlice(d.Get("dns_nameservers").([]interface{})),
+			ServiceTypes:    expandToStringSlice(d.Get("service_types").([]interface{})),
 			HostRoutes:      expandNetworkingSubnetV2HostRoutes(d.Get("host_routes").([]interface{})),
 			SubnetPoolID:    d.Get("subnetpool_id").(string),
 			IPVersion:       gophercloud.IPVersion(d.Get("ip_version").(int)),
@@ -362,6 +371,7 @@ func resourceNetworkingSubnetV2Read(ctx context.Context, d *schema.ResourceData,
 	d.Set("description", s.Description)
 	d.Set("tenant_id", s.TenantID)
 	d.Set("dns_nameservers", s.DNSNameservers)
+	d.Set("service_types", s.ServiceTypes)
 	d.Set("enable_dhcp", s.EnableDHCP)
 	d.Set("network_id", s.NetworkID)
 	d.Set("ipv6_address_mode", s.IPv6AddressMode)
@@ -439,6 +449,12 @@ func resourceNetworkingSubnetV2Update(ctx context.Context, d *schema.ResourceDat
 		hasChange = true
 		nameservers := expandToStringSlice(d.Get("dns_nameservers").([]interface{}))
 		updateOpts.DNSNameservers = &nameservers
+	}
+
+	if d.HasChange("service_types") {
+		hasChange = true
+		serviceTypes := expandToStringSlice(d.Get("service_types").([]interface{}))
+		updateOpts.ServiceTypes = &serviceTypes
 	}
 
 	if d.HasChange("host_routes") {

--- a/website/docs/d/networking_subnet_v2.html.markdown
+++ b/website/docs/d/networking_subnet_v2.html.markdown
@@ -60,6 +60,7 @@ are exported:
 * `allocation_pools` - Allocation pools of the subnet.
 * `enable_dhcp` - Whether the subnet has DHCP enabled or not.
 * `dns_nameservers` - DNS Nameservers of the subnet.
+* `service_types` - Service types of the subnet.
 * `host_routes` - Host Routes of the subnet.
 * `region` - See Argument Reference above.
 * `all_tags` - A set of string tags applied on the subnet.

--- a/website/docs/r/networking_subnet_v2.html.markdown
+++ b/website/docs/r/networking_subnet_v2.html.markdown
@@ -91,6 +91,9 @@ The following arguments are supported:
     in this subnet. Changing this updates the DNS name servers for the existing
     subnet.
 
+* `service_types` - (Optional) An array of service types used by the subnet.
+    Changing this updates the service types for the existing subnet.
+
 * `host_routes` - (**Deprecated** - use `openstack_networking_subnet_route_v2`
     instead) An array of routes that should be used by devices
     with IPs from this subnet (not including local subnet route). The host_route
@@ -136,6 +139,7 @@ The following attributes are exported:
 * `gateway_ip` - See Argument Reference above.
 * `enable_dhcp` - See Argument Reference above.
 * `dns_nameservers` - See Argument Reference above.
+* `service_types` - See Argument Reference above.
 * `host_routes` - See Argument Reference above.
 * `subnetpool_id` - See Argument Reference above.
 * `tags` - See Argument Reference above.


### PR DESCRIPTION
Bump gophercloud version to include support for this. Update both the subnet resource and the data source to support using service types.

close #1443 