### PR TITLE
data_source_blockstorage_volume_v3: Add Attachment Information

### DIFF
--- a/docs/data-sources/blockstorage_volume_v3.md
+++ b/docs/data-sources/blockstorage_volume_v3.md
@@ -45,3 +45,6 @@ are exported:
 * `source_volume_id` - The ID of the volume from which the current volume was created.
 * `multiattach` - Indicates if the volume can be attached to more then one server.
 * `host` - The OpenStack host on which the volume is located.
+* `attachment` - If a volume is attached to an instance, this attribute will
+    display the Attachment ID, Instance ID, and the Device as the Instance
+    sees it.

--- a/openstack/data_source_openstack_blockstorage_volume_v3.go
+++ b/openstack/data_source_openstack_blockstorage_volume_v3.go
@@ -73,6 +73,28 @@ func dataSourceBlockStorageVolumeV3() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+
+			"attachment": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"device": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+				Set: blockStorageVolumeV3AttachmentHash,
+			},
 		},
 	}
 }
@@ -133,4 +155,12 @@ func dataSourceBlockStorageVolumeV3Attributes(d *schema.ResourceData, volume Vol
 	if err := d.Set("metadata", volume.Metadata); err != nil {
 		log.Printf("[DEBUG] Unable to set metadata for openstack_blockstorage_volume_v3 %s: %s", volume.ID, err)
 	}
+
+	attachments := flattenBlockStorageVolumeV3Attachments(volume.Attachments)
+	log.Printf("[DEBUG] openstack_blockstorage_volume_v3 %s attachments: %#v", d.Id(), attachments)
+	if err := d.Set("attachment", attachments); err != nil {
+		log.Printf(
+			"[DEBUG] unable to set openstack_blockstorage_volume_v3 %s attachments: %s", d.Id(), err)
+	}
+
 }

--- a/openstack/data_source_openstack_blockstorage_volume_v3.go
+++ b/openstack/data_source_openstack_blockstorage_volume_v3.go
@@ -162,5 +162,4 @@ func dataSourceBlockStorageVolumeV3Attributes(d *schema.ResourceData, volume Vol
 		log.Printf(
 			"[DEBUG] unable to set openstack_blockstorage_volume_v3 %s attachments: %s", d.Id(), err)
 	}
-
 }

--- a/openstack/data_source_openstack_blockstorage_volume_v3_test.go
+++ b/openstack/data_source_openstack_blockstorage_volume_v3_test.go
@@ -135,7 +135,7 @@ func TestAccBlockStorageV3VolumeDataSource_attachment(t *testing.T) {
 			{
 				Config: testAccBlockStorageV3VolumeDataSourceAttachment(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair("data.openstack_blockstorage_volume_v3.volume_1", "attachment", "openstack_blockstorage_volume_v3.data_1", "attachment"),
+					resource.TestCheckResourceAttrPair("data.openstack_blockstorage_volume_v3.volume_1", "attachment", "openstack_blockstorage_volume_v3.volume_1", "attachment"),
 				),
 			},
 		},

--- a/openstack/data_source_openstack_blockstorage_volume_v3_test.go
+++ b/openstack/data_source_openstack_blockstorage_volume_v3_test.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -124,6 +125,8 @@ func testAccBlockStorageV3VolumeDataSourceBasic(snapshotName string) string {
 }
 
 func TestAccBlockStorageV3VolumeDataSource_attachment(t *testing.T) {
+	var dataVolume volumes.Volume
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -135,7 +138,9 @@ func TestAccBlockStorageV3VolumeDataSource_attachment(t *testing.T) {
 			{
 				Config: testAccBlockStorageV3VolumeDataSourceAttachment(),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBlockStorageV3VolumeExists("data.openstack_blockstorage_volume_v3.volume_1", &dataVolume),
 					resource.TestCheckResourceAttrPair("data.openstack_blockstorage_volume_v3.volume_1", "attachment", "openstack_blockstorage_volume_v3.volume_1", "attachment"),
+					testAccCheckBlockStorageV3VolumeAttachment(&dataVolume, *regexp.MustCompile(`\/dev\/.dc`)),
 				),
 			},
 		},

--- a/openstack/resource_openstack_blockstorage_volume_v3_test.go
+++ b/openstack/resource_openstack_blockstorage_volume_v3_test.go
@@ -146,6 +146,28 @@ func TestAccBlockStorageV3Volume_timeout(t *testing.T) {
 	})
 }
 
+func TestAccBlockStorageV3Volume_attachment(t *testing.T) {
+	var volume volumes.Volume
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckNonAdminOnly(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckBlockStorageV3VolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBlockStorageV3VolumeAttachment(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBlockStorageV3VolumeExists("openstack_blockstorage_volume_v3.volume_1", &volume),
+					testAccCheckBlockStorageV3VolumeAttachment(&volume, "dev/vdc"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckBlockStorageV3VolumeDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	blockStorageClient, err := config.BlockStorageV3Client(osRegionName)
@@ -219,6 +241,27 @@ func testAccCheckBlockStorageV3VolumeMetadata(
 		}
 
 		return fmt.Errorf("Metadata not found: %s", k)
+	}
+}
+
+func testAccCheckBlockStorageV3VolumeAttachment(
+	volume *volumes.Volume, v string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if volume.Attachments == nil {
+			return fmt.Errorf("No Attachment information")
+		}
+
+		if len(volume.Attachments) == 0 {
+			return fmt.Errorf("Volume shows not being attached to any Instance")
+		} else if len(volume.Attachments) > 1 {
+			return fmt.Errorf("Volume shows being attached to more Instances than expected")
+		}
+
+		if volume.Attachments[0].Device == v {
+			return nil
+		} else {
+			return fmt.Errorf("Volume shows other mountpoint than expected")
+		}
 	}
 }
 
@@ -321,3 +364,26 @@ resource "openstack_blockstorage_volume_v3" "volume_1" {
   }
 }
 `
+
+func testAccBlockStorageV3VolumeAttachment() string {
+	return fmt.Sprintf(`
+resource "openstack_blockstorage_volume_v3" "volume_1" {
+  name = "volume_1"
+  size = 1
+}
+
+resource "openstack_compute_instance_v2" "instance_1" {
+  name = "instance_1"
+  security_groups = ["default"]
+  network {
+    uuid = "%s"
+  }
+}
+
+resource "openstack_compute_volume_attach_v2" "va_1" {
+  instance_id = "${openstack_compute_instance_v2.instance_1.id}"
+  volume_id = "${openstack_blockstorage_volume_v3.volume_1.id}"
+  device = "/dev/vdc"
+}
+`, osNetworkID)
+}


### PR DESCRIPTION
Hello,
I am currently reworking the terraform setup for the openstack cloud at my work. While figuring out how to best handle long-term volumes, like databases that should ideally not be deleted recreated if something changes, I noticed a discrepancy between the _**resource** openstack_blockstorage_volume_v3_ and the _**data source** openstack_blockstorage_volume_v3_:

### Issue

The result of creating a volume via terraform has the attribute "attachment", which exposes the instance and the location on which the Volume is mounted (e.g. /dev/vdb on Linux) See [documentation here.](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/blockstorage_volume_v3#attributes-reference)
However, when creating the volume manually outside of terraform, and using the data source to get the same information, the result is missing this attribute.

Example:
```
# Get info on an existing volume with this name
data "openstack_blockstorage_volume_v3" "existing_volume" {
  name = "existing-volume-for-instance-x"
}
# Create new volume, managed by terraform
resource "openstack_blockstorage_volume_v3" "new_volume" {
  name = "new-volume-for-instance-x"
  size = 42
  # etc.
}

# Works, gives the right output
output "new_attachment" {
  value = openstack_blockstorage_volume_v3.new_volume.attachment
}

# Error, This object does not have an attribute named "attachment"
output "existing_attachment" {
  value = data.openstack_blockstorage_volume_v3.existing_volume.attachment
}
```

### Proposal 
Taking a curious look at the code of the resource [(this part](https://github.com/terraform-provider-openstack/terraform-provider-openstack/blob/main/openstack/resource_openstack_blockstorage_volume_v3.go#L269-L274) especially), I noticed that there the code itself is very similar between the resource and the data source, so I tried to just copy the relevant part over to the corresponding function for the data source.

Testing it in our environment, this does indeed work, I now get the correct mountpoint for the volume, (if I make sure the volume is attached before I retrieve the data).
I have to admit I did no further in-depth testing than this, I am not familiar enough with either the code or openstack/terraform to identify potential edge cases that may make it more complicated than this. For me it looks like it just needs to extract and expose the information the same way it is done for the resource, since it only reads data, not needing to manipulate anything.

I hope this PR provides some useful functionality,
Jess Scholtes