### PR TITLE
[containerinfra_cluster_v1] add kubeconfig to data source

### DIFF
--- a/openstack/data_source_openstack_containerinfra_cluster_v1.go
+++ b/openstack/data_source_openstack_containerinfra_cluster_v1.go
@@ -142,6 +142,12 @@ func dataSourceContainerInfraCluster() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"kubeconfig": {
+				Type:      schema.TypeMap,
+				Computed:  true,
+				Sensitive: true,
+				Elem:      &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -181,6 +187,11 @@ func dataSourceContainerInfraClusterRead(ctx context.Context, d *schema.Resource
 	d.Set("fixed_network", c.FixedNetwork)
 	d.Set("fixed_subnet", c.FixedSubnet)
 	d.Set("floating_ip_enabled", c.FloatingIPEnabled)
+	kubeconfig, err := flattenContainerInfraV1Kubeconfig(d, containerInfraClient)
+	if err != nil {
+		return diag.Errorf("Error building kubeconfig for openstack_containerinfra_cluster_v1 %s: %s", d.Id(), err)
+	}
+	d.Set("kubeconfig", kubeconfig)
 
 	if err := d.Set("labels", c.Labels); err != nil {
 		log.Printf("[DEBUG] Unable to set labels for openstack_containerinfra_cluster_v1 %s: %s", c.UUID, err)

--- a/openstack/data_source_openstack_containerinfra_cluster_v1_test.go
+++ b/openstack/data_source_openstack_containerinfra_cluster_v1_test.go
@@ -56,6 +56,7 @@ func TestAccContainerInfraV1ClusterDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "node_addresses.#", strconv.Itoa(1)),
 					resource.TestCheckResourceAttrSet(resourceName, "stack_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "floating_ip_enabled"),
+					resource.TestCheckResourceAttrSet(resourceName, "kubeconfig"),
 				),
 			},
 		},

--- a/website/docs/d/containerinfra_cluster_v1.html.markdown
+++ b/website/docs/d/containerinfra_cluster_v1.html.markdown
@@ -79,3 +79,15 @@ attributes are exported:
 * `node_addresses` - IP addresses of the node of the cluster.
 
 * `stack_id` - UUID of the Orchestration service stack.
+
+* `kubeconfig` - The Kubernetes cluster's credentials
+
+  * `raw_config` - The raw kubeconfig file
+
+  * `host` - The cluster's API server URL
+
+  * `cluster_ca_certificate` - The cluster's CA certificate
+
+  * `client_key` - The client's RSA key
+  
+  * `client_certificate` - The client's certificate


### PR DESCRIPTION
Hello,

We needed the kubeconfig attribute in order to parameter our kubernetes provider, so we implemented it.

I hope we did not miss anything, we are using it right now and it  :copyright: works on my machine :copyright: 

fix #1442