### PR TITLE
Facilitate providing a list of tags in data_source_openstack_images_image_v2

### DIFF
--- a/openstack/data_source_openstack_images_image_v2.go
+++ b/openstack/data_source_openstack_images_image_v2.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"sort"
 	"time"
@@ -89,13 +90,11 @@ func dataSourceImagesImageV2() *schema.Resource {
 					"asc", "desc",
 				}, false),
 			},
-
 			"tag": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-
 			"most_recent": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -176,10 +175,10 @@ func dataSourceImagesImageV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"tags": {
 				Type:     schema.TypeSet,
 				Computed: true,
+				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
@@ -199,6 +198,10 @@ func dataSourceImagesImageV2Read(ctx context.Context, d *schema.ResourceData, me
 	memberStatus := resourceImagesImageV2MemberStatusFromString(d.Get("member_status").(string))
 
 	var tags []string
+	tag_list := d.Get("tags").(*schema.Set).List()
+	for _, v := range tag_list {
+		tags = append(tags, fmt.Sprint(v))
+	}
 	tag := d.Get("tag").(string)
 	if tag != "" {
 		tags = append(tags, tag)

--- a/openstack/data_source_openstack_images_image_v2.go
+++ b/openstack/data_source_openstack_images_image_v2.go
@@ -90,11 +90,13 @@ func dataSourceImagesImageV2() *schema.Resource {
 					"asc", "desc",
 				}, false),
 			},
+
 			"tag": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
+
 			"most_recent": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -175,6 +177,7 @@ func dataSourceImagesImageV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
 			"tags": {
 				Type:     schema.TypeSet,
 				Computed: true,
@@ -197,11 +200,12 @@ func dataSourceImagesImageV2Read(ctx context.Context, d *schema.ResourceData, me
 	visibility := resourceImagesImageV2VisibilityFromString(d.Get("visibility").(string))
 	memberStatus := resourceImagesImageV2MemberStatusFromString(d.Get("member_status").(string))
 
-	var tags []string
-	tag_list := d.Get("tags").(*schema.Set).List()
-	for _, v := range tag_list {
+	tags := []string{}
+	tagList := d.Get("tags").(*schema.Set).List()
+	for _, v := range tagList {
 		tags = append(tags, fmt.Sprint(v))
 	}
+
 	tag := d.Get("tag").(string)
 	if tag != "" {
 		tags = append(tags, tag)

--- a/openstack/data_source_openstack_images_image_v2_test.go
+++ b/openstack/data_source_openstack_images_image_v2_test.go
@@ -58,6 +58,12 @@ func TestAccOpenStackImagesV2ImageDataSource_testQueries(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccOpenStackImagesV2ImageDataSourceQueryTagList(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImagesV2DataSourceID("data.openstack_images_image_v2.image_1"),
+				),
+			},
+			{
 				Config: testAccOpenStackImagesV2ImageDataSourceQuerySizeMin(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImagesV2DataSourceID("data.openstack_images_image_v2.image_1"),
@@ -163,7 +169,17 @@ data "openstack_images_image_v2" "image_1" {
 }
 `, testAccOpenStackImagesV2ImageDataSourceCirros)
 }
+func testAccOpenStackImagesV2ImageDataSourceQueryTagList() string {
+	return fmt.Sprintf(`
+%s
 
+data "openstack_images_image_v2" "image_1" {
+	most_recent = true
+	visibility = "private"
+	tags = ["cirros-tf_1"]
+}
+`, testAccOpenStackImagesV2ImageDataSourceCirros)
+}
 func testAccOpenStackImagesV2ImageDataSourceQuerySizeMin() string {
 	return fmt.Sprintf(`
 %s

--- a/website/docs/d/images_image_v2.html.markdown
+++ b/website/docs/d/images_image_v2.html.markdown
@@ -53,6 +53,9 @@ data "openstack_images_image_v2" "ubuntu" {
 
 * `tag` - (Optional) Search for images with a specific tag.
 
+* `tags` - (Optional) A list of tags required to be set on the image 
+      (all specified tags must be in the images tag list for it to be matched).
+
 * `visibility` - (Optional) The visibility of the image. Must be one of
    "public", "private", "community", or "shared". Defaults to "private".
 


### PR DESCRIPTION
The current implementation of `data_source_openstack_images_image_v20` only allows for setting a single `tag` attribute while the API is able to accept a list of tags to filter on.

This change allows users to directly set the `tags` attribute to a list of tags in their data source block while maintaining backwards compatibility with the existing `tag` attribute. If both are provided, the singular `tag` is simply added to the `tags` attribute before being added to the `ListOpts`.

Examples

**Original Syntax**
```hcl
data "openstack_images_image_v2" "image_1" {
  tag   = "cirros-tf_1"
}
```

**New Syntax with `tags` attribute**
```hcl
data "openstack_images_image_v2" "ubuntu" {
  tags = ["cirros-tf_1"]
}
```
**New Syntax using both `tag` and `tags` attribute**
```hcl
data "openstack_images_image_v2" "ubuntu" {
  tag   = "cirros-tf_1"
  tags = ["cirros-tf_1"]
}
```

I've added an additional acceptance test as well to account for being able to specify the `tags` attribute in the data source.