### PR TITLE
[DRAFT] Add support for IPIP protocol in SG rules

### DIFF
--- a/openstack/networking_secgroup_rule_v2.go
+++ b/openstack/networking_secgroup_rule_v2.go
@@ -63,6 +63,8 @@ func resourceNetworkingSecGroupRuleV2Protocol(protocol string) (rules.RuleProtoc
 		return rules.ProtocolICMP, nil
 	case string(rules.ProtocolIGMP):
 		return rules.ProtocolIGMP, nil
+	case string(rules.ProtocolIPIP):
+		return rules.ProtocolIPIP, nil
 	case string(rules.ProtocolIPv6Encap):
 		return rules.ProtocolIPv6Encap, nil
 	case string(rules.ProtocolIPv6Frag):

--- a/openstack/networking_secgroup_rule_v2_test.go
+++ b/openstack/networking_secgroup_rule_v2_test.go
@@ -67,6 +67,7 @@ func TestResourceNetworkingSecGroupRuleV2ProtocolString(t *testing.T) {
 		string(rules.ProtocolGRE):       rules.ProtocolGRE,
 		string(rules.ProtocolICMP):      rules.ProtocolICMP,
 		string(rules.ProtocolIGMP):      rules.ProtocolIGMP,
+		string(rules.ProtocolIPIP):      rules.ProtocolIPIP,
 		string(rules.ProtocolIPv6Encap): rules.ProtocolIPv6Encap,
 		string(rules.ProtocolIPv6Frag):  rules.ProtocolIPv6Frag,
 		string(rules.ProtocolIPv6ICMP):  rules.ProtocolIPv6ICMP,

--- a/openstack/resource_openstack_networking_secgroup_rule_v2_test.go
+++ b/openstack/resource_openstack_networking_secgroup_rule_v2_test.go
@@ -106,6 +106,7 @@ func TestAccNetworkingV2SecGroupRule_protocols(t *testing.T) {
 	var secgroupRuleEsp rules.SecGroupRule
 	var secgroupRuleGre rules.SecGroupRule
 	var secgroupRuleIgmp rules.SecGroupRule
+	var secgroupRuleIPIP rules.SecGroupRule
 	var secgroupRuleIPv6Encap rules.SecGroupRule
 	var secgroupRuleIPv6Frag rules.SecGroupRule
 	var secgroupRuleIPv6Icmp rules.SecGroupRule
@@ -145,6 +146,8 @@ func TestAccNetworkingV2SecGroupRule_protocols(t *testing.T) {
 					testAccCheckNetworkingV2SecGroupRuleExists(
 						"openstack_networking_secgroup_rule_v2.secgroup_rule_igmp", &secgroupRuleIgmp),
 					testAccCheckNetworkingV2SecGroupRuleExists(
+						"openstack_networking_secgroup_rule_v2.secgroup_rule_ipip", &secgroupRuleIPIP),
+					testAccCheckNetworkingV2SecGroupRuleExists(
 						"openstack_networking_secgroup_rule_v2.secgroup_rule_ipv6_encap", &secgroupRuleIPv6Encap),
 					testAccCheckNetworkingV2SecGroupRuleExists(
 						"openstack_networking_secgroup_rule_v2.secgroup_rule_ipv6_frag", &secgroupRuleIPv6Frag),
@@ -180,6 +183,8 @@ func TestAccNetworkingV2SecGroupRule_protocols(t *testing.T) {
 						"openstack_networking_secgroup_rule_v2.secgroup_rule_gre", "protocol", "gre"),
 					resource.TestCheckResourceAttr(
 						"openstack_networking_secgroup_rule_v2.secgroup_rule_igmp", "protocol", "igmp"),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_secgroup_rule_v2.secgroup_rule_ipip", "protocol", "ipip"),
 					resource.TestCheckResourceAttr(
 						"openstack_networking_secgroup_rule_v2.secgroup_rule_ipv6_encap", "protocol", "ipv6-encap"),
 					resource.TestCheckResourceAttr(
@@ -430,6 +435,14 @@ resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_igmp" {
   direction = "ingress"
   ethertype = "IPv4"
   protocol = "igmp"
+  remote_ip_prefix = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.secgroup_1.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_ipip" {
+  direction = "ingress"
+  ethertype = "IPv4"
+  protocol = "ipip"
   remote_ip_prefix = "0.0.0.0/0"
   security_group_id = "${openstack_networking_secgroup_v2.secgroup_1.id}"
 }

--- a/website/docs/r/networking_secgroup_rule_v2.html.markdown
+++ b/website/docs/r/networking_secgroup_rule_v2.html.markdown
@@ -58,6 +58,7 @@ The following arguments are supported:
   * __esp__
   * __gre__
   * __igmp__
+  * __ipip__
   * __ipv6-encap__
   * __ipv6-frag__
   * __ipv6-icmp__


### PR DESCRIPTION
This PR adds support for configuring the protocol `ipip` in Security Group rules.

Since https://github.com/gophercloud/gophercloud/pull/2583 was merged recently, and no new release of `gophercloud` has been cut yet i'll leave this PR in draft. When a new release has been cut over at `gophercloud` we can bump that dependency here.