### PR TITLE
Refactor to avoid panic

### DIFF
--- a/openstack/db_configuration_v1.go
+++ b/openstack/db_configuration_v1.go
@@ -23,10 +23,14 @@ func expandDatabaseConfigurationV1Values(rawValues []interface{}) map[string]int
 	values := make(map[string]interface{})
 
 	for _, rawValue := range rawValues {
+		var isStringType bool
 		v := rawValue.(map[string]interface{})
 		name := v["name"].(string)
 		value := v["value"]
-		isStringType := v["string_type"].(bool)
+
+		if v["string_type"] != nil {
+			isStringType = v["string_type"].(bool)
+		}
 
 		if !isStringType {
 			// check if value can be converted into int

--- a/openstack/db_configuration_v1.go
+++ b/openstack/db_configuration_v1.go
@@ -23,16 +23,11 @@ func expandDatabaseConfigurationV1Values(rawValues []interface{}) map[string]int
 	values := make(map[string]interface{})
 
 	for _, rawValue := range rawValues {
-		var isStringType bool
 		v := rawValue.(map[string]interface{})
 		name := v["name"].(string)
 		value := v["value"]
 
-		if v["string_type"] != nil {
-			isStringType = v["string_type"].(bool)
-		}
-
-		if !isStringType {
+		if isStringType, ok := v["string_type"].(bool); !ok || !isStringType {
 			// check if value can be converted into int
 			if valueInt, err := strconv.Atoi(value.(string)); err == nil {
 				value = valueInt

--- a/openstack/db_configuration_v1_test.go
+++ b/openstack/db_configuration_v1_test.go
@@ -39,12 +39,35 @@ func TestExpandDatabaseConfigurationV1Values(t *testing.T) {
 			"name":  "max_connections",
 			"value": "200",
 		},
+		map[string]interface{}{
+			"name":        "collation_connection",
+			"value":       "47",
+			"string_type": false,
+		},
+		map[string]interface{}{
+			"name":        "connect_timeout",
+			"value":       "3",
+			"string_type": true,
+		},
+		map[string]interface{}{
+			"name":  "autocommit",
+			"value": "true",
+		},
+		map[string]interface{}{
+			"name":        "sync_binlog",
+			"value":       "true",
+			"string_type": true,
+		},
 	}
 
 	expected := map[string]interface{}{
-		"collation_server":   "latin1_swedish_ci",
-		"collation_database": "latin1_swedish_ci",
-		"max_connections":    200,
+		"collation_server":     "latin1_swedish_ci",
+		"collation_database":   "latin1_swedish_ci",
+		"max_connections":      200,
+		"collation_connection": 47,
+		"connect_timeout":      "3",
+		"autocommit":           true,
+		"sync_binlog":          "true",
 	}
 
 	actual := expandDatabaseConfigurationV1Values(values)


### PR DESCRIPTION
As mentioned in https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1527 go test currently fails.

This is an attempt to nil check so that it does not panic.

Closes: #1527