### PR TITLE
Set terraform version on acceptance tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,7 +14,7 @@ test: fmtcheck
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+	TF_ACC=1 TF_ACC_TERRAFORM_VERSION=1.2.9 go test $(TEST) -v $(TESTARGS) -timeout 120m
 
 vet:
 	@echo "go vet ."


### PR DESCRIPTION
Acceptance tests for imports where a data source is used are failing
in terraform >= 1.3.X. Pin tf version to 1.2.9 till a fix is introduced
upstream.

RelatesTo: #1449