### PR TITLE
Update ci to include Openstack Zed

### DIFF
--- a/.github/workflows/functional-blockstorage_v3.yml
+++ b/.github/workflows/functional-blockstorage_v3.yml
@@ -23,6 +23,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"        
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
@@ -32,15 +35,6 @@ jobs:
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
-          - name: "victoria"
-            openstack_version: "stable/victoria"
-            ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: blockstorage_v3 on OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests
     steps:

--- a/.github/workflows/functional-compute.yml
+++ b/.github/workflows/functional-compute.yml
@@ -21,6 +21,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"        
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
@@ -30,15 +33,6 @@ jobs:
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
-          - name: "victoria"
-            openstack_version: "stable/victoria"
-            ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: compute on OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests
     steps:

--- a/.github/workflows/functional-dns.yml
+++ b/.github/workflows/functional-dns.yml
@@ -20,6 +20,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
@@ -29,15 +32,6 @@ jobs:
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
-          - name: "victoria"
-            openstack_version: "stable/victoria"
-            ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: dns on OpenStack ${{ matrix.name }} with Designate and run dns acceptance tests
     steps:

--- a/.github/workflows/functional-identity.yml
+++ b/.github/workflows/functional-identity.yml
@@ -21,6 +21,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"        
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
@@ -30,15 +33,6 @@ jobs:
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
-          - name: "victoria"
-            openstack_version: "stable/victoria"
-            ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: identity on OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests
     steps:

--- a/.github/workflows/functional-images.yml
+++ b/.github/workflows/functional-images.yml
@@ -21,6 +21,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"        
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
@@ -30,15 +33,6 @@ jobs:
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
-          - name: "victoria"
-            openstack_version: "stable/victoria"
-            ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: images/glance on OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests
     steps:

--- a/.github/workflows/functional-keymanager.yml
+++ b/.github/workflows/functional-keymanager.yml
@@ -23,6 +23,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"        
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"

--- a/.github/workflows/functional-loadbalancer.yml
+++ b/.github/workflows/functional-loadbalancer.yml
@@ -20,6 +20,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
@@ -29,15 +32,6 @@ jobs:
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
-          - name: "victoria"
-            openstack_version: "stable/victoria"
-            ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: loadbalancing for OpenStack ${{ matrix.name }} with Octavia and run loadbalancer acceptance tests
     steps:

--- a/.github/workflows/functional-networking.yml
+++ b/.github/workflows/functional-networking.yml
@@ -20,38 +20,19 @@ jobs:
         name: ["master"]
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
-        devstack_conf_overrides: ["enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing master"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"         
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/yoga
           - name: "xena"
             openstack_version: "stable/xena"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/xena
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/wallaby
-          - name: "victoria"
-            openstack_version: "stable/victoria"
-            ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/victoria
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/ussuri
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing train-eol
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: networking on OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests
     steps:
@@ -63,7 +44,7 @@ jobs:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
             Q_ML2_PLUGIN_EXT_DRIVERS=qos,port_security,dns_domain_keywords
-            ${{ matrix.devstack_conf_overrides }}
+            enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing ${{ matrix.openstack_version }}
           enabled_services: 'neutron-dhcp,neutron-dns,neutron-qos,neutron-segments,neutron-trunk,neutron-uplink-status-propagation,neutron-network-segment-range,neutron-port-forwarding'
       - name: Checkout go
         uses: actions/setup-go@v3

--- a/.github/workflows/functional-objectstorage.yml
+++ b/.github/workflows/functional-objectstorage.yml
@@ -20,6 +20,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"        
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
@@ -29,15 +32,6 @@ jobs:
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
-          - name: "victoria"
-            openstack_version: "stable/victoria"
-            ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: objectstorage OpenStack ${{ matrix.name }} with Swift and run objectstorage acceptance tests
     steps:

--- a/.github/workflows/functional-orchestration.yml
+++ b/.github/workflows/functional-orchestration.yml
@@ -20,6 +20,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"        
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
@@ -29,15 +32,6 @@ jobs:
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
-          - name: "victoria"
-            openstack_version: "stable/victoria"
-            ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Heat and run orchestration acceptance tests
     steps:

--- a/.github/workflows/functional-sharedfilesystem.yml
+++ b/.github/workflows/functional-sharedfilesystem.yml
@@ -20,6 +20,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["20.04"]
         include:
+          - name: "zed"
+            openstack_version: "stable/zed"
+            ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
@@ -29,15 +32,6 @@ jobs:
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
-          - name: "victoria"
-            openstack_version: "stable/victoria"
-            ubuntu_version: "20.04"
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: sharedfilesystem on OpenStack ${{ matrix.name }} with Manila and run sharedfilesystem acceptance tests
     steps:

--- a/.github/workflows/functional-vpnaas.yml
+++ b/.github/workflows/functional-vpnaas.yml
@@ -16,49 +16,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        name: ["master"]
+        openstack_version: ["master"]
+        ubuntu_version: ["20.04"]      
         include:
-          - name: "master"
-            openstack_version: "master"
+          - name: "zed"
+            openstack_version: "stable/zed"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing master
-              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas master
           - name: "yoga"
             openstack_version: "stable/yoga"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/yoga
-              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas stable/yoga
           - name: "xena"
             openstack_version: "stable/xena"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/xena
-              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas stable/xena
           - name: "wallaby"
             openstack_version: "stable/wallaby"
             ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/wallaby
-              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas stable/wallaby
-          - name: "victoria"
-            openstack_version: "stable/victoria"
-            ubuntu_version: "20.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/victoria
-              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas stable/victoria
-          - name: "ussuri"
-            openstack_version: "stable/ussuri"
-            ubuntu_version: "18.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing stable/ussuri
-              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas ussuri-eol
-          - name: "train"
-            openstack_version: "stable/train"
-            ubuntu_version: "18.04"
-            devstack_conf_overrides: |
-              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing train-eol
-              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas train-eol
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Neutron and run vpnaas acceptance tests
     steps:
@@ -70,6 +43,8 @@ jobs:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
             Q_ML2_PLUGIN_EXT_DRIVERS=qos,port_security,dns_domain_keywords
+              enable_plugin neutron-dynamic-routing https://opendev.org/openstack/neutron-dynamic-routing ${{ matrix.openstack_version }}
+              enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas ${{ matrix.openstack_version }}           
             ${{ matrix.devstack_conf_overrides }}
           enabled_services: 'neutron-dns,neutron-qos,neutron-segments,neutron-trunk,neutron-uplink-status-propagation,neutron-network-segment-range,neutron-port-forwarding'
       - name: Checkout go


### PR DESCRIPTION
Openstack Zed was released recently. Update all workflows to test the Zed version as well. Moreover, decrease the tested versions from master + 6 latest to master + 4 latest. This gives a wide enough testing while at the same type simplifies ci and minimizes various deprecations.