### PR TITLE
Add deprecation notice on multiattach volumes

### DIFF
--- a/docs/resources/blockstorage_volume_v3.md
+++ b/docs/resources/blockstorage_volume_v3.md
@@ -65,7 +65,7 @@ The following arguments are supported:
 * `volume_type` - (Optional) The type of volume to create.
     Changing this creates a new volume.
 
-* `multiattach` - (Optional) Allow the volume to be attached to more than one Compute instance.
+* `multiattach` - (**Deprecated** - use multiattach enabled volume types instead) (Optional) Allow the volume to be attached to more than one Compute instance.
 
 * `scheduler_hints` - (Optional) Provide the Cinder scheduler with hints on where
     to instantiate a volume in the OpenStack cloud. The available hints are described below.

--- a/openstack/resource_openstack_blockstorage_volume_v3.go
+++ b/openstack/resource_openstack_blockstorage_volume_v3.go
@@ -113,8 +113,9 @@ func resourceBlockStorageVolumeV3() *schema.Resource {
 			},
 
 			"multiattach": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Type:       schema.TypeBool,
+				Optional:   true,
+				Deprecated: "multiattach parameter has been deprecated and removed on Openstack Bobcat. The default behavior is to use multiattach enabled volume types",
 			},
 
 			"attachment": {

--- a/openstack/resource_openstack_blockstorage_volume_v3_test.go
+++ b/openstack/resource_openstack_blockstorage_volume_v3_test.go
@@ -103,6 +103,7 @@ func TestAccBlockStorageV3Volume_image_multiattach(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
+			t.Skip("Multiattach volumes has been deprecated and removed. Multiattach enabled volume types should be used instead")
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
 			testAccSkipReleasesAbove(t, "stable/wallaby")


### PR DESCRIPTION
Multiattach volumes has been deprecated since Queens and completely removed on Bobcat. Add deprecation notice on the argument and set the tests to skip