### PR TITLE
Set terraform version on acceptance tests scripts

### DIFF
--- a/.github/workflows/functional-blockstorage_v3.yml
+++ b/.github/workflows/functional-blockstorage_v3.yml
@@ -11,6 +11,7 @@ on:
       - '!**v2**'
       - '!**v1**'
       - 'CHANGELOG.md'
+      - 'scripts/*'
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/.github/workflows/functional-compute.yml
+++ b/.github/workflows/functional-compute.yml
@@ -9,6 +9,7 @@ on:
       - '.github/workflows/functional-compute.yml'
       - '**compute**'
       - 'CHANGELOG.md'
+      - 'scripts/*'      
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/.github/workflows/functional-dns.yml
+++ b/.github/workflows/functional-dns.yml
@@ -8,6 +8,7 @@ on:
       - '.github/workflows/functional-dns.yml'
       - '**dns**'
       - 'CHANGELOG.md'
+      - 'scripts/*'
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/.github/workflows/functional-identity.yml
+++ b/.github/workflows/functional-identity.yml
@@ -9,6 +9,7 @@ on:
       - '.github/workflows/functional-identity.yml'
       - '**identity**'
       - 'CHANGELOG.md'
+      - 'scripts/*'
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/.github/workflows/functional-images.yml
+++ b/.github/workflows/functional-images.yml
@@ -9,6 +9,7 @@ on:
       - '.github/workflows/functional-images.yml'
       - '**images**'
       - 'CHANGELOG.md'
+      - 'scripts/*'
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/.github/workflows/functional-keymanager.yml
+++ b/.github/workflows/functional-keymanager.yml
@@ -11,6 +11,7 @@ on:
       - '.github/workflows/functional-keymanager.yml'
       - '**keymanager**'
       - 'CHANGELOG.md'
+      - 'scripts/*'
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/.github/workflows/functional-loadbalancer.yml
+++ b/.github/workflows/functional-loadbalancer.yml
@@ -8,6 +8,7 @@ on:
       - '.github/workflows/functional-loadbalancer.yml'
       - '**_lb_**'
       - 'CHANGELOG.md'
+      - 'scripts/*'
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/.github/workflows/functional-networking.yml
+++ b/.github/workflows/functional-networking.yml
@@ -9,6 +9,7 @@ on:
       - '.github/workflows/functional-networking.yml'
       - '**networking**'
       - 'CHANGELOG.md'
+      - 'scripts/*'
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/.github/workflows/functional-objectstorage.yml
+++ b/.github/workflows/functional-objectstorage.yml
@@ -8,6 +8,7 @@ on:
       - '.github/workflows/functional-objectstorage.yml'
       - '**objectstorage**'
       - 'CHANGELOG.md'
+      - 'scripts/*'
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/.github/workflows/functional-orchestration.yml
+++ b/.github/workflows/functional-orchestration.yml
@@ -8,6 +8,7 @@ on:
       - '.github/workflows/functional-orchestration.yml'
       - '**orchestration**'
       - 'CHANGELOG.md'
+      - 'scripts/*'
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/.github/workflows/functional-sharedfilesystem.yml
+++ b/.github/workflows/functional-sharedfilesystem.yml
@@ -8,6 +8,7 @@ on:
       - '.github/workflows/functional-sharedfilesystem.yml'
       - '**sharedfilesystem**'
       - 'CHANGELOG.md'
+      - 'scripts/*'
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/.github/workflows/functional-vpnaas.yml
+++ b/.github/workflows/functional-vpnaas.yml
@@ -8,6 +8,7 @@ on:
       - '.github/workflows/functional-vpnaas.yml'
       - '**vpnaas**'
       - 'CHANGELOG.md'
+      - 'scripts/*'
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/scripts/acceptancetest.sh
+++ b/scripts/acceptancetest.sh
@@ -25,7 +25,7 @@ fi
 source `dirname $0`/stackenv.sh admin
 
 for acceptance_test in "${ACCEPTANCE_TESTS[@]}"; do
-  OS_DEBUG=1 TF_LOG=DEBUG TF_ACC=1 go test ./openstack -v -timeout 120m -run $(echo "$acceptance_test" | tr " " "|") |& tee -a ${LOG_DIR}/acceptance_tests.log
+  OS_DEBUG=1 TF_LOG=DEBUG TF_ACC=1 TF_ACC_TERRAFORM_VERSION=1.2.9 go test ./openstack -v -timeout 120m -run $(echo "$acceptance_test" | tr " " "|") |& tee -a ${LOG_DIR}/acceptance_tests.log
   # Check the error code after each suite, but do not exit early if a suite failed.
   if [[ $? != 0 ]]; then
     failed=1
@@ -36,7 +36,7 @@ done
 source `dirname $0`/stackenv.sh demo
 
 for acceptance_test in "${ACCEPTANCE_TESTS[@]}"; do
-  OS_DEBUG=1 TF_LOG=DEBUG TF_ACC=1 go test ./openstack -v -timeout 120m -run $(echo "$acceptance_test" | tr " " "|") |& tee -a ${LOG_DIR}/acceptance_tests.log
+  OS_DEBUG=1 TF_LOG=DEBUG TF_ACC=1 TF_ACC_TERRAFORM_VERSION=1.2.9 go test ./openstack -v -timeout 120m -run $(echo "$acceptance_test" | tr " " "|") |& tee -a ${LOG_DIR}/acceptance_tests.log
   # Check the error code after each suite, but do not exit early if a suite failed.
   if [[ $? != 0 ]]; then
     failed=1


### PR DESCRIPTION
TF version was not set on the script that is used for the ci. Additionally, set trigger for workflows when ci related scripts
are updated. Related to: #1449