### PR TITLE
Set segments.segmentation_id as computed on networks

### DIFF
--- a/openstack/resource_openstack_networking_network_v2.go
+++ b/openstack/resource_openstack_networking_network_v2.go
@@ -102,6 +102,7 @@ func resourceNetworkingNetworkV2() *schema.Resource {
 						"segmentation_id": {
 							Type:     schema.TypeInt,
 							Optional: true,
+							Computed: true,
 						},
 					},
 				},


### PR DESCRIPTION
`Segmentation_id` on openstack_networking_network_v2:
1. is statically defined by the user: in this case any changes on it should trigger a recreation of the network.
2. is not defined by the user but neutron has an available pool: in this case, neutron picks a segmentation_id from the pool and allocates it for this network. Thus the value is computed by neutron. 

Because use-case 1 AND 2 are valid (depending on the cloud configuration) we cannot use something like [DiffSuppressFunc](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#diffsuppressfunc). Setting it as `computed` should work in both cases. 

Unfortunately i dont think we can easily test this in the ci.

Close #1560 