### PR TITLE
Add name_regex attribute to data_source_openstack_images_image_v2

### DIFF
--- a/openstack/data_source_openstack_images_image_v2.go
+++ b/openstack/data_source_openstack_images_image_v2.go
@@ -27,9 +27,10 @@ func dataSourceImagesImageV2() *schema.Resource {
 			},
 
 			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name_regex"},
 			},
 
 			"visibility": {
@@ -115,6 +116,14 @@ func dataSourceImagesImageV2() *schema.Resource {
 				Optional: true,
 				ForceNew: false,
 				Default:  false,
+			},
+
+			"name_regex": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ValidateFunc:  validation.StringIsValidRegExp,
+				ConflictsWith: []string{"name"},
 			},
 
 			// Computed values
@@ -245,6 +254,12 @@ func dataSourceImagesImageV2Read(ctx context.Context, d *schema.ResourceData, me
 		allImages = imagesFilterByProperties(allImages, properties)
 
 		log.Printf("[DEBUG] Image list filtered by properties: %#v", properties)
+	}
+
+	nameRegex, nameRegexOk := d.GetOk("name_regex")
+	if nameRegexOk {
+		allImages = imagesFilterByRegex(allImages, nameRegex.(string))
+		log.Printf("[DEBUG] Image list filtered by regex: %s", d.Get("name_regex"))
 	}
 
 	if len(allImages) < 1 {

--- a/openstack/data_source_openstack_images_image_v2_test.go
+++ b/openstack/data_source_openstack_images_image_v2_test.go
@@ -52,6 +52,12 @@ func TestAccOpenStackImagesV2ImageDataSource_testQueries(t *testing.T) {
 				Config: testAccOpenStackImagesV2ImageDataSourceCirros,
 			},
 			{
+				Config: testAccOpenStackImagesV2ImageDataSourceNameRegex(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImagesV2DataSourceID("data.openstack_images_image_v2.image_2"),
+				),
+			},
+			{
 				Config: testAccOpenStackImagesV2ImageDataSourceQueryTag(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImagesV2DataSourceID("data.openstack_images_image_v2.image_1"),
@@ -158,6 +164,16 @@ data "openstack_images_image_v2" "image_1" {
 `, testAccOpenStackImagesV2ImageDataSourceCirros)
 }
 
+func testAccOpenStackImagesV2ImageDataSourceNameRegex() string {
+	return fmt.Sprintf(`
+%s
+
+data "openstack_images_image_v2" "image_2" {
+	most_recent = true
+	name_regex = "^.+tf_2$"
+}
+`, testAccOpenStackImagesV2ImageDataSourceCirros)
+}
 func testAccOpenStackImagesV2ImageDataSourceQueryTag() string {
 	return fmt.Sprintf(`
 %s

--- a/website/docs/d/images_image_v2.html.markdown
+++ b/website/docs/d/images_image_v2.html.markdown
@@ -33,7 +33,13 @@ data "openstack_images_image_v2" "ubuntu" {
 * `most_recent` - (Optional) If more than one result is returned, use the most
   recent image.
 
-* `name` - (Optional) The name of the image.
+* `name` - (Optional) The name of the image. Cannot be used simultaneously
+    with `name_regex`.
+
+* `name_regex` - (Optional) The regular expressian of the name of the image.
+    Cannot be used simultaneously with `name`. Unlike filtering by `name` the
+    `name_regex` filtering does by client on the result of OpenStack search
+    query.
 
 * `owner` - (Optional) The owner (UUID) of the image.
 


### PR DESCRIPTION
Noticed that `data_source_openstack_images_image_ids_v2` has `name_regex` to filter images, while `data_source_openstack_images_image_v2` doesn't. This PR adds it, and works in the same way.


**Before:**

Exact name matching only

```hcl
data "openstack_images_image_ids_v2" "images" {
  name = "Ubuntu_16.04_cloudimage_amd64"
 }
```

**After:**

Partial name matching possible

```hcl
data "openstack_images_image_ids_v2" "images" {
  name_regex = "^Ubuntu_16\\.04.*_amd64$"
 }
```
