### PR TITLE
Modernize splat syntax-related examples

### DIFF
--- a/docs/resources/compute_interface_attach_v2.md
+++ b/docs/resources/compute_interface_attach_v2.md
@@ -105,7 +105,7 @@ resource "openstack_compute_instance_v2" "instance_1" {
 
 resource "openstack_compute_interface_attach_v2" "attachments" {
   count       = 2
-  port_id     = "${openstack_networking_port_v2.ports.*.id[count.index]}"
+  port_id     = openstack_networking_port_v2.ports[count.index].id
   instance_id = openstack_compute_instance_v2.instance_1.id
 }
 ```
@@ -137,12 +137,12 @@ resource "openstack_compute_instance_v2" "instance_1" {
 
 resource "openstack_compute_interface_attach_v2" "ai_1" {
   instance_id = openstack_compute_instance_v2.instance_1.id
-  port_id     = "${openstack_networking_port_v2.ports.*.id[0]}"
+  port_id     = openstack_networking_port_v2.ports[0].id
 }
 
 resource "openstack_compute_interface_attach_v2" "ai_2" {
   instance_id = openstack_compute_instance_v2.instance_1.id
-  port_id     = "${openstack_networking_port_v2.ports.*.id[1]}"
+  port_id     = openstack_networking_port_v2.ports[1].id
 }
 ```
 

--- a/docs/resources/compute_volume_attach_v2.md
+++ b/docs/resources/compute_volume_attach_v2.md
@@ -50,11 +50,11 @@ resource "openstack_compute_instance_v2" "instance_1" {
 resource "openstack_compute_volume_attach_v2" "attachments" {
   count       = 2
   instance_id = openstack_compute_instance_v2.instance_1.id
-  volume_id   = "${openstack_blockstorage_volume_v2.volumes.*.id[count.index]}"
+  volume_id   = openstack_blockstorage_volume_v2.volumes[count.index].id
 }
 
 output "volume_devices" {
-  value = "${openstack_compute_volume_attach_v2.attachments.*.device}"
+  value = openstack_compute_volume_attach_v2.attachments.*.device
 }
 ```
 


### PR DESCRIPTION
See #1585 (50b9dacd9d5b1178b9932786d188e0ba940cd072) for background.

These splat uses were ommitted from the original patch because they're slightly more complicated and easier to just think about separately.