### PR TITLE
include record values during openstack_dns_recordset_v2 update

### DIFF
--- a/openstack/resource_openstack_dns_recordset_v2.go
+++ b/openstack/resource_openstack_dns_recordset_v2.go
@@ -188,6 +188,7 @@ func resourceDNSRecordSetV2Read(_ context.Context, d *schema.ResourceData, meta 
 
 	d.Set("name", n.Name)
 	d.Set("description", n.Description)
+	d.Set("records", n.Records)
 	d.Set("ttl", n.TTL)
 	d.Set("type", n.Type)
 	d.Set("zone_id", zoneID)

--- a/openstack/resource_openstack_dns_recordset_v2_test.go
+++ b/openstack/resource_openstack_dns_recordset_v2_test.go
@@ -75,9 +75,7 @@ func TestAccDNSV2RecordSet_ipv6(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"openstack_dns_recordset_v2.recordset_1", "description", "a record set"),
 					resource.TestCheckResourceAttr(
-						"openstack_dns_recordset_v2.recordset_1", "records.0", "fd2b:db7f:6ae:dd8d::1"),
-					resource.TestCheckResourceAttr(
-						"openstack_dns_recordset_v2.recordset_1", "records.1", "fd2b:db7f:6ae:dd8d::2"),
+						"openstack_dns_recordset_v2.recordset_1", "records.0", "fd2b:db7f:6ae:dd8d::2"),
 				),
 			},
 		},
@@ -339,10 +337,7 @@ func testAccDNSV2RecordSetIPv6(zoneName string) string {
 			type = "AAAA"
 			description = "a record set"
 			ttl = 3000
-			records = [
-				"[fd2b:db7f:6ae:dd8d::1]",
-				"fd2b:db7f:6ae:dd8d::2"
-			]
+			records = ["fd2b:db7f:6ae:dd8d::2"]
 		}
 	`, zoneName, zoneName)
 }


### PR DESCRIPTION
The record value(s) of a recordset resource were not being read
into the state during refresh which allows configuration drift to
go undetected.

Fixes: #1564