### PR TITLE
DOCS: Fix import examples

### DIFF
--- a/website/docs/r/compute_flavor_access_v2.html.markdown
+++ b/website/docs/r/compute_flavor_access_v2.html.markdown
@@ -64,5 +64,5 @@ This resource can be imported by specifying all two arguments, separated
 by a forward slash:
 
 ```
-$ terraform import openstack_compute_flavor_access_v2.access_1 <flavor_id>/<tenant_id>
+$ terraform import openstack_compute_flavor_access_v2.access_1 flavor_id/tenant_id
 ```

--- a/website/docs/r/compute_floatingip_associate_v2.html.markdown
+++ b/website/docs/r/compute_floatingip_associate_v2.html.markdown
@@ -99,5 +99,5 @@ This resource can be imported by specifying all three arguments, separated
 by a forward slash:
 
 ```
-$ terraform import openstack_compute_floatingip_associate_v2.fip_1 <floating_ip>/<instance_id>/<fixed_ip>
+$ terraform import openstack_compute_floatingip_associate_v2.fip_1 floating_ip/instance_id/fixed_ip
 ```

--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -731,7 +731,7 @@ resource "openstack_compute_instance_v2" "basic_instance" {
 ```
 Then you execute
 ```
-terraform import openstack_compute_instance_v2.basic_instance <instance_id>
+terraform import openstack_compute_instance_v2.basic_instance instance_id
 ```
 
 ### Importing an instance with multiple emphemeral disks
@@ -830,10 +830,10 @@ To import the instance outlined in the above configuration
 do the following:
 
 ```
-terraform import openstack_compute_instance_v2.instance_2 <instance_id>
-import openstack_blockstorage_volume_v2.volume_1 <volume_id>
+terraform import openstack_compute_instance_v2.instance_2 instance_id
+import openstack_blockstorage_volume_v2.volume_1 volume_id
 terraform import openstack_compute_volume_attach_v2.va_1
-<instance_id>/<volume_id>
+instance_id/volume_id
 ```
 
 * A note on block storage volumes, the importer does not read

--- a/website/docs/r/dns_recordset_v2.html.markdown
+++ b/website/docs/r/dns_recordset_v2.html.markdown
@@ -89,5 +89,5 @@ This resource can be imported by specifying the zone ID and recordset ID,
 separated by a forward slash.
 
 ```
-$ terraform import openstack_dns_recordset_v2.recordset_1 <zone_id>/<recordset_id>
+$ terraform import openstack_dns_recordset_v2.recordset_1 zone_id/recordset_id
 ```

--- a/website/docs/r/dns_transfer_accept_v2.html.markdown
+++ b/website/docs/r/dns_transfer_accept_v2.html.markdown
@@ -70,5 +70,5 @@ The following attributes are exported:
 This resource can be imported by specifying the transferAccept ID:
 
 ```
-$ terraform import openstack_dns_transfer_accept_v2.accept_1 <accept_id>
+$ terraform import openstack_dns_transfer_accept_v2.accept_1 accept_id
 ```

--- a/website/docs/r/dns_transfer_request_v2.html.markdown
+++ b/website/docs/r/dns_transfer_request_v2.html.markdown
@@ -68,5 +68,5 @@ The following attributes are exported:
 This resource can be imported by specifying the transferRequest ID:
 
 ```
-$ terraform import openstack_dns_transfer_request_v2.request_1 <request_id>
+$ terraform import openstack_dns_transfer_request_v2.request_1 request_id
 ```

--- a/website/docs/r/dns_zone_v2.html.markdown
+++ b/website/docs/r/dns_zone_v2.html.markdown
@@ -83,6 +83,6 @@ The following attributes are exported:
 This resource can be imported by specifying the zone ID with optional project ID:
 
 ```
-$ terraform import openstack_dns_zone_v2.zone_1 <zone_id>
-$ terraform import openstack_dns_zone_v2.zone_1 <zone_id>:<project_id>
+$ terraform import openstack_dns_zone_v2.zone_1 zone_id
+$ terraform import openstack_dns_zone_v2.zone_1 zone_id/project_id
 ```

--- a/website/docs/r/identity_user_membership_v3.html.markdown
+++ b/website/docs/r/identity_user_membership_v3.html.markdown
@@ -76,5 +76,5 @@ This resource can be imported by specifying all two arguments, separated
 by a forward slash:
 
 ```
-$ terraform import openstack_identity_user_membership_v3.user_membership_1 <user_id>/<group_id>
+$ terraform import openstack_identity_user_membership_v3.user_membership_1 user_id/group_id
 ```

--- a/website/docs/r/networking_router_interface_v2.html.markdown
+++ b/website/docs/r/networking_router_interface_v2.html.markdown
@@ -73,5 +73,5 @@ Router Interfaces can be imported using the port `id`, e.g.
 
 ```
 $ openstack port list --router <router name or id>
-$ terraform import openstack_networking_router_interface_v2.int_1 <port id from above output>
+$ terraform import openstack_networking_router_interface_v2.int_1 port_id
 ```

--- a/website/docs/r/objectstorage_container_v1.html.markdown
+++ b/website/docs/r/objectstorage_container_v1.html.markdown
@@ -174,5 +174,5 @@ Some attributes can't be imported :
 So you'll have to `terraform plan` and `terraform apply` after the import to fix those missing attributes.
 
 ```
-$ terraform import openstack_objectstorage_container_v1.container_1 <name>
+$ terraform import openstack_objectstorage_container_v1.container_1 container_name
 ```

--- a/website/docs/r/sharedfilesystem_securityservice_v2.html.markdown
+++ b/website/docs/r/sharedfilesystem_securityservice_v2.html.markdown
@@ -91,5 +91,5 @@ The following arguments are supported:
 This resource can be imported by specifying the ID of the security service:
 
 ```
-$ terraform import openstack_sharedfilesystem_securityservice_v2.securityservice_1 <id>
+$ terraform import openstack_sharedfilesystem_securityservice_v2.securityservice_1 id
 ```

--- a/website/docs/r/sharedfilesystem_share_access_v2.html.markdown
+++ b/website/docs/r/sharedfilesystem_share_access_v2.html.markdown
@@ -155,5 +155,5 @@ This resource can be imported by specifying the ID of the share and the ID of th
 share access, separated by a slash, e.g.:
 
 ```
-$ terraform import openstack_sharedfilesystem_share_access_v2.share_access_1 <share id>/<share access id>
+$ terraform import openstack_sharedfilesystem_share_access_v2.share_access_1 share_id/share_access_id
 ```

--- a/website/docs/r/sharedfilesystem_share_v2.html.markdown
+++ b/website/docs/r/sharedfilesystem_share_v2.html.markdown
@@ -111,5 +111,5 @@ The following arguments are supported:
 This resource can be imported by specifying the ID of the share:
 
 ```
-$ terraform import openstack_sharedfilesystem_share_v2.share_1 <id>
+$ terraform import openstack_sharedfilesystem_share_v2.share_1 id
 ```

--- a/website/docs/r/sharedfilesystem_sharenetwork_v2.html.markdown
+++ b/website/docs/r/sharedfilesystem_sharenetwork_v2.html.markdown
@@ -123,5 +123,5 @@ The following arguments are supported:
 This resource can be imported by specifying the ID of the share network:
 
 ```
-$ terraform import openstack_sharedfilesystem_sharenetwork_v2.sharenetwork_1 <id>
+$ terraform import openstack_sharedfilesystem_sharenetwork_v2.sharenetwork_1 id
 ```


### PR DESCRIPTION
"<..>" are not visible when within code blocks. Remove any "<..>" from import examples on docs

Close #1543 