### PR TITLE
Implement rule for openstack_networking_secgroup_v2

### DIFF
--- a/openstack/networking_secgroup_v2.go
+++ b/openstack/networking_secgroup_v2.go
@@ -1,12 +1,18 @@
 package openstack
 
 import (
+	"bytes"
+	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
+	"github.com/gophercloud/utils/terraform/hashcode"
 )
 
 // networkingSecgroupV2StateRefreshFuncDelete returns a special case resource.StateRefreshFunc to try to delete a secgroup.
@@ -40,5 +46,150 @@ func networkingSecgroupV2StateRefreshFuncDelete(networkingClient *gophercloud.Se
 		log.Printf("[DEBUG] openstack_networking_secgroup_v2 %s is still active", id)
 
 		return r, "ACTIVE", nil
+	}
+}
+
+func networkingSecgroupV2RuleHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+
+	buf.WriteString(fmt.Sprintf("%s-", m["description"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", m["direction"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", m["ethertype"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", m["protocol"].(string)))
+	buf.WriteString(fmt.Sprintf("%d-", m["port_range_min"].(int)))
+	buf.WriteString(fmt.Sprintf("%d-", m["port_range_max"].(int)))
+	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["remote_ip_prefix"].(string))))
+	buf.WriteString(fmt.Sprintf("%s-", m["remote_group_id"].(string)))
+	buf.WriteString(fmt.Sprintf("%t-", m["self"].(bool)))
+
+	return hashcode.String(buf.String())
+}
+
+func networkingSecgroupV2RulesCheckForErrors(d *schema.ResourceData) error {
+	rawRules := d.Get("rule").(*schema.Set).List()
+
+	for _, rawRule := range rawRules {
+		rawRuleMap := rawRule.(map[string]interface{})
+
+		// only one of cidr, from_group_id, or self can be set
+		remoteIPPrefix := rawRuleMap["remote_ip_prefix"].(string)
+		remoteGroupID := rawRuleMap["remote_group_id"].(string)
+		self := rawRuleMap["self"].(bool)
+		errorMessage := fmt.Errorf("Only one of remote_ip_prefix, remote_group_id, or self can be set")
+
+		// if remote_ip_prefix is set, remote_group_id and self cannot be set
+		if remoteIPPrefix != "" {
+			if remoteGroupID != "" || self {
+				return errorMessage
+			}
+		}
+
+		// if remote_group_id is set, remote_ip_prefix and self cannot be set
+		if remoteGroupID != "" {
+			if remoteIPPrefix != "" || self {
+				return errorMessage
+			}
+		}
+
+		// if self is set, remote_ip_prefix and remote_group_id cannot be set
+		if self {
+			if remoteIPPrefix != "" || remoteGroupID != "" {
+				return errorMessage
+			}
+		}
+	}
+
+	return nil
+}
+
+func expandNetworkingSecgroupV2CreateRules(d *schema.ResourceData) ([]rules.CreateOpts, error) {
+	rawRules := d.Get("rule").(*schema.Set).List()
+	createRuleOptsList := make([]rules.CreateOpts, len(rawRules))
+
+	for i, rawRule := range rawRules {
+		rule, err := expandNetworkingSecgroupV2CreateRule(d, rawRule)
+		if err != nil {
+			return []rules.CreateOpts{}, err
+		}
+		createRuleOptsList[i] = rule
+	}
+
+	return createRuleOptsList, nil
+}
+
+func expandNetworkingSecgroupV2CreateRule(d *schema.ResourceData, rawRule interface{}) (rules.CreateOpts, error) {
+	rawRuleMap := rawRule.(map[string]interface{})
+	remoteGroupID := rawRuleMap["remote_group_id"].(string)
+	if rawRuleMap["self"].(bool) {
+		remoteGroupID = d.Id()
+	}
+
+	protocol, err := resourceNetworkingSecGroupRuleV2Protocol(rawRuleMap["protocol"].(string))
+	if err != nil {
+		return rules.CreateOpts{}, err
+	}
+
+	direction, err := resourceNetworkingSecGroupRuleV2Direction(rawRuleMap["direction"].(string))
+	if err != nil {
+		return rules.CreateOpts{}, err
+	}
+
+	ethertype, err := resourceNetworkingSecGroupRuleV2EtherType(rawRuleMap["ethertype"].(string))
+	if err != nil {
+		return rules.CreateOpts{}, err
+	}
+
+	return rules.CreateOpts{
+		SecGroupID:     d.Id(),
+		Description:    rawRuleMap["description"].(string),
+		Direction:      direction,
+		EtherType:      ethertype,
+		Protocol:       protocol,
+		PortRangeMin:   rawRuleMap["port_range_min"].(int),
+		PortRangeMax:   rawRuleMap["port_range_max"].(int),
+		RemoteIPPrefix: rawRuleMap["remote_ip_prefix"].(string),
+		RemoteGroupID:  remoteGroupID,
+	}, nil
+}
+
+func flattenNetworkingSecgroupV2Rules(computeClient *gophercloud.ServiceClient, d *schema.ResourceData, sgrs []rules.SecGroupRule) ([]map[string]interface{}, error) {
+	sgrMap := make([]map[string]interface{}, len(sgrs))
+	for i, sgr := range sgrs {
+		self := false
+
+		if sgr.RemoteGroupID == d.Id() {
+			self = true
+		}
+
+		sgrMap[i] = map[string]interface{}{
+			"id":               sgr.ID,
+			"description":      sgr.Description,
+			"direction":        sgr.Direction,
+			"ethertype":        sgr.EtherType,
+			"protocol":         sgr.Protocol,
+			"port_range_min":   sgr.PortRangeMin,
+			"port_range_max":   sgr.PortRangeMax,
+			"remote_ip_prefix": sgr.RemoteIPPrefix,
+			"remote_group_id":  sgr.RemoteGroupID,
+			"self":             self,
+		}
+	}
+	return sgrMap, nil
+}
+
+func expandNetworkingSecgroupV2Rule(d *schema.ResourceData, rawRule interface{}) rules.SecGroupRule {
+	rawRuleMap := rawRule.(map[string]interface{})
+
+	return rules.SecGroupRule{
+		ID:             rawRuleMap["id"].(string),
+		SecGroupID:     d.Id(),
+		Description:    rawRuleMap["description"].(string),
+		Direction:      rawRuleMap["direction"].(string),
+		EtherType:      rawRuleMap["ethertype"].(string),
+		PortRangeMin:   rawRuleMap["port_range_min"].(int),
+		PortRangeMax:   rawRuleMap["port_range_max"].(int),
+		RemoteIPPrefix: rawRuleMap["remote_ip_prefix"].(string),
+		RemoteGroupID:  rawRuleMap["remote_group_id"].(string),
 	}
 }

--- a/openstack/networking_secgroup_v2_test.go
+++ b/openstack/networking_secgroup_v2_test.go
@@ -1,0 +1,103 @@
+package openstack
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
+)
+
+func TestExpandNetworkingSecgroupV2CreateRules(t *testing.T) {
+	r := resourceNetworkingSecGroupV2()
+	d := r.TestResourceData()
+	d.SetId("1")
+
+	rule1 := map[string]interface{}{
+		"port_range_min":   22,
+		"port_range_max":   22,
+		"protocol":         "tcp",
+		"remote_ip_prefix": "0.0.0.0/0",
+	}
+
+	rule2 := map[string]interface{}{
+		"port_range_min":   1,
+		"port_range_max":   65536,
+		"protocol":         "udp",
+		"remote_ip_prefix": "0.0.0.0/0",
+	}
+
+	rule3 := map[string]interface{}{
+		"port_range_min":   -1,
+		"port_range_max":   -1,
+		"protocol":         "icmp",
+		"remote_ip_prefix": "0.0.0.0/0",
+	}
+
+	allRules := []map[string]interface{}{rule1, rule2, rule3}
+	d.Set("rule", allRules)
+
+	expectedRules := []rules.CreateOpts{
+		{
+			SecGroupID:     "1",
+			PortRangeMin:   -1,
+			PortRangeMax:   -1,
+			Protocol:       "icmp",
+			RemoteIPPrefix: "0.0.0.0/0",
+		},
+
+		{
+			SecGroupID:     "1",
+			PortRangeMin:   1,
+			PortRangeMax:   65536,
+			Protocol:       "udp",
+			RemoteIPPrefix: "0.0.0.0/0",
+		},
+
+		{
+			SecGroupID:     "1",
+			PortRangeMin:   22,
+			PortRangeMax:   22,
+			Protocol:       "tcp",
+			RemoteIPPrefix: "0.0.0.0/0",
+		},
+	}
+
+	actualRules, err := expandNetworkingSecgroupV2CreateRules(d)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(expectedRules, actualRules) {
+		t.Fatalf("Rules differ. Want: %#v, but got: %#v", expectedRules, actualRules)
+	}
+}
+
+func TestExpandNetworkingSecgroupV2Rule(t *testing.T) {
+	r := resourceNetworkingSecGroupV2()
+	d := r.TestResourceData()
+	d.SetId("1")
+
+	rule1 := map[string]interface{}{
+		"id":               "2",
+		"port_range_min":   22,
+		"port_range_max":   22,
+		"protocol":         "tcp",
+		"remote_ip_prefix": "0.0.0.0/0",
+	}
+
+	expectedRules := rules.SecGroupRule{
+		SecGroupID:     "1",
+		ID:             "2",
+		PortRangeMin:   22,
+		PortRangeMax:   22,
+		Protocol:       "tcp",
+		RemoteIPPrefix: "0.0.0.0/0",
+	}
+
+	actualRules := expandNetworkingSecgroupV2Rule(d, rule1)
+
+	if !reflect.DeepEqual(expectedRules, actualRules) {
+		t.Fatalf("Results differ. Want: %#v, but got: %#v", expectedRules, actualRules)
+	}
+}

--- a/openstack/resource_openstack_networking_secgroup_v2.go
+++ b/openstack/resource_openstack_networking_secgroup_v2.go
@@ -3,12 +3,14 @@ package openstack
 import (
 	"context"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
@@ -71,6 +73,79 @@ func resourceNetworkingSecGroupV2() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+
+			"rule": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Set:      networkingSecgroupV2RuleHash,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: false,
+						},
+
+						"direction": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: false,
+						},
+
+						"ethertype": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: false,
+						},
+
+						"protocol": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: false,
+						},
+
+						"port_range_min": {
+							Type:     schema.TypeInt,
+							Required: true,
+							ForceNew: false,
+						},
+
+						"port_range_max": {
+							Type:     schema.TypeInt,
+							Required: true,
+							ForceNew: false,
+						},
+
+						"remote_ip_prefix": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: false,
+							StateFunc: func(v interface{}) string {
+								return strings.ToLower(v.(string))
+							},
+						},
+
+						"remote_group_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: false,
+						},
+
+						"self": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+							ForceNew: false,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -82,8 +157,14 @@ func resourceNetworkingSecGroupV2Create(ctx context.Context, d *schema.ResourceD
 		return diag.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
+	// Before creating the security group, make sure all rules are valid.
+	if err := networkingSecgroupV2RulesCheckForErrors(d); err != nil {
+		return diag.FromErr(err)
+	}
+
+	name := d.Get("name").(string)
 	opts := groups.CreateOpts{
-		Name:        d.Get("name").(string),
+		Name:        name,
 		Description: d.Get("description").(string),
 		TenantID:    d.Get("tenant_id").(string),
 	}
@@ -122,6 +203,19 @@ func resourceNetworkingSecGroupV2Create(ctx context.Context, d *schema.ResourceD
 		log.Printf("[DEBUG] Set tags %s on openstack_networking_secgroup_v2 %s", tags, sg.ID)
 	}
 
+	// Now that the security group has been created, iterate through each rule and create it
+	createRuleOptsList, err := expandNetworkingSecgroupV2CreateRules(d)
+	if err != nil {
+		return diag.Errorf("Error creating openstack_networking_secgroup_v2 %s rules:", err)
+	}
+
+	for _, createRuleOpts := range createRuleOptsList {
+		_, err := rules.Create(networkingClient, createRuleOpts).Extract()
+		if err != nil {
+			return diag.Errorf("Error creating openstack_networking_secgroup_v2 %s rule: %s", name, err)
+		}
+	}
+
 	log.Printf("[DEBUG] Created openstack_networking_secgroup_v2: %#v", sg)
 
 	return resourceNetworkingSecGroupV2Read(ctx, d, meta)
@@ -145,6 +239,27 @@ func resourceNetworkingSecGroupV2Read(ctx context.Context, d *schema.ResourceDat
 	d.Set("region", GetRegion(d, config))
 
 	networkingV2ReadAttributesTags(d, sg.Tags)
+
+	sgrPager, err := rules.List(networkingClient, rules.ListOpts{SecGroupID: d.Id()}).AllPages()
+	if err != nil {
+		return diag.Errorf("Error retrieving openstack_networking_secgroup_v2: %s", err)
+	}
+
+	sgRules, err := rules.ExtractRules(sgrPager)
+	if err != nil {
+		return diag.Errorf("Error retrieving openstack_networking_secgroup_v2: %s", err)
+	}
+
+	rules, err := flattenNetworkingSecgroupV2Rules(networkingClient, d, sgRules)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[DEBUG] Retrieved openstack_networking_secgroup_v2 %s rules: %#v", d.Id(), rules)
+
+	if err := d.Set("rule", rules); err != nil {
+		return diag.Errorf("Unable to set openstack_networking_secgroup_v2 %s rules: %s", d.Id(), err)
+	}
 
 	return nil
 }
@@ -188,6 +303,42 @@ func resourceNetworkingSecGroupV2Update(ctx context.Context, d *schema.ResourceD
 			return diag.Errorf("Error setting tags on openstack_networking_secgroup_v2 %s: %s", d.Id(), err)
 		}
 		log.Printf("[DEBUG] Set tags %s on openstack_networking_secgroup_v2 %s", tags, d.Id())
+	}
+
+	if d.HasChange("rule") {
+		oldSGRaw, newSGRaw := d.GetChange("rule")
+		oldSGRSet, newSGRSet := oldSGRaw.(*schema.Set), newSGRaw.(*schema.Set)
+		secgrouprulesToAdd := newSGRSet.Difference(oldSGRSet)
+		secgrouprulesToRemove := oldSGRSet.Difference(newSGRSet)
+
+		log.Printf("[DEBUG] openstack_networking_secgroup_v2 %s rules to add: %v", d.Id(), secgrouprulesToAdd)
+		log.Printf("[DEBUG] openstack_networking_secgroup_v2 %s rules to remove: %v", d.Id(), secgrouprulesToRemove)
+
+		for _, rawRule := range secgrouprulesToAdd.List() {
+			createRuleOpts, err := expandNetworkingSecgroupV2CreateRule(d, rawRule)
+			if err != nil {
+				return diag.Errorf("Error adding rule to openstack_networking_secgroup_v2 %s: %s", d.Id(), err)
+			}
+
+			_, erro := rules.Create(networkingClient, createRuleOpts).Extract()
+			if erro != nil {
+				return diag.Errorf("Error adding rule to openstack_networking_secgroup_v2 %s: %s", d.Id(), err)
+			}
+		}
+
+		for _, r := range secgrouprulesToRemove.List() {
+			rule := expandNetworkingSecgroupV2Rule(d, r)
+
+			log.Printf("[DEBUG] openstack_networking_secgroup_v2 %s removing rule %v", d.Id(), rule.ID)
+			err := rules.Delete(networkingClient, rule.ID).ExtractErr()
+			if err != nil {
+				if _, ok := err.(gophercloud.ErrDefault404); ok {
+					continue
+				}
+
+				return diag.Errorf("Error removing rule %s from openstack_networking_secgroup_v2 %s: %s", rule.ID, d.Id(), err)
+			}
+		}
 	}
 
 	return resourceNetworkingSecGroupV2Read(ctx, d, meta)

--- a/openstack/resource_openstack_networking_secgroup_v2_test.go
+++ b/openstack/resource_openstack_networking_secgroup_v2_test.go
@@ -84,6 +84,28 @@ func TestAccNetworkingV2SecGroup_timeout(t *testing.T) {
 	})
 }
 
+func TestAccNetworkingV2SecGroup_rule(t *testing.T) {
+	var securityGroup groups.SecGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			//testAccPreCheckNonAdminOnly(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckNetworkingV2SecGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2SecGroupRule,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2SecGroupExists("openstack_networking_secgroup_v2.secgroup_1", &securityGroup),
+					testAccCheckNetworkingV2SecGroupRuleCount(&securityGroup, 2),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkingV2SecGroupDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	networkingClient, err := config.NetworkingV2Client(osRegionName)
@@ -177,6 +199,30 @@ resource "openstack_networking_secgroup_v2" "secgroup_1" {
 
   timeouts {
     delete = "5m"
+  }
+}
+`
+const testAccNetworkingV2SecGroupRule = `
+resource "openstack_networking_secgroup_v2" "secgroup_1" {
+  name = "security_group"
+	delete_default_rules = true
+
+  rule {
+    port_range_min   = 22
+    port_range_max   = 22
+    protocol         = "tcp"
+	  ethertype        = "IPv4"
+	  direction        = "ingress"
+    remote_ip_prefix = "0.0.0.0/0"
+  }
+
+  rule {
+    port_range_min   = 80
+    port_range_max   = 80
+    protocol         = "tcp"
+	  ethertype        = "IPv4"
+	  direction        = "ingress"
+    remote_ip_prefix = "0.0.0.0/0"
   }
 }
 `

--- a/openstack/resource_openstack_networking_secgroup_v2_test.go
+++ b/openstack/resource_openstack_networking_secgroup_v2_test.go
@@ -211,8 +211,8 @@ resource "openstack_networking_secgroup_v2" "secgroup_1" {
     port_range_min   = 22
     port_range_max   = 22
     protocol         = "tcp"
-	  ethertype        = "IPv4"
-	  direction        = "ingress"
+    ethertype        = "IPv4"
+    direction        = "ingress"
     remote_ip_prefix = "0.0.0.0/0"
   }
 
@@ -220,8 +220,8 @@ resource "openstack_networking_secgroup_v2" "secgroup_1" {
     port_range_min   = 80
     port_range_max   = 80
     protocol         = "tcp"
-	  ethertype        = "IPv4"
-	  direction        = "ingress"
+    ethertype        = "IPv4"
+    direction        = "ingress"
     remote_ip_prefix = "0.0.0.0/0"
   }
 }

--- a/website/docs/r/networking_secgroup_v2.html.markdown
+++ b/website/docs/r/networking_secgroup_v2.html.markdown
@@ -12,12 +12,32 @@ Manages a V2 neutron security group resource within OpenStack.
 Unlike Nova security groups, neutron separates the group from the rules
 and also allows an admin to target a specific tenant_id.
 
+~> **NOTE on Security Groups and Security Group Rules:** We currently support the
+definition of security group rules with both, openstack_networking_secgroup_v2 and
+openstack_networking_secgroup_rule_v2. It is at this time not possible to mix
+the usage of both resource. Doing so will lead to unpredictable behavior.
+
 ## Example Usage
 
 ```hcl
 resource "openstack_networking_secgroup_v2" "secgroup_1" {
   name        = "secgroup_1"
   description = "My neutron security group"
+}
+```
+
+```hcl
+resource "openstack_networking_secgroup_v2" "secgroup_2" {
+  name        = "secgroup_2"
+
+  rule {
+    port_range_min   = 22
+    port_range_max   = 22
+    protocol         = "tcp"
+    ethertype        = "IPv4"
+    direction        = "ingress"
+    remote_ip_prefix = "0.0.0.0/0"
+  }
 }
 ```
 
@@ -44,6 +64,65 @@ The following arguments are supported:
 
 * `tags` - (Optional) A set of string tags for the security group.
 
+* `rule` - (Optional) A configuration block of security group rules. Can be specified
+    multiple times for each security group rule. The structure is documented below.
+
+The `rule` block supports:
+
+* `description` - (Optional) A description of the rule. Changing this creates a
+    new security group rule.
+
+* `direction` - (Required) The direction of the rule, valid values are **ingress**
+    or **egress**. Changing this creates a new security group rule.
+
+* `ethertype` - (Required) The layer 3 protocol type, valid values are **IPv4**
+    or **IPv6**. Changing this creates a new security group rule.
+
+* `protocol` - (Optional) The layer 4 protocol type, valid values are following.
+    This is required if you want to specify a port range. Changing this creates
+    a new security group rule.
+  * **tcp**
+  * **udp**
+  * **icmp**
+  * **ah**
+  * **dccp**
+  * **egp**
+  * **esp**
+  * **gre**
+  * **igmp**
+  * **ipv6-encap**
+  * **ipv6-frag**
+  * **ipv6-icmp**
+  * **ipv6-nonxt**
+  * **ipv6-opts**
+  * **ipv6-route**
+  * **ospf**
+  * **pgm**
+  * **rsvp**
+  * **sctp**
+  * **udplite**
+  * **vrrp**
+
+* `port_range_min` - (Required) The lower part of the allowed port range, valid
+    integer value needs to be between 1 and 65535. Changing this creates a new
+    security group rule.
+
+* `port_range_max` - (Required) The higher part of the allowed port range, valid
+    integer value needs to be between 1 and 65535. Changing this creates a new
+    security group rule.
+
+* `remote_ip_prefix` - (Optional) The remote CIDR, the value needs to be a valid
+    CIDR (i.e. 192.168.0.0/16). Changing this creates a new security group rule.
+
+* `remote_group_id` - (Optional) The remote group id, the value needs to be an
+    Openstack ID of a security group in the same tenant. Changing this creates
+    a new security group rule.
+
+* `self` - (Optional) Required if `remote_ip_prefix` and `remote_group_id` is
+    empty. If true, the security group itself will be added as a source to this
+    security group rule. Cannot be combined with `remote_ip_prefix` or
+    `remote_group_id`.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -53,6 +132,7 @@ The following attributes are exported:
 * `description` - See Argument Reference above.
 * `tenant_id` - See Argument Reference above.
 * `tags` - See Argument Reference above.
+* `rule` - See Argument Reference above.
 * `all_tags` - The collection of tags assigned on the security group, which have
   been explicitly and implicitly added.
 


### PR DESCRIPTION
This PR implements a new `rule` argument for the `openstack_networking_secgroup_v2` resource. Most of this was copied from the deprecated `openstack_compute_secgroup_v2` resource.

# The problem

We're already able to deploy security group rules with the help of the [`openstack_networking_secgroup_rule_v2`](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/networking_secgroup_rule_v2). But this comes with problems when defining a bunch of security group rules.

There are, as far as I known, 2 ways to iterate over resources:

## count

```terraform
terraform {
  required_providers {
    openstack = {
      source = "terraform-provider-openstack/openstack"
    }
  }
}

locals {
  allow_ssh_server = ["10.0.0.1/32", "10.0.0.2/32"]
  rules = [for ip in local.allow_ssh_server : {
    direction        = "ingress"
    ethertype        = "IPv4"
    protocol         = "tcp"
    port_range_min   = 22,
    port_range_max   = 22,
    remote_ip_prefix = ip
    }
  ]
}

resource "openstack_networking_secgroup_v2" "secgroup_1" {
  name                 = "secgroup_1"
  delete_default_rules = true
}

resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_1" {
  count             = length(local.rules)
  direction         = local.rules[count.index]["direction"]
  ethertype         = local.rules[count.index]["ethertype"]
  protocol          = local.rules[count.index]["protocol"]
  port_range_min    = local.rules[count.index]["port_range_min"]
  port_range_max    = local.rules[count.index]["port_range_max"]
  remote_ip_prefix  = local.rules[count.index]["remote_ip_prefix"]
  security_group_id = openstack_networking_secgroup_v2.secgroup_1.id
}
```



## for_each

```terraform
terraform {
  required_providers {
    openstack = {
      source = "terraform-provider-openstack/openstack"
    }
  }
}

locals {
  allow_ssh_server = ["10.0.0.1/32", "10.0.0.2/32"]
  rules = {for ip in local.allow_ssh_server : ip => {
    direction        = "ingress"
    ethertype        = "IPv4"
    protocol         = "tcp"
    port_range_min   = 22,
    port_range_max   = 22,
    remote_ip_prefix = ip
    }
  }
}

resource "openstack_networking_secgroup_v2" "secgroup_1" {
  name                 = "secgroup_1"
  delete_default_rules = true
}

resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_1" {
  for_each          = local.rules
  direction         = each.value.direction
  ethertype         = each.value.ethertype
  protocol          = each.value.protocol
  port_range_min    = each.value.port_range_min
  port_range_max    = each.value.port_range_max
  remote_ip_prefix  = each.value.remote_ip_prefix
  security_group_id = openstack_networking_secgroup_v2.secgroup_1.id
}
```

Both options have disadvantages:

* count
  * Changing the order of the IPs recreates security group rules because the resource key changes
* for_each
  * Requires a key in a map that isn't used anywhere else because a security group rule doesn't have a name/title.

# Solution

This new approach brings the advantage of allowing a list to be the input and doesn't come with the drawback of securiy group recreation.

```terraform
terraform {
  required_providers {
    openstack = {
      source = "terraform-provider-openstack/openstack"
    }
  }
}

locals {
  allow_ssh_server = ["10.0.0.1/32", "10.0.0.2/32"]
  rules = [for ip in local.allow_ssh_server : {
    direction        = "ingress"
    ethertype        = "IPv4"
    protocol         = "tcp"
    port_range_min   = 22,
    port_range_max   = 22,
    remote_ip_prefix = ip
    }
  ]
}

resource "openstack_networking_secgroup_v2" "secgroup_1" {
  name = "secgroup_1"

  dynamic "rule" {
    for_each = local.rules
    content {
      direction         = rule.value["direction"]
      ethertype         = rule.value["ethertype"]
      protocol          = rule.value["protocol"]
      port_range_min    = rule.value["port_range_min"]
      port_range_max    = rule.value["port_range_max"]
      remote_ip_prefix  = rule.value["remote_ip_prefix"]
    }
  }
}
```

For us this is important when using a generic security group (rule) module because it allows us to specify a variable of type `list(object)`:

```terraform
variable "rules" {
  type = list(object({
    direction        = optional(string, "ingress")
    ethertype        = optional(string, "IPv4")
    description      = optional(string)
    protocol         = optional(string)
    port_range_min   = optional(number)
    port_range_max   = optional(number)
    remote_ip_prefix = optional(string)
    tenant_id        = optional(string)
    remote_group_id  = optional(string)
  }))
  default = []

  validation {
    condition = alltrue([
      for r in var.rules : contains(["ingress", "egress"], r.direction)
    ])
    error_message = "All rules must have 'direction' of either 'ingress' or 'egress'."
  }
  # ...
}
```

With this users of that module don't have to bother about an irrelevant key for their security group rules.