### PR TITLE
Update ci triggers to exclude docs

### DIFF
--- a/.github/workflows/functional-blockstorage_v2.yml
+++ b/.github/workflows/functional-blockstorage_v2.yml
@@ -8,7 +8,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/functional-blockstorage_v2.yml'
-      - '**blockstorage**'
+      - 'go.mod'
+      - 'openstack/**blockstorage**'
       - '!**v3**'
 jobs:
   functional-basic:

--- a/.github/workflows/functional-blockstorage_v3.yml
+++ b/.github/workflows/functional-blockstorage_v3.yml
@@ -7,7 +7,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/functional-blockstorage_v3.yml'
-      - '**blockstorage**'
+      - 'go.mod'
+      - 'openstack/**blockstorage**'
       - '!**v2**'
       - '!**v1**'
       - 'CHANGELOG.md'

--- a/.github/workflows/functional-compute.yml
+++ b/.github/workflows/functional-compute.yml
@@ -7,7 +7,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/functional-compute.yml'
-      - '**compute**'
+      - 'go.mod'
+      - 'openstack/**compute**'
       - 'CHANGELOG.md'
       - 'scripts/*'      
   schedule:

--- a/.github/workflows/functional-dns.yml
+++ b/.github/workflows/functional-dns.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/functional-dns.yml'
-      - '**dns**'
+      - 'go.mod'
+      - 'openstack/**dns**'
       - 'CHANGELOG.md'
       - 'scripts/*'
   schedule:

--- a/.github/workflows/functional-fwaas_v2.yml
+++ b/.github/workflows/functional-fwaas_v2.yml
@@ -7,7 +7,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/functional-fwaas.yml'
-      - '**_fw_**'
+      - 'go.mod'
+      - 'openstack/**_fw_**'
       - '!**v1**'
       - 'CHANGELOG.md'
       - 'scripts/*'

--- a/.github/workflows/functional-identity.yml
+++ b/.github/workflows/functional-identity.yml
@@ -7,7 +7,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/functional-identity.yml'
-      - '**identity**'
+      - 'go.mod'
+      - 'openstack/**identity**'
       - 'CHANGELOG.md'
       - 'scripts/*'
   schedule:

--- a/.github/workflows/functional-images.yml
+++ b/.github/workflows/functional-images.yml
@@ -7,7 +7,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/functional-images.yml'
-      - '**images**'
+      - 'go.mod'
+      - 'openstack/**images**'
       - 'CHANGELOG.md'
       - 'scripts/*'
   schedule:

--- a/.github/workflows/functional-keymanager.yml
+++ b/.github/workflows/functional-keymanager.yml
@@ -9,7 +9,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/functional-keymanager.yml'
-      - '**keymanager**'
+      - 'go.mod'
+      - 'openstack/**keymanager**'
       - 'CHANGELOG.md'
       - 'scripts/*'
   schedule:

--- a/.github/workflows/functional-loadbalancer.yml
+++ b/.github/workflows/functional-loadbalancer.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/functional-loadbalancer.yml'
-      - '**_lb_**'
+      - 'go.mod'
+      - 'openstack/**_lb_**'
       - 'CHANGELOG.md'
       - 'scripts/*'
   schedule:

--- a/.github/workflows/functional-networking.yml
+++ b/.github/workflows/functional-networking.yml
@@ -7,7 +7,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/functional-networking.yml'
-      - '**networking**'
+      - 'go.mod'
+      - 'openstack/**networking**'
       - 'CHANGELOG.md'
       - 'scripts/*'
   schedule:

--- a/.github/workflows/functional-objectstorage.yml
+++ b/.github/workflows/functional-objectstorage.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/functional-objectstorage.yml'
-      - '**objectstorage**'
+      - 'go.mod'
+      - 'openstack/**objectstorage**'
       - 'CHANGELOG.md'
       - 'scripts/*'
   schedule:

--- a/.github/workflows/functional-orchestration.yml
+++ b/.github/workflows/functional-orchestration.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/functional-orchestration.yml'
-      - '**orchestration**'
+      - 'go.mod'
+      - 'openstack/**orchestration**'
       - 'CHANGELOG.md'
       - 'scripts/*'
   schedule:

--- a/.github/workflows/functional-sharedfilesystem.yml
+++ b/.github/workflows/functional-sharedfilesystem.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/functional-sharedfilesystem.yml'
-      - '**sharedfilesystem**'
+      - 'go.mod'
+      - 'openstack/**sharedfilesystem**'
       - 'CHANGELOG.md'
       - 'scripts/*'
   schedule:

--- a/.github/workflows/functional-vpnaas.yml
+++ b/.github/workflows/functional-vpnaas.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/functional-vpnaas.yml'
-      - '**vpnaas**'
+      - 'go.mod'
+      - 'openstack/**vpnaas**'
       - 'CHANGELOG.md'
       - 'scripts/*'
   schedule:


### PR DESCRIPTION
Currently workflows are triggered also on docs updates. Update workflows to trigger them only when a resource is actually updated or go.mod changed