### PR TITLE
Fix SkipBelow and SkipAfter ci check func

### DIFF
--- a/.github/workflows/functional-blockstorage_v2.yml
+++ b/.github/workflows/functional-blockstorage_v2.yml
@@ -37,6 +37,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: 'blockstorage.*v2|v2.*blockstorage'
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./scripts/collectlogs.sh
         if: failure()

--- a/.github/workflows/functional-blockstorage_v3.yml
+++ b/.github/workflows/functional-blockstorage_v3.yml
@@ -54,6 +54,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: 'blockstorage.*v3|v3.*blockstorage'
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./scripts/collectlogs.sh
         if: failure()

--- a/.github/workflows/functional-compute.yml
+++ b/.github/workflows/functional-compute.yml
@@ -54,6 +54,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: 'compute'
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./scripts/collectlogs.sh
         if: failure()

--- a/.github/workflows/functional-dns.yml
+++ b/.github/workflows/functional-dns.yml
@@ -53,6 +53,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: "dns"
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./scripts/collectlogs.sh
         if: failure()

--- a/.github/workflows/functional-identity.yml
+++ b/.github/workflows/functional-identity.yml
@@ -52,6 +52,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: 'identity'
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./scripts/collectlogs.sh
         if: failure()

--- a/.github/workflows/functional-images.yml
+++ b/.github/workflows/functional-images.yml
@@ -52,6 +52,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: 'images'
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./scripts/collectlogs.sh
         if: failure()

--- a/.github/workflows/functional-keymanager.yml
+++ b/.github/workflows/functional-keymanager.yml
@@ -56,6 +56,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: "keymanager"
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./scripts/collectlogs.sh
         if: failure()

--- a/.github/workflows/functional-networking.yml
+++ b/.github/workflows/functional-networking.yml
@@ -55,6 +55,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: 'networking'
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./scripts/collectlogs.sh
         if: failure()

--- a/.github/workflows/functional-objectstorage.yml
+++ b/.github/workflows/functional-objectstorage.yml
@@ -57,6 +57,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: 'objectstorage'
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./scripts/collectlogs.sh
         if: failure()

--- a/.github/workflows/functional-orchestration.yml
+++ b/.github/workflows/functional-orchestration.yml
@@ -53,6 +53,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: 'orchestration'
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./scripts/collectlogs.sh
         if: failure()

--- a/.github/workflows/functional-sharedfilesystem.yml
+++ b/.github/workflows/functional-sharedfilesystem.yml
@@ -66,6 +66,7 @@ jobs:
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: "sharedfilesystem|sfs.*v2|v2.*sfs"
+          OS_BRANCH: ${{ matrix.openstack_version }}
       - name: Generate logs on failure
         run: ./scripts/collectlogs.sh
         if: failure()

--- a/openstack/provider_test.go
+++ b/openstack/provider_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 var (
-	osBranch                     = os.Getenv("OS_BRANCH")
 	osDBEnvironment              = os.Getenv("OS_DB_ENVIRONMENT")
 	osDBDatastoreVersion         = os.Getenv("OS_DB_DATASTORE_VERSION")
 	osDBDatastoreType            = os.Getenv("OS_DB_DATASTORE_TYPE")
@@ -262,25 +261,50 @@ func testAccPreCheckHypervisor(t *testing.T) {
 	}
 }
 
-// SkipReleasesBelow will have the test be skipped on releases below a certain
+// testAccSkipReleasesBelow will have the test be skipped on releases below a certain
 // one. Releases are named such as 'stable/mitaka', master, etc.
 func testAccSkipReleasesBelow(t *testing.T, release string) {
-	testAccPreCheckRequiredEnvVars(t)
+	currentBranch := os.Getenv("OS_BRANCH")
 
 	if IsReleasesBelow(t, release) {
-		t.Skipf("this is not supported below %s, testing in %s", release, osBranch)
+		t.Skipf("this is not supported below %s, testing in %s", release, currentBranch)
 	}
 }
 
 // IsReleasesBelow will return true on releases below a certain
 // one. Releases are named such as 'stable/mitaka', master, etc.
 func IsReleasesBelow(t *testing.T, release string) bool {
-	testAccPreCheckRequiredEnvVars(t)
+	currentBranch := os.Getenv("OS_BRANCH")
 
-	if osBranch != "master" && osBranch < release {
+	if currentBranch != "master" && currentBranch < release {
 		return true
 	}
-	t.Logf("Target release %s is above the current branch %s", release, osBranch)
+	t.Logf("Target release %s is above the current branch %s", release, currentBranch)
+	return false
+}
+
+// testAccSkipReleasesAbove will have the test be skipped on releases above a certain
+// one. The test is always skipped on master release. Releases are named such
+// as 'stable/mitaka', master, etc.
+func testAccSkipReleasesAbove(t *testing.T, release string) {
+	currentBranch := os.Getenv("OS_BRANCH")
+
+	if IsReleasesAbove(t, release) {
+		t.Skipf("this is not supported above %s, testing in %s", release, currentBranch)
+	}
+}
+
+// IsReleasesAbove will return true on releases above a certain
+// one. The result is always true on master release. Releases are named such
+// as 'stable/mitaka', master, etc.
+func IsReleasesAbove(t *testing.T, release string) bool {
+	currentBranch := os.Getenv("OS_BRANCH")
+
+	// Assume master is always too new
+	if currentBranch == "master" || currentBranch > release {
+		return true
+	}
+	t.Logf("Target release %s is below the current branch %s", release, currentBranch)
 	return false
 }
 

--- a/openstack/resource_openstack_blockstorage_volume_v3_test.go
+++ b/openstack/resource_openstack_blockstorage_volume_v3_test.go
@@ -105,6 +105,7 @@ func TestAccBlockStorageV3Volume_image_multiattach(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
+			testAccSkipReleasesAbove(t, "stable/wallaby")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckBlockStorageV3VolumeDestroy,

--- a/openstack/resource_openstack_networking_trunk_v2_test.go
+++ b/openstack/resource_openstack_networking_trunk_v2_test.go
@@ -198,7 +198,7 @@ func TestAccNetworkingV2Trunk_tags(t *testing.T) {
 //	})
 //}
 
-func TestAccNetworkingV2Trunk_computeInstance(t *testing.T) {
+func TestAccNetworkingV2Trunk_Instance(t *testing.T) {
 	var instance1 servers.Server
 	var parentPort1, subport1 ports.Port
 	var trunk1 trunks.Trunk


### PR DESCRIPTION
SkipBelow and SkipAfter ci func were not working properly
as OS_BRANCH was not in the env vars. Make it available
to all acceptance ci jobs. Moreover skip cinder multi_attach
test after zed release as it is no longer possible to do
multi_attach on a volume level.

This has to be done on volume_type basis. Related [commit](https://github.com/openstack/cinder/commit/d5a45f875a0919660df250e35c614e65a51b7038)


Close #1500 