### PR TITLE
Update various github actions to avoid deprecations

### DIFF
--- a/.github/workflows/functional-blockstorage_v2.yml
+++ b/.github/workflows/functional-blockstorage_v2.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout TPO
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.7
+        uses: EmilienM/devstack-action@v0.9
         with:
           branch: ${{ matrix.openstack_version }}
           enabled_services: 's-account,s-container,s-object,s-proxy'

--- a/.github/workflows/functional-blockstorage_v3.yml
+++ b/.github/workflows/functional-blockstorage_v3.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout TPO
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.7
+        uses: EmilienM/devstack-action@v0.9
         with:
           branch: ${{ matrix.openstack_version }}
           enabled_services: 's-account,s-container,s-object,s-proxy'

--- a/.github/workflows/functional-compute.yml
+++ b/.github/workflows/functional-compute.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout TPO
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.7
+        uses: EmilienM/devstack-action@v0.9
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-dns.yml
+++ b/.github/workflows/functional-dns.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout TPO
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.7
+        uses: EmilienM/devstack-action@v0.9
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-identity.yml
+++ b/.github/workflows/functional-identity.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout TPO
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.7
+        uses: EmilienM/devstack-action@v0.9
         with:
           branch: ${{ matrix.openstack_version }}
           enabled_services: 's-account,s-container,s-object,s-proxy'

--- a/.github/workflows/functional-images.yml
+++ b/.github/workflows/functional-images.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout TPO
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.7
+        uses: EmilienM/devstack-action@v0.9
         with:
           branch: ${{ matrix.openstack_version }}
           enabled_services: 's-account,s-container,s-object,s-proxy'

--- a/.github/workflows/functional-keymanager.yml
+++ b/.github/workflows/functional-keymanager.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout TPO
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.7
+        uses: EmilienM/devstack-action@v0.9
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-loadbalancer.yml
+++ b/.github/workflows/functional-loadbalancer.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout TPO
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.7
+        uses: EmilienM/devstack-action@v0.9
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-networking.yml
+++ b/.github/workflows/functional-networking.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout TPO
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.7
+        uses: EmilienM/devstack-action@v0.9
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-objectstorage.yml
+++ b/.github/workflows/functional-objectstorage.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Gophercloud
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.7
+        uses: EmilienM/devstack-action@v0.9
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-orchestration.yml
+++ b/.github/workflows/functional-orchestration.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout TPO
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.7
+        uses: EmilienM/devstack-action@v0.9
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-sharedfilesystem.yml
+++ b/.github/workflows/functional-sharedfilesystem.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout TPO
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.7
+        uses: EmilienM/devstack-action@v0.9
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/functional-vpnaas.yml
+++ b/.github/workflows/functional-vpnaas.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout TPO
         uses: actions/checkout@v3
       - name: Deploy devstack
-        uses: EmilienM/devstack-action@v0.7
+        uses: EmilienM/devstack-action@v0.9
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,25 +15,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Unshallow
         run: git fetch --prune --unshallow
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.17
 
       - name: Import GPG key
         id: import_gpg
-        uses: paultyng/ghaction-import-gpg@v2.1.0
+        uses: crazy-max/ghaction-import-gpg@v5.2.0
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
           args: release --rm-dist


### PR DESCRIPTION
Various actions need to be update to avoid deprecations due to using node12 => More info here:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12