### PR TITLE
Add bobcat to ci jobs and remove xena

### DIFF
--- a/.github/workflows/functional-blockstorage_v3.yml
+++ b/.github/workflows/functional-blockstorage_v3.yml
@@ -23,6 +23,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "bobcat"
+            openstack_version: "stable/2023.2"
+            ubuntu_version: "22.04"
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
@@ -31,9 +34,6 @@ jobs:
             ubuntu_version: "20.04"        
           - name: "yoga"
             openstack_version: "stable/yoga"
-            ubuntu_version: "20.04"
-          - name: "xena"
-            openstack_version: "stable/xena"
             ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: blockstorage_v3 on OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests

--- a/.github/workflows/functional-compute.yml
+++ b/.github/workflows/functional-compute.yml
@@ -21,6 +21,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "bobcat"
+            openstack_version: "stable/2023.2"
+            ubuntu_version: "22.04"
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
@@ -29,9 +32,6 @@ jobs:
             ubuntu_version: "20.04"        
           - name: "yoga"
             openstack_version: "stable/yoga"
-            ubuntu_version: "20.04"
-          - name: "xena"
-            openstack_version: "stable/xena"
             ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: compute on OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests

--- a/.github/workflows/functional-dns.yml
+++ b/.github/workflows/functional-dns.yml
@@ -20,6 +20,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "bobcat"
+            openstack_version: "stable/2023.2"
+            ubuntu_version: "22.04"
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
@@ -28,9 +31,6 @@ jobs:
             ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
-            ubuntu_version: "20.04"
-          - name: "xena"
-            openstack_version: "stable/xena"
             ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: dns on OpenStack ${{ matrix.name }} with Designate and run dns acceptance tests

--- a/.github/workflows/functional-fwaas_v2.yml
+++ b/.github/workflows/functional-fwaas_v2.yml
@@ -22,6 +22,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "bobcat"
+            openstack_version: "stable/2023.2"
+            ubuntu_version: "22.04"
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-identity.yml
+++ b/.github/workflows/functional-identity.yml
@@ -21,6 +21,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "bobcat"
+            openstack_version: "stable/2023.2"
+            ubuntu_version: "22.04"
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
@@ -29,9 +32,6 @@ jobs:
             ubuntu_version: "20.04"        
           - name: "yoga"
             openstack_version: "stable/yoga"
-            ubuntu_version: "20.04"
-          - name: "xena"
-            openstack_version: "stable/xena"
             ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: identity on OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests

--- a/.github/workflows/functional-images.yml
+++ b/.github/workflows/functional-images.yml
@@ -21,6 +21,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "bobcat"
+            openstack_version: "stable/2023.2"
+            ubuntu_version: "22.04"
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
@@ -29,9 +32,6 @@ jobs:
             ubuntu_version: "20.04"        
           - name: "yoga"
             openstack_version: "stable/yoga"
-            ubuntu_version: "20.04"
-          - name: "xena"
-            openstack_version: "stable/xena"
             ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: images/glance on OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests

--- a/.github/workflows/functional-keymanager.yml
+++ b/.github/workflows/functional-keymanager.yml
@@ -23,6 +23,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "bobcat"
+            openstack_version: "stable/2023.2"
+            ubuntu_version: "22.04"
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
@@ -31,9 +34,6 @@ jobs:
             ubuntu_version: "20.04"        
           - name: "yoga"
             openstack_version: "stable/yoga"
-            ubuntu_version: "20.04"
-          - name: "xena"
-            openstack_version: "stable/xena"
             ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: keymanager on OpenStack ${{ matrix.name }} with Barbican and run keymanager acceptance tests

--- a/.github/workflows/functional-loadbalancer.yml
+++ b/.github/workflows/functional-loadbalancer.yml
@@ -20,6 +20,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "bobcat"
+            openstack_version: "stable/2023.2"
+            ubuntu_version: "22.04"
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
@@ -28,9 +31,6 @@ jobs:
             ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
-            ubuntu_version: "20.04"
-          - name: "xena"
-            openstack_version: "stable/xena"
             ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: loadbalancing for OpenStack ${{ matrix.name }} with Octavia and run loadbalancer acceptance tests

--- a/.github/workflows/functional-networking.yml
+++ b/.github/workflows/functional-networking.yml
@@ -21,6 +21,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "bobcat"
+            openstack_version: "stable/2023.2"
+            ubuntu_version: "22.04"
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
@@ -29,9 +32,6 @@ jobs:
             ubuntu_version: "20.04"         
           - name: "yoga"
             openstack_version: "stable/yoga"
-            ubuntu_version: "20.04"
-          - name: "xena"
-            openstack_version: "stable/xena"
             ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: networking on OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests

--- a/.github/workflows/functional-objectstorage.yml
+++ b/.github/workflows/functional-objectstorage.yml
@@ -20,6 +20,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "bobcat"
+            openstack_version: "stable/2023.2"
+            ubuntu_version: "22.04"
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
@@ -28,9 +31,6 @@ jobs:
             ubuntu_version: "20.04"        
           - name: "yoga"
             openstack_version: "stable/yoga"
-            ubuntu_version: "20.04"
-          - name: "xena"
-            openstack_version: "stable/xena"
             ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: objectstorage OpenStack ${{ matrix.name }} with Swift and run objectstorage acceptance tests

--- a/.github/workflows/functional-orchestration.yml
+++ b/.github/workflows/functional-orchestration.yml
@@ -20,6 +20,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "bobcat"
+            openstack_version: "stable/2023.2"
+            ubuntu_version: "22.04"
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
@@ -28,9 +31,6 @@ jobs:
             ubuntu_version: "20.04"        
           - name: "yoga"
             openstack_version: "stable/yoga"
-            ubuntu_version: "20.04"
-          - name: "xena"
-            openstack_version: "stable/xena"
             ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Heat and run orchestration acceptance tests

--- a/.github/workflows/functional-sharedfilesystem.yml
+++ b/.github/workflows/functional-sharedfilesystem.yml
@@ -20,6 +20,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "bobcat"
+            openstack_version: "stable/2023.2"
+            ubuntu_version: "22.04"
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
@@ -28,9 +31,6 @@ jobs:
             ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
-            ubuntu_version: "20.04"
-          - name: "xena"
-            openstack_version: "stable/xena"
             ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: sharedfilesystem on OpenStack ${{ matrix.name }} with Manila and run sharedfilesystem acceptance tests

--- a/.github/workflows/functional-vpnaas.yml
+++ b/.github/workflows/functional-vpnaas.yml
@@ -20,6 +20,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]      
         include:
+          - name: "bobcat"
+            openstack_version: "stable/2023.2"
+            ubuntu_version: "22.04"
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
@@ -28,9 +31,6 @@ jobs:
             ubuntu_version: "20.04"
           - name: "yoga"
             openstack_version: "stable/yoga"
-            ubuntu_version: "20.04"
-          - name: "xena"
-            openstack_version: "stable/xena"
             ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: vpnaas on OpenStack ${{ matrix.name }} with Neutron and run vpnaas acceptance tests


### PR DESCRIPTION
Openstack Bobcat was released 04/10. Add it to the ci jobs and remove Xena to cover the 4 latest Openstack releases on the ci