### PR TITLE
[compute v2] Add multiattach flag to instance block_device (#1057)

### DIFF
--- a/openstack/compute_instance_v2.go
+++ b/openstack/compute_instance_v2.go
@@ -28,6 +28,7 @@ const (
 	computeV2InstanceCreateServerWithTagsMicroversion        = "2.52"
 	computeV2TagsExtensionMicroversion                       = "2.26"
 	computeV2InstanceBlockDeviceVolumeTypeMicroversion       = "2.67"
+	computeV2InstanceBlockDeviceMultiattachMicroversion      = "2.60"
 )
 
 // InstanceNIC is a structured representation of a Gophercloud servers.Server

--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -284,6 +284,12 @@ func resourceComputeInstanceV2() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 						},
+						"multiattach": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+							ForceNew: true,
+						},
 					},
 				},
 			},
@@ -552,6 +558,14 @@ func resourceComputeInstanceV2Create(ctx context.Context, d *schema.ResourceData
 		blockDevices, err := resourceInstanceBlockDevicesV2(d, vL.([]interface{}))
 		if err != nil {
 			return diag.FromErr(err)
+		}
+
+		// Check if Multiattach was set in any of the Block Devices.
+		// If so, set the client's microversion appropriately.
+		for _, bd := range d.Get("block_device").([]interface{}) {
+			if bd.(map[string]interface{})["multiattach"].(bool) {
+				computeClient.Microversion = computeV2InstanceBlockDeviceMultiattachMicroversion
+			}
 		}
 
 		// Check if VolumeType was set in any of the Block Devices.

--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -479,6 +479,9 @@ The `block_device` block supports:
 * `disk_bus` - (Optional) The low-level disk bus that will be used. Most common
     thing is to leave this empty. Changing this creates a new server.
 
+* `multiattach` - (Optional) Enable the attachment of multiattach-capable
+    volumes.
+
 The `scheduler_hints` block supports:
 
 * `group` - (Optional) A UUID of a Server Group. The instance will be placed


### PR DESCRIPTION
### Issue

Please see #1057 for detailed description.

It is not currently possible to use multiattach volumes with the `block_device` block of compute instances, as it requires compute microversion `>=2.60`. This is a major show stopper for my use case, where I need to attach such a volume to an instance *before* it boots.

### Proposal

~~The provider *already* uses microversion `2.67` when the `volume_type` parameter is set in the `block_device` block. Rather than adding more arbitrary checks for these edge cases, I propose we stick to a KISS philosophy by removing this check altogether, and simply pin to this "BlockDevice" microversion any time the `block_device` block is used.~~

As per a maintainer's suggestion below, I have added a `multiattach` flag to the `block_device` block, which sets the compute microversion to the required `2.60`. This is similar to how other resources already handle multiattach volumes, allowing for an easy way to utilize them, while maintaining backwards compatibility with older versions of OpenStack.

I've also made note of the added flag in the relevant documentation page.