### PR TITLE
Flag private-key attribute as sensitive

### DIFF
--- a/openstack/resource_openstack_compute_keypair_v2.go
+++ b/openstack/resource_openstack_compute_keypair_v2.go
@@ -48,8 +48,8 @@ func resourceComputeKeypairV2() *schema.Resource {
 
 			// computed-only
 			"private_key": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
 				Sensitive: true,
 			},
 

--- a/openstack/resource_openstack_compute_keypair_v2.go
+++ b/openstack/resource_openstack_compute_keypair_v2.go
@@ -50,6 +50,7 @@ func resourceComputeKeypairV2() *schema.Resource {
 			"private_key": {
 				Type:     schema.TypeString,
 				Computed: true,
+				Sensitive: true,
 			},
 
 			"fingerprint": {


### PR DESCRIPTION
Trying to fix https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/677
as it seems `terraform plan` is leaking full-body private_key
```
Terraform detected the following changes made outside of Terraform since the
last "terraform apply" which may have affected this plan:

  # openstack_compute_keypair_v2.keypair_1 has been deleted
  - resource "openstack_compute_keypair_v2" "keypair_1" {
      - id          = "prod-prod-1-keypair_1" -> null
        name        = "prod-prod-1-keypair_1"
      - private_key = <<-EOT
            -----BEGIN RSA PRIVATE KEY-----
            <skip-skip-skip-skip>
            -----END RSA PRIVATE KEY-----
        EOT -> null
      - public_key  = "ssh-rsa <skip-skip-skip-skip> Generated-by-Nova" -> null
        # (1 unchanged attribute hidden)
    }
```