### PR TITLE
Use single quotes in linter go version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,9 +3,9 @@ run:
 
 linters-settings:
   staticcheck:
-    go: 1.20
+    go: '1.20'
   stylecheck:
-    go: 1.20
+    go: '1.20'
   gci:
     local-prefixes: github.com/gophercloud
   goimports:


### PR DESCRIPTION
Just in case
Reference: https://golangci-lint.run/usage/configuration/