### PR TITLE
Add deprecation warning to various resources

### DIFF
--- a/openstack/data_source_openstack_blockstorage_snapshot_v2.go
+++ b/openstack/data_source_openstack_blockstorage_snapshot_v2.go
@@ -14,6 +14,7 @@ func dataSourceBlockStorageSnapshotV2() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceBlockStorageSnapshotV2Read,
 
+		DeprecationMessage: "use openstack_blockstorage_snapshot_v3 data-source instead",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/openstack/data_source_openstack_blockstorage_volume_v2.go
+++ b/openstack/data_source_openstack_blockstorage_volume_v2.go
@@ -14,6 +14,7 @@ func dataSourceBlockStorageVolumeV2() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceBlockStorageVolumeV2Read,
 
+		DeprecationMessage: "use openstack_blockstorage_volume_v3 data-source instead",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/openstack/data_source_openstack_fw_policy_v1.go
+++ b/openstack/data_source_openstack_fw_policy_v1.go
@@ -14,6 +14,7 @@ func dataSourceFWPolicyV1() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceFWPolicyV1Read,
 
+		DeprecationMessage: "use openstack_fw_policy_v2 data-source instead",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/openstack/resource_openstack_blockstorage_quotaset_v2.go
+++ b/openstack/resource_openstack_blockstorage_quotaset_v2.go
@@ -29,6 +29,7 @@ func resourceBlockStorageQuotasetV2() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		DeprecationMessage: "use openstack_blockstorage_quotaset_v3 resource instead",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/openstack/resource_openstack_blockstorage_volume_attach_v2.go
+++ b/openstack/resource_openstack_blockstorage_volume_attach_v2.go
@@ -26,6 +26,7 @@ func resourceBlockStorageVolumeAttachV2() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		DeprecationMessage: "use openstack_blockstorage_volume_attach_v3 resource instead",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/openstack/resource_openstack_blockstorage_volume_v1.go
+++ b/openstack/resource_openstack_blockstorage_volume_v1.go
@@ -29,6 +29,7 @@ func resourceBlockStorageVolumeV1() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		DeprecationMessage: "use openstack_blockstorage_volume_v3 resource instead",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/openstack/resource_openstack_blockstorage_volume_v2.go
+++ b/openstack/resource_openstack_blockstorage_volume_v2.go
@@ -30,6 +30,7 @@ func resourceBlockStorageVolumeV2() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		DeprecationMessage: "use openstack_blockstorage_volume_v3 resource instead",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/openstack/resource_openstack_fw_firewall_v1.go
+++ b/openstack/resource_openstack_fw_firewall_v1.go
@@ -29,6 +29,7 @@ func resourceFWFirewallV1() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		DeprecationMessage: "openstack_fw_fireall_v1 is deprecated. Consider using FWaaS v2",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/openstack/resource_openstack_fw_policy_v1.go
+++ b/openstack/resource_openstack_fw_policy_v1.go
@@ -27,6 +27,7 @@ func resourceFWPolicyV1() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		DeprecationMessage: "use openstack_fw_policy_v2 resource instead",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/openstack/resource_openstack_fw_rule_v1.go
+++ b/openstack/resource_openstack_fw_rule_v1.go
@@ -21,6 +21,7 @@ func resourceFWRuleV1() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
+		DeprecationMessage: "use openstack_fw_rule_v2 resource instead",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/openstack/resource_openstack_lb_member_v1.go
+++ b/openstack/resource_openstack_lb_member_v1.go
@@ -28,6 +28,7 @@ func resourceLBMemberV1() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		DeprecationMessage: "use openstack_lb_member_v2 resource instead",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/openstack/resource_openstack_lb_monitor_v1.go
+++ b/openstack/resource_openstack_lb_monitor_v1.go
@@ -29,6 +29,7 @@ func resourceLBMonitorV1() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		DeprecationMessage: "use openstack_lb_monitor_v2 resource instead",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/openstack/resource_openstack_lb_pool_v1.go
+++ b/openstack/resource_openstack_lb_pool_v1.go
@@ -28,6 +28,7 @@ func resourceLBPoolV1() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		DeprecationMessage: "use openstack_lb_pool_v2 resource instead",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/openstack/resource_openstack_lb_vip_v1.go
+++ b/openstack/resource_openstack_lb_vip_v1.go
@@ -29,6 +29,7 @@ func resourceLBVipV1() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		DeprecationMessage: "openstack_lb_vip_v1 is deprecated. Consider using LBaaS v2 / Octavia resources",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Various resources have been documented as deprecated. Additionally add a deprecation warning for the user.

The related resources have been deprecated on openstack side for many releases now. We do not have any deprecation policy in place and there is no big harm keeping the code (if it doesn't block newer features etc which typically it doesn't). Nonetheless we do not have any ci coverage for these resources for years and it is good to warn the user that these are deprecated.