### PR TITLE
Fixed markdown syntax

### DIFF
--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -757,7 +757,7 @@ resource "openstack_compute_instance_v2" "boot-from-volume" {
   name            = "boot-from-volume"
   flavor_id       = "<flavor_id"
   key_pair        = "<keyname>"
-  image_id        = <image_id>
+  image_id        = "<image_id>"
   security_groups = ["default"]
 
   network {

--- a/website/docs/r/networking_network_v2.html.markdown
+++ b/website/docs/r/networking_network_v2.html.markdown
@@ -44,8 +44,8 @@ resource "openstack_networking_port_v2" "port_1" {
   security_group_ids = ["${openstack_compute_secgroup_v2.secgroup_1.id}"]
 
   fixed_ip {
-    "subnet_id"  = "${openstack_networking_subnet_v2.subnet_1.id}"
-    "ip_address" = "192.168.199.10"
+    subnet_id  = "${openstack_networking_subnet_v2.subnet_1.id}"
+    ip_address = "192.168.199.10"
   }
 }
 


### PR DESCRIPTION
The upbound tool named "scrape" (used in the process of generating a crossplane provider from the terraform provider) was failing when trying to convert markdown to JSON

In the case of `website/docs/r/compute_instance_v2.html.markdown`, this was the error: 
```example.hcl:5,21-22: Invalid expression; Expected the start of an expression, but found an invalid expression token.```

In the case of `website/docs/r/networking_network_v2.html.markdown` the error was:
```example.hcl:32,5-6: Invalid argument name; Argument names must not be quoted.```

Hence the fixes.