### PR TITLE
Allow providing a list of tags in data_source_openstack_images_image_ids_v2

### DIFF
--- a/openstack/data_source_openstack_images_image_ids_v2.go
+++ b/openstack/data_source_openstack_images_image_ids_v2.go
@@ -122,6 +122,13 @@ func dataSourceImagesImageIDsV2() *schema.Resource {
 				ConflictsWith: []string{"name"},
 			},
 
+			"tags": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
 			// Computed values
 			"ids": {
 				Type:     schema.TypeList,
@@ -160,8 +167,14 @@ func dataSourceImagesImageIdsV2Read(ctx context.Context, d *schema.ResourceData,
 	properties := resourceImagesImageV2ExpandProperties(
 		d.Get("properties").(map[string]interface{}))
 
-	var tags []string
-	if tag := d.Get("tag").(string); tag != "" {
+	tags := []string{}
+	tagList := d.Get("tags").(*schema.Set).List()
+	for _, v := range tagList {
+		tags = append(tags, fmt.Sprint(v))
+	}
+
+	tag := d.Get("tag").(string)
+	if tag != "" {
 		tags = append(tags, tag)
 	}
 

--- a/openstack/data_source_openstack_images_image_ids_v2_test.go
+++ b/openstack/data_source_openstack_images_image_ids_v2_test.go
@@ -53,6 +53,16 @@ func TestAccOpenStackImagesV2ImageIDsDataSource_basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccOpenStackImagesV2ImageIDsDataSourceTagList(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.openstack_images_image_ids_v2.images_by_tag", "ids.#", "1"),
+					resource.TestCheckResourceAttrPair(
+						"data.openstack_images_image_ids_v2.images_by_tag", "ids.0",
+						"openstack_images_image_v2.image_1", "id"),
+				),
+			},
+			{
 				Config: testAccOpenStackImagesV2ImageIDsDataSourceProperties(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
@@ -133,6 +143,17 @@ func testAccOpenStackImagesV2ImageIDsDataSourceTag() string {
 
 data "openstack_images_image_ids_v2" "images_by_tag" {
 	tag = "cirros-tf_1"
+	visibility = "private"
+}
+`, testAccOpenStackImagesV2ImageIDsDataSourceCirros)
+}
+
+func testAccOpenStackImagesV2ImageIDsDataSourceTagList() string {
+	return fmt.Sprintf(`
+%s
+
+data "openstack_images_image_ids_v2" "images_by_tag" {
+	tags = ["cirros-tf_1"]
 	visibility = "private"
 }
 `, testAccOpenStackImagesV2ImageIDsDataSourceCirros)

--- a/website/docs/d/images_image_ids_v2.html.markdown
+++ b/website/docs/d/images_image_ids_v2.html.markdown
@@ -69,6 +69,9 @@ data "openstack_images_image_ids_v2" "images" {
 
 * `tag` - (Optional) Search for images with a specific tag.
 
+* `tags` - (Optional) A list of tags required to be set on the image
+      (all specified tags must be in the images tag list for it to be matched).
+
 * `visibility` - (Optional) The visibility of the image. Must be one of
    "public", "private", "community", or "shared". Defaults to "private".
 


### PR DESCRIPTION
Ports change from #1462 for `openstack_images_image_ids_v2`  
Fixes #1467

Allows filtering using a list a tags by setting the `tags` attribute, while maintaining backwards compatibility with `tag` attribute.

Original Syntax

```hcl
data "openstack_images_image_ids_v2" "image_1" {
  tag   = "cirros-tf_1"
}
```

New Syntax with tags attribute

```hcl
data "openstack_images_image_ids_v2" "image_1" {
  tags = ["cirros-tf_1"]
}
````

New Syntax using both tag and tags attribute

```hcl
data "openstack_images_image_ids_v2" "image_1" {
  tag   = "cirros-tf_1"
  tags = ["cirros-tf_1"]
}
```