### PR TITLE
keymanager v1: fix payload retrieve for binary data

### DIFF
--- a/openstack/data_source_openstack_keymanager_secret_v1.go
+++ b/openstack/data_source_openstack_keymanager_secret_v1.go
@@ -233,7 +233,7 @@ func dataSourceKeyManagerSecretV1Read(ctx context.Context, d *schema.ResourceDat
 	payloadContentType := secret.ContentTypes["default"]
 	d.Set("payload_content_type", payloadContentType)
 
-	d.Set("payload", keyManagerSecretV1GetPayload(kmClient, d.Id()))
+	d.Set("payload", keyManagerSecretV1GetPayload(kmClient, d.Id(), payloadContentType))
 	metadataMap, err := secrets.GetMetadata(kmClient, d.Id()).Extract()
 	if err != nil {
 		log.Printf("[DEBUG] Unable to get %s secret metadata: %s", uuid, err)

--- a/openstack/keymanager_secret_v1.go
+++ b/openstack/keymanager_secret_v1.go
@@ -97,32 +97,18 @@ func keyManagerSecretMetadataV1WaitForSecretMetadataCreation(kmClient *gopherclo
 	}
 }
 
-func keyManagerSecretV1GetPayload(kmClient *gophercloud.ServiceClient, id string) string {
-	payload, err := secrets.GetPayload(kmClient, id, nil).Extract()
+func keyManagerSecretV1GetPayload(kmClient *gophercloud.ServiceClient, id, contentType string) string {
+	opts := secrets.GetPayloadOpts{
+		PayloadContentType: contentType,
+	}
+	payload, err := secrets.GetPayload(kmClient, id, opts).Extract()
 	if err != nil {
 		log.Printf("[DEBUG] Could not retrieve payload for secret with id %s: %s", id, err)
 	}
-	return string(payload)
-}
 
-func resourceSecretV1PayloadBase64CustomizeDiff(diff *schema.ResourceDiff) error {
-	encoding := diff.Get("payload_content_encoding").(string)
-	if diff.Id() != "" && diff.HasChange("payload") && encoding == "base64" {
-		o, n := diff.GetChange("payload")
-		oldPayload := o.(string)
-		newPayload := n.(string)
-
-		v, err := base64.StdEncoding.DecodeString(newPayload)
-		if err != nil {
-			return fmt.Errorf("The Payload is not in the defined base64 format: %s", err)
-		}
-		newPayloadDecoded := string(v)
-
-		if oldPayload == newPayloadDecoded {
-			log.Printf("[DEBUG] payload has not changed. clearing diff")
-			return diff.Clear("payload")
-		}
+	if !strings.HasPrefix(contentType, "text/") {
+		return base64.StdEncoding.EncodeToString(payload)
 	}
 
-	return nil
+	return string(payload)
 }

--- a/website/docs/r/keymanager_secret_v1.html.markdown
+++ b/website/docs/r/keymanager_secret_v1.html.markdown
@@ -37,6 +37,12 @@ resource "openstack_keymanager_secret_v1" "secret_1" {
 
 ### Secret with whitespaces
 
+~> **Note** If you want to store payload with leading or trailing whitespaces,
+it's recommended to store it in a base64 encoding. Plain text payload can also
+work, but further addind or removing of the leading or trailing whitespaces
+won't be detected as a state change, e.g. changing plain text payload from
+`password ` to `password` won't recreate the secret.
+
 ```hcl
 resource "openstack_keymanager_secret_v1" "secret_1" {
   name                     = "password"


### PR DESCRIPTION
Fixes #1492 

Now payload state is stored in base64 format in case when it's not the text. In these cases it's responsibility of end user to detect the encoding/content-type and call https://developer.hashicorp.com/terraform/language/functions/base64decode

Payloads with whitespaces and newlines are also supported now, e.g. passwords that have whitespace at the end.