### PR TITLE
Add openstack_identity_limit_v3 resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-provider-openstack/terraform-provider-openstack
 go 1.20
 
 require (
-	github.com/gophercloud/gophercloud v1.2.1-0.20230309142102-36ac4a411ba7
+	github.com/gophercloud/gophercloud v1.4.0
 	github.com/gophercloud/utils v0.0.0-20230324070755-05e9e7f5ea4d
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/gophercloud/gophercloud v1.1.1/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
 github.com/gophercloud/gophercloud v1.2.1-0.20230309142102-36ac4a411ba7 h1:wDr3jLA3vAtpH5DvqdTHtn34Uo15qA7F6EdEIJtm7+s=
 github.com/gophercloud/gophercloud v1.2.1-0.20230309142102-36ac4a411ba7/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
+github.com/gophercloud/gophercloud v1.4.0 h1:RqEu43vaX0lb0LanZr5BylK5ICVxjpFFoc0sxivyuHU=
+github.com/gophercloud/gophercloud v1.4.0/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
 github.com/gophercloud/utils v0.0.0-20230324070755-05e9e7f5ea4d h1:AfRlf5NnsYsHIW5nNxhYp+99Bmj/fLeOYwD5Z4CMlzw=
 github.com/gophercloud/utils v0.0.0-20230324070755-05e9e7f5ea4d/go.mod h1:z4Dey7xsTUXgcB1C8elMvGRKTjV1ez0eoYQlMrduG1g=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=

--- a/openstack/import_openstack_identity_limit_v3_test.go
+++ b/openstack/import_openstack_identity_limit_v3_test.go
@@ -1,0 +1,31 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIdentityV3Limit_importBasic(t *testing.T) {
+	resourceName := "openstack_identity_limit_v3.limit_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckIdentityV3LimitDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityV3LimitBasic,
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -365,6 +365,7 @@ func Provider() *schema.Provider {
 			"openstack_identity_group_v3":                        resourceIdentityGroupV3(),
 			"openstack_identity_application_credential_v3":       resourceIdentityApplicationCredentialV3(),
 			"openstack_identity_ec2_credential_v3":               resourceIdentityEc2CredentialV3(),
+			"openstack_identity_limit_v3":                        resourceIdentityLimitV3(),
 			"openstack_images_image_v2":                          resourceImagesImageV2(),
 			"openstack_images_image_access_v2":                   resourceImagesImageAccessV2(),
 			"openstack_images_image_access_accept_v2":            resourceImagesImageAccessAcceptV2(),

--- a/openstack/resource_openstack_identity_limit_v3.go
+++ b/openstack/resource_openstack_identity_limit_v3.go
@@ -1,0 +1,170 @@
+package openstack
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/limits"
+)
+
+func resourceIdentityLimitV3() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIdentityLimitV3Create,
+		ReadContext:   resourceIdentityLimitV3Read,
+		UpdateContext: resourceIdentityLimitV3Update,
+		DeleteContext: resourceIdentityLimitV3Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"domain_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"service_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"resource_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"resource_limit": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceIdentityLimitV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating OpenStack identity client: %s", err)
+	}
+
+	createOpts := limits.BatchCreateOpts{
+		limits.CreateOpts{
+			RegionID:      GetRegion(d, config),
+			DomainID:      d.Get("domain_id").(string),
+			ProjectID:     d.Get("project_id").(string),
+			ServiceID:     d.Get("service_id").(string),
+			ResourceName:  d.Get("resource_name").(string),
+			ResourceLimit: d.Get("resource_limit").(int),
+			Description:   d.Get("description").(string),
+		},
+	}
+
+	log.Printf("[DEBUG] openstack_identity_limit_v3 create options: %#v", createOpts)
+	limit, err := limits.BatchCreate(identityClient, createOpts).Extract()
+	if err != nil {
+		return diag.Errorf("Error creating openstack_identity_limit_v3: %s", err)
+	}
+
+	d.SetId(limit[0].ID)
+
+	return resourceIdentityLimitV3Read(ctx, d, meta)
+}
+
+func resourceIdentityLimitV3Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating OpenStack identity client: %s", err)
+	}
+
+	limit, err := limits.Get(identityClient, d.Id()).Extract()
+	if err != nil {
+		return diag.FromErr(CheckDeleted(d, err, "Error retrieving openstack_identity_limit_v3"))
+	}
+
+	log.Printf("[DEBUG] Retrieved openstack_identity_limit_v3: %#v", limit)
+
+	d.Set("region", GetRegion(d, config))
+	d.Set("domain_id", limit.DomainID)
+	d.Set("project_id", limit.ProjectID)
+	d.Set("service_id", limit.ServiceID)
+	d.Set("resource_name", limit.ResourceName)
+	d.Set("resource_limit", limit.ResourceLimit)
+	d.Set("description", limit.Description)
+
+	return nil
+}
+
+func resourceIdentityLimitV3Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating OpenStack identity client: %s", err)
+	}
+
+	var hasChange bool
+	var updateOpts limits.UpdateOpts
+
+	if d.HasChange("resource_limit") {
+		hasChange = true
+		resourceLimit := d.Get("resource_limit").(int)
+		updateOpts.ResourceLimit = &resourceLimit
+	}
+
+	if d.HasChange("description") {
+		hasChange = true
+		description := d.Get("description").(string)
+		updateOpts.Description = &description
+	}
+
+	if hasChange {
+		_, err := limits.Update(identityClient, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return diag.Errorf("Error updating openstack_identity_limit_v3 %s: %s", d.Id(), err)
+		}
+	}
+
+	return resourceIdentityLimitV3Read(ctx, d, meta)
+}
+
+func resourceIdentityLimitV3Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating OpenStack identity client: %s", err)
+	}
+
+	err = limits.Delete(identityClient, d.Id()).ExtractErr()
+	if err != nil {
+		return diag.FromErr(CheckDeleted(d, err, "Error deleting openstack_identity_limit_v3"))
+	}
+
+	return nil
+}

--- a/openstack/resource_openstack_identity_limit_v3_test.go
+++ b/openstack/resource_openstack_identity_limit_v3_test.go
@@ -1,0 +1,157 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/limits"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/services"
+)
+
+func TestAccIdentityV3Limit_basic(t *testing.T) {
+	var project projects.Project
+	var service services.Service
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckIdentityV3LimitDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityV3LimitBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityV3LimitExists("openstack_identity_limit_v3.limit_1", &project, &service),
+					resource.TestCheckResourceAttrPtr(
+						"openstack_identity_limit_v3.limit_1", "service_id", &service.ID),
+					resource.TestCheckResourceAttrPtr(
+						"openstack_identity_limit_v3.limit_1", "project_id", &project.ID),
+					resource.TestCheckResourceAttr(
+						"openstack_identity_limit_v3.limit_1", "resource_name", "image_count_total"),
+					resource.TestCheckResourceAttr(
+						"openstack_identity_limit_v3.limit_1", "resource_limit", "10"),
+					resource.TestCheckResourceAttr(
+						"openstack_identity_limit_v3.limit_1", "description", "foo"),
+				),
+			},
+			{
+				Config: testAccIdentityV3LimitUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityV3LimitExists("openstack_identity_limit_v3.limit_1", &project, &service),
+					resource.TestCheckResourceAttrPtr(
+						"openstack_identity_limit_v3.limit_1", "service_id", &service.ID),
+					resource.TestCheckResourceAttrPtr(
+						"openstack_identity_limit_v3.limit_1", "project_id", &project.ID),
+					resource.TestCheckResourceAttr(
+						"openstack_identity_limit_v3.limit_1", "resource_name", "image_count_total"),
+					resource.TestCheckResourceAttr(
+						"openstack_identity_limit_v3.limit_1", "resource_limit", "10"),
+					resource.TestCheckResourceAttr(
+						"openstack_identity_limit_v3.limit_1", "description", "bar"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIdentityV3LimitDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	identityClient, err := config.IdentityV3Client(osRegionName)
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack identity client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "openstack_identity_limit_v3" {
+			continue
+		}
+
+		_, err := limits.Get(identityClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Limit still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckIdentityV3LimitExists(n string, project *projects.Project, service *services.Service) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		identityClient, err := config.IdentityV3Client(osRegionName)
+		if err != nil {
+			return fmt.Errorf("Error creating OpenStack identity client: %s", err)
+		}
+
+		found, err := limits.Get(identityClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("Limit not found")
+		}
+
+		project, err = projects.Get(identityClient, found.ProjectID).Extract()
+		if err != nil {
+			return fmt.Errorf("Error retrieving OpenStack project %s: %s", found.ProjectID, err)
+		}
+
+		service, err = services.Get(identityClient, found.ServiceID).Extract()
+		if err != nil {
+			return fmt.Errorf("Error retrieving OpenStack service %s: %s", found.ServiceID, err)
+		}
+
+		return nil
+	}
+}
+
+const testAccIdentityV3LimitBasic = `
+data "openstack_identity_service_v3" "glance" {
+	name = "glance"
+}
+
+resource "openstack_identity_project_v3" "project_1" {
+	name = "project_1"
+}
+
+resource "openstack_identity_limit_v3" "limit_1" {
+	project_id = openstack_identity_project_v3.project_1.id
+	service_id = data.openstack_identity_service_v3.glance.id
+	resource_name = "image_count_total"
+	resource_limit = 10 
+	description = "foo"
+}
+`
+
+const testAccIdentityV3LimitUpdate = `
+data "openstack_identity_service_v3" "glance" {
+	name = "glance"
+}
+
+resource "openstack_identity_project_v3" "project_1" {
+	name = "project_1"
+}
+
+resource "openstack_identity_limit_v3" "limit_1" {
+	project_id = openstack_identity_project_v3.project_1.id
+	service_id = data.openstack_identity_service_v3.glance.id
+	resource_name = "image_count_total"
+	resource_limit = 100 
+	description = "bar"
+}
+`

--- a/website/docs/r/identity_limit_v3.html.markdown
+++ b/website/docs/r/identity_limit_v3.html.markdown
@@ -1,0 +1,82 @@
+---
+subcategory: "Identity / Keystone"
+layout: "openstack"
+page_title: "OpenStack: openstack_identity_limit_v3"
+sidebar_current: "docs-openstack-resource-identity-limit-v3"
+description: |-
+  Manages a V3 Limit resource within OpenStack Keystone.
+---
+
+# openstack\_identity\_limit\_v3
+
+Manages a V3 Limit resource within OpenStack Keystone.
+
+~> **Note:** You _must_ have admin privileges in your OpenStack cloud to use
+this resource.
+
+## Example Usage
+
+```hcl
+data "openstack_identity_service_v3" "glance" {
+	name = "glance"
+}
+
+resource "openstack_identity_project_v3" "project_1" {
+	name = "project_1"
+}
+
+resource "openstack_identity_limit_v3" "limit_1" {
+	project_id     = openstack_identity_project_v3.project_1.id
+	service_id     = data.openstack_identity_service_v3.glance.id
+	resource_name  = "image_count_total"
+	resource_limit = 10 
+	description    = "foo"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_id` - (Optional) The project the limit applies to. Changing this
+    creates a new Limit.
+
+* `domain_id` - (Optional) The domain the limit applies to. Changing this
+    creates a new Limit.
+
+* `region` - (Optional) The region in which to obtain the V3 Keystone client.
+    If omitted, the `region` argument of the provider is used. Changing this
+    creates a new Limit.
+
+* `service_id` - (Required) The service the limit applies to. Changing this
+    creates a new Limit.
+
+* `resource_name` - (Required) The resource that the limit applies to. Changing 
+    this creates a new Limit.
+
+* `resource_limit` - (Required) Integer for the actual limit.
+
+* `description` - (Optional) Description of the limit
+
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The id of the limit
+* `project_id` - See Argument Reference above.
+* `domain_id` - See Argument Reference above.
+* `region` - See Argument Reference above.
+* `service_id` - See Argument Reference above.
+* `resource_name` - See Argument Reference above.
+* `resource_limit` - See Argument Reference above.
+* `description` - See Argument Reference above.
+
+## Import
+
+Limits can be imported using the `id`, e.g.
+
+```
+$ terraform import openstack_identity_limit_v3.limit_1 89c60255-9bd6-460c-822a-e2b959ede9d2
+```

--- a/website/openstack.erb
+++ b/website/openstack.erb
@@ -318,6 +318,9 @@
             <li<%= sidebar_current("docs-openstack-resource-identity-service-v3") %>>
               <a href="/docs/providers/openstack/r/identity_service_v3.html">openstack_identity_service_v3</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-resource-identity-limit-v3") %>>
+              <a href="/docs/providers/openstack/r/identity_limit_v3.html">openstack_identity_limit_v3</a>
+            </li>
           </ul>
         </li>
 


### PR DESCRIPTION
Add openstack_identity_limit_v3 resource, import test and documentation. Limit resource creates only 1 limit, instead of multiple as the api allows. The reasoning is that a single limit leads to much easier code to understand and maintain, while multiple limits would create issues in handling ids, updates etc.