### PR TITLE
Create new identity_inherit_role_assignment_v3 resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-provider-openstack/terraform-provider-openstack
 go 1.20
 
 require (
-	github.com/gophercloud/gophercloud v1.2.1-0.20230309142102-36ac4a411ba7
+	github.com/gophercloud/gophercloud v1.3.1-0.20230517135124-33412becb1d0
 	github.com/gophercloud/utils v0.0.0-20230324070755-05e9e7f5ea4d
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/gophercloud/gophercloud v1.1.1/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
 github.com/gophercloud/gophercloud v1.2.1-0.20230309142102-36ac4a411ba7 h1:wDr3jLA3vAtpH5DvqdTHtn34Uo15qA7F6EdEIJtm7+s=
 github.com/gophercloud/gophercloud v1.2.1-0.20230309142102-36ac4a411ba7/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
+github.com/gophercloud/gophercloud v1.3.1-0.20230517135124-33412becb1d0 h1:NSIQAuPoktKrxJryRQRmiNbYD2udN3w267oJalbW0zw=
+github.com/gophercloud/gophercloud v1.3.1-0.20230517135124-33412becb1d0/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
 github.com/gophercloud/utils v0.0.0-20230324070755-05e9e7f5ea4d h1:AfRlf5NnsYsHIW5nNxhYp+99Bmj/fLeOYwD5Z4CMlzw=
 github.com/gophercloud/utils v0.0.0-20230324070755-05e9e7f5ea4d/go.mod h1:z4Dey7xsTUXgcB1C8elMvGRKTjV1ez0eoYQlMrduG1g=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=

--- a/openstack/import_openstack_identity_inherit_role_assignment_v3_test.go
+++ b/openstack/import_openstack_identity_inherit_role_assignment_v3_test.go
@@ -1,0 +1,31 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIdentityV3InheritRoleAssignment_importBasic(t *testing.T) {
+	resourceName := "openstack_identity_inherit_role_assignment_v3.role_assignment_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckIdentityV3InheritRoleAssignmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityV3InheritRoleAssignmentBasic,
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -359,6 +359,7 @@ func Provider() *schema.Provider {
 			"openstack_identity_project_v3":                      resourceIdentityProjectV3(),
 			"openstack_identity_role_v3":                         resourceIdentityRoleV3(),
 			"openstack_identity_role_assignment_v3":              resourceIdentityRoleAssignmentV3(),
+			"openstack_identity_inherit_role_assignment_v3":      resourceIdentityInheritRoleAssignmentV3(),
 			"openstack_identity_service_v3":                      resourceIdentityServiceV3(),
 			"openstack_identity_user_v3":                         resourceIdentityUserV3(),
 			"openstack_identity_user_membership_v3":              resourceIdentityUserMembershipV3(),

--- a/openstack/resource_openstack_identity_inherit_role_assignment_v3.go
+++ b/openstack/resource_openstack_identity_inherit_role_assignment_v3.go
@@ -1,0 +1,157 @@
+package openstack
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/osinherit"
+)
+
+func resourceIdentityInheritRoleAssignmentV3() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIdentityInheritRoleAssignmentV3Create,
+		ReadContext:   resourceIdentityInheritRoleAssignmentV3Read,
+		DeleteContext: resourceIdentityInheritRoleAssignmentV3Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"domain_id": {
+				Type:          schema.TypeString,
+				ConflictsWith: []string{"project_id"},
+				Optional:      true,
+				ForceNew:      true,
+			},
+
+			"group_id": {
+				Type:          schema.TypeString,
+				ConflictsWith: []string{"user_id"},
+				Optional:      true,
+				ForceNew:      true,
+			},
+
+			"project_id": {
+				Type:          schema.TypeString,
+				ConflictsWith: []string{"domain_id"},
+				Optional:      true,
+				ForceNew:      true,
+			},
+
+			"role_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"user_id": {
+				Type:          schema.TypeString,
+				ConflictsWith: []string{"group_id"},
+				Optional:      true,
+				ForceNew:      true,
+			},
+		},
+	}
+}
+
+func resourceIdentityInheritRoleAssignmentV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating OpenStack identity client: %s", err)
+	}
+
+	roleID := d.Get("role_id").(string)
+	domainID := d.Get("domain_id").(string)
+	groupID := d.Get("group_id").(string)
+	projectID := d.Get("project_id").(string)
+	userID := d.Get("user_id").(string)
+
+	opts := osinherit.AssignOpts{
+		DomainID:  domainID,
+		GroupID:   groupID,
+		ProjectID: projectID,
+		UserID:    userID,
+	}
+
+	err = osinherit.Assign(identityClient, roleID, opts).ExtractErr()
+	if err != nil {
+		return diag.Errorf("Error creating openstack_identity_inherit_role_assignment_v3: %s", err)
+	}
+
+	id := identityRoleAssignmentV3ID(domainID, projectID, groupID, userID, roleID)
+	d.SetId(id)
+
+	return resourceIdentityInheritRoleAssignmentV3Read(ctx, d, meta)
+}
+
+func resourceIdentityInheritRoleAssignmentV3Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating OpenStack identity client: %s", err)
+	}
+
+	domainID, projectID, groupID, userID, roleID, err := identityRoleAssignmentV3ParseID(d.Id())
+	if err != nil {
+		return diag.Errorf("Error determining openstack_identity_inherit_role_assignment_v3 ID: %s", err)
+	}
+
+	validateOpts := osinherit.ValidateOpts{
+		DomainID:  domainID,
+		ProjectID: projectID,
+		UserID:    userID,
+		GroupID:   groupID,
+	}
+
+	err = osinherit.Validate(identityClient, roleID, validateOpts).ExtractErr()
+	if err != nil {
+		return diag.FromErr(CheckDeleted(d, err, "Error vaalidatin openstack_identity_inherit_role_assignment_v3"))
+	}
+
+	log.Printf("[DEBUG] Retrieved openstack_identity_inherit_role_assignment_v3 %s", d.Id())
+	d.Set("domain_id", domainID)
+	d.Set("project_id", projectID)
+	d.Set("group_id", groupID)
+	d.Set("user_id", userID)
+	d.Set("role_id", roleID)
+	d.Set("region", GetRegion(d, config))
+
+	return nil
+}
+
+func resourceIdentityInheritRoleAssignmentV3Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating OpenStack identity client: %s", err)
+	}
+
+	domainID, projectID, groupID, userID, roleID, err := identityRoleAssignmentV3ParseID(d.Id())
+	if err != nil {
+		return diag.Errorf("Error determining openstack_identity_inherit_role_assignment_v3 ID: %s", err)
+	}
+
+	opts := osinherit.UnassignOpts{
+		DomainID:  domainID,
+		GroupID:   groupID,
+		ProjectID: projectID,
+		UserID:    userID,
+	}
+
+	if err := osinherit.Unassign(identityClient, roleID, opts).ExtractErr(); err != nil {
+		return diag.FromErr(CheckDeleted(d, err, "Error unassigning openstack_identity_inherit_role_assignment_v3"))
+	}
+
+	return nil
+}

--- a/openstack/resource_openstack_identity_inherit_role_assignment_v3_test.go
+++ b/openstack/resource_openstack_identity_inherit_role_assignment_v3_test.go
@@ -1,0 +1,140 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/osinherit"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
+)
+
+func TestAccIdentityV3InheritRoleAssignment_basic(t *testing.T) {
+	var role roles.Role
+	var user users.User
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckIdentityV3InheritRoleAssignmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityV3InheritRoleAssignmentBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityV3InheritRoleAssignmentExists("openstack_identity_inherit_role_assignment_v3.role_assignment_1", &role, &user),
+					resource.TestCheckResourceAttr(
+						"openstack_identity_inherit_role_assignment_v3.role_assignment_1", "domain_id", "default"),
+					resource.TestCheckResourceAttrPtr(
+						"openstack_identity_inherit_role_assignment_v3.role_assignment_1", "user_id", &user.ID),
+					resource.TestCheckResourceAttrPtr(
+						"openstack_identity_inherit_role_assignment_v3.role_assignment_1", "role_id", &role.ID),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIdentityV3InheritRoleAssignmentDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	identityClient, err := config.IdentityV3Client(osRegionName)
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack identity client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "openstack_identity_inherit_role_assignment_v3" {
+			continue
+		}
+
+		domainID, projectID, groupID, userID, roleID, err := identityRoleAssignmentV3ParseID(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Error determining openstack_identity_inherit_role_assignment_v3 ID: %s", err)
+		}
+
+		var opts = osinherit.ValidateOpts{
+			GroupID:   groupID,
+			DomainID:  domainID,
+			ProjectID: projectID,
+			UserID:    userID,
+		}
+
+		err = osinherit.Validate(identityClient, roleID, opts).ExtractErr()
+		if err == nil {
+			return fmt.Errorf("Inherit Role assignment still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckIdentityV3InheritRoleAssignmentExists(n string, role *roles.Role, user *users.User) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		identityClient, err := config.IdentityV3Client(osRegionName)
+		if err != nil {
+			return fmt.Errorf("Error creating OpenStack identity client: %s", err)
+		}
+
+		domainID, projectID, groupID, userID, roleID, err := identityRoleAssignmentV3ParseID(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Error determining openstack_identity_inherit_role_assignment_v3 ID: %s", err)
+		}
+
+		var opts = osinherit.ValidateOpts{
+			GroupID:   groupID,
+			DomainID:  domainID,
+			ProjectID: projectID,
+			UserID:    userID,
+		}
+
+		err = osinherit.Validate(identityClient, roleID, opts).ExtractErr()
+		if err != nil {
+			return err
+		}
+
+		u, err := users.Get(identityClient, userID).Extract()
+		if err != nil {
+			return fmt.Errorf("User not found")
+		}
+		*user = *u
+		r, err := roles.Get(identityClient, roleID).Extract()
+		if err != nil {
+			return fmt.Errorf("Role not found")
+		}
+		*role = *r
+
+		return nil
+	}
+}
+
+const testAccIdentityV3InheritRoleAssignmentBasic = `
+resource "openstack_identity_user_v3" "user_1" {
+  name = "user_1"
+  domain_id = "default"
+}
+
+resource "openstack_identity_role_v3" "role_1" {
+  name = "role_1"
+  domain_id = "default"
+}
+
+resource "openstack_identity_inherit_role_assignment_v3" "role_assignment_1" {
+  user_id = "${openstack_identity_user_v3.user_1.id}"
+  domain_id = "default"
+  role_id = "${openstack_identity_role_v3.role_1.id}"
+}
+`

--- a/website/docs/r/identity_inherit_role_assignment_v3.html.markdown
+++ b/website/docs/r/identity_inherit_role_assignment_v3.html.markdown
@@ -1,0 +1,78 @@
+---
+subcategory: "Identity / Keystone"
+layout: "openstack"
+page_title: "OpenStack: openstack_identity_inherit_role_assignment_v3"
+sidebar_current: "docs-openstack-resource-identity-inherit-role-assignment-v3"
+description: |-
+  Manages a V3 Inherit Role assignment within OpenStack Keystone.
+---
+
+# openstack\_identity\_inherit\_role\_assignment\_v3
+
+Manages a V3 Inherit Role assignment within OpenStack Keystone. This uses the
+Openstack keystone `OS-INHERIT` api to created inherit roles within domains
+and parent projects for users and groups.
+
+~> **Note:** You _must_ have admin privileges in your OpenStack cloud to use
+this resource.
+
+## Example Usage
+
+```hcl
+resource "openstack_identity_user_v3" "user_1" {
+  name = "user_1"
+  domain_id = "default"
+}
+
+resource "openstack_identity_role_v3" "role_1" {
+  name = "role_1"
+  domain_id = "default"
+}
+
+resource "openstack_identity_inherit_role_assignment_v3" "role_assignment_1" {
+  user_id = "${openstack_identity_user_v3.user_1.id}"
+  domain_id = "default"
+  role_id = "${openstack_identity_role_v3.role_1.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_id` - (Optional; Required if `project_id` is empty) The domain to assign the role in.
+
+* `group_id` - (Optional; Required if `user_id` is empty) The group to assign the role to.
+
+* `project_id` - (Optional; Required if `domain_id` is empty) The project to assign the role in.
+  The project should be able to containt child projects.
+
+* `user_id` - (Optional; Required if `group_id` is empty) The user to assign the role to.
+
+* `role_id` - (Required) The role to assign.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `domain_id` - See Argument Reference above.
+* `project_id` - See Argument Reference above.
+* `group_id` - See Argument Reference above.
+* `user_id` - See Argument Reference above.
+* `role_id` - See Argument Reference above.
+
+## Import
+
+Inherit role assignments can be imported using a constructed id. The id should 
+have the form of `domainID/projectID/groupID/userID/roleID`. When something is
+not used then leave blank.
+
+For example this will import the inherit role assignment for: 
+projectID: 014395cd-89fc-4c9b-96b7-13d1ee79dad2,
+userID: 4142e64b-1b35-44a0-9b1e-5affc7af1106,
+roleID: ea257959-eeb1-4c10-8d33-26f0409a755d
+( domainID and groupID are left blank)
+
+```
+$ terraform import openstack_identity_inherit_role_assignment_v3.role_assignment_1 /014395cd-89fc-4c9b-96b7-13d1ee79dad2//4142e64b-1b35-44a0-9b1e-5affc7af1106/ea257959-eeb1-4c10-8d33-26f0409a755d
+```

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -309,6 +309,9 @@
             <li<%= sidebar_current("docs-openstack-resource-identity-role-assignment-v3") %>>
               <a href="/docs/providers/openstack/r/identity_role_assignment_v3.html">openstack_identity_role_assignment_v3</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-resource-identity-inherit-role-assignment-v3") %>>
+              <a href="/docs/providers/openstack/r/identity_role_assignment_v3.html">openstack_identity_inherit_role_assignment_v3</a>
+            </li>
             <li<%= sidebar_current("docs-openstack-resource-identity-user-v3") %>>
               <a href="/docs/providers/openstack/r/identity_user_v3.html">openstack_identity_user_v3</a>
             </li>


### PR DESCRIPTION
This creates new identity resource for inherited roles using the OS-INHERIT keystone API. Chose to create a new resource instead of adding this functionality to existing role assignment to:
- keep the resources clean and easy
- this is a seperate api, thus i prefer a new resource to manage it
- adding it to existing assignment would require updating the resource id and could impact users

Close #1372 