### PR TITLE
fix(containerinfra): replace nodegroup if cluster_id changes

### DIFF
--- a/openstack/resource_openstack_containerinfra_nodegroup_v1.go
+++ b/openstack/resource_openstack_containerinfra_nodegroup_v1.go
@@ -42,7 +42,7 @@ func resourceContainerInfraNodeGroupV1() *schema.Resource {
 			"cluster_id": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: false,
+				ForceNew: true,
 			},
 			"name": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
If the cluster attached to a node group changed, that node group
cannot be "re-attached", it should just be fully rebuilt.
