### PR TITLE
Explicitly use ExtractErr() call instead of accessing res.Err

### DIFF
--- a/openstack/resource_openstack_images_image_v2.go
+++ b/openstack/resource_openstack_images_image_v2.go
@@ -290,9 +290,9 @@ func resourceImagesImageV2Create(ctx context.Context, d *schema.ResourceData, me
 		}
 
 		log.Printf("[DEBUG] Import Options: %#v", importOpts)
-		res := imageimport.Create(imageClient, d.Id(), importOpts)
-		if res.Err != nil {
-			return diag.Errorf("Error while importing url %q: %s", imgURL, res.Err)
+		err = imageimport.Create(imageClient, d.Id(), importOpts).ExtractErr()
+		if err != nil {
+			return diag.Errorf("Error while importing url %q: %s", imgURL, err)
 		}
 	} else {
 		// variable declaration
@@ -319,9 +319,9 @@ func resourceImagesImageV2Create(ctx context.Context, d *schema.ResourceData, me
 		defer imgFile.Close()
 		log.Printf("[WARN] Uploading image %s (%d bytes). This can be pretty long.", d.Id(), fileSize)
 
-		res := imagedata.Upload(imageClient, d.Id(), imgFile)
-		if res.Err != nil {
-			return diag.Errorf("Error while uploading file %q: %s", imgFilePath, res.Err)
+		err = imagedata.Upload(imageClient, d.Id(), imgFile).ExtractErr()
+		if err != nil {
+			return diag.Errorf("Error while uploading file %q: %s", imgFilePath, err)
 		}
 	}
 

--- a/openstack/resource_openstack_keymanager_container_v1.go
+++ b/openstack/resource_openstack_keymanager_container_v1.go
@@ -257,19 +257,19 @@ func resourceKeyManagerContainerV1Update(ctx context.Context, d *schema.Resource
 
 		// delete old references first
 		for _, delRef := range expandKeyManagerContainerV1SecretRefs(delRefs) {
-			res := containers.DeleteSecretRef(kmClient, d.Id(), delRef)
-			if res.Err != nil {
-				if _, ok := res.Err.(gophercloud.ErrDefault404); !ok {
-					return diag.Errorf("Error removing old %s secret reference from the %s container: %s", delRef.Name, d.Id(), res.Err)
+			err := containers.DeleteSecretRef(kmClient, d.Id(), delRef).ExtractErr()
+			if err != nil {
+				if _, ok := err.(gophercloud.ErrDefault404); !ok {
+					return diag.Errorf("Error removing old %s secret reference from the %s container: %s", delRef.Name, d.Id(), err)
 				}
 			}
 		}
 
 		// then add new ones
 		for _, addRef := range expandKeyManagerContainerV1SecretRefs(addRefs) {
-			res := containers.CreateSecretRef(kmClient, d.Id(), addRef)
-			if res.Err != nil {
-				return diag.Errorf("Error adding new %s secret reference to the %s container: %s", addRef.Name, d.Id(), res.Err)
+			_, err := containers.CreateSecretRef(kmClient, d.Id(), addRef).Extract()
+			if err != nil {
+				return diag.Errorf("Error adding new %s secret reference to the %s container: %s", addRef.Name, d.Id(), err)
 			}
 		}
 	}


### PR DESCRIPTION
This is a minor change to explicitly use the `ExtractErr()` call to fetch errors.