### PR TITLE
Fix update of containerinfra cluster template's labels

### DIFF
--- a/openstack/containerinfra_shared_v1.go
+++ b/openstack/containerinfra_shared_v1.go
@@ -51,12 +51,12 @@ func expandContainerInfraV1LabelsString(v map[string]interface{}) (string, error
 		}
 		formattedLabels = strings.Join([]string{
 			formattedLabels,
-			fmt.Sprintf("%s=%s", key, labelValue),
+			fmt.Sprintf("'%s':'%s'", key, labelValue),
 		}, ",")
 	}
 	formattedLabels = strings.Trim(formattedLabels, ",")
 
-	return formattedLabels, nil
+	return fmt.Sprintf("{%s}", formattedLabels), nil
 }
 
 func containerInfraV1GetLabelsMerged(labelsAdded map[string]string, labelsSkipped map[string]string, labelsOverridden map[string]string, labels map[string]string, resourceDataLabels map[string]string) map[string]string {

--- a/openstack/containerinfra_shared_v1_test.go
+++ b/openstack/containerinfra_shared_v1_test.go
@@ -30,8 +30,8 @@ func TestExpandContainerInfraV1LabelsString(t *testing.T) {
 		"bar": "baz",
 	}
 
-	expectedLabels1 := "foo=bar,bar=baz"
-	expectedLabels2 := "bar=baz,foo=bar"
+	expectedLabels1 := "{'foo':'bar','bar':'baz'}"
+	expectedLabels2 := "{'bar':'baz','foo':'bar'}"
 
 	actualLabels, err := expandContainerInfraV1LabelsString(labels)
 	assert.Equal(t, err, nil)


### PR DESCRIPTION
This PR fixes errors while updating cluster template's labels.

Current data format (request body) send to Magnum API
```
[
  {
    "op": "replace",
    "path": "/labels",
    "value": "boot_volume_size=5"
  }
]
```
causes error (respond body) like below
```
{
	"errors": [{
			"request_id": "",
			"code": "client",
			"status": 400,
			"title": "Couldn't apply patch '[{'path': '/labels', 'op': 'replace', 'value': 'boot_volume_size=5",
			"detail": "Couldn't apply patch '[{'path': '/labels', 'op': 'replace', 'value': 'boot_volume_size=5'}]'. Reason: invalid syntax (<unknown>, line 1)",
			"links": []
		}
	]
}
```
Valid data format:
```
[
  {
    "op": "replace",
    "path": "/labels",
    "value": "{'boot_volume_size':'5'}"
  }
]
```