### PR TITLE
Fix ci tests for binding:vnic_type on port resource

### DIFF
--- a/docs/resources/networking_port_v2.md
+++ b/docs/resources/networking_port_v2.md
@@ -211,7 +211,7 @@ The `binding` block supports:
 
 * `vnic_type` - (Optional) VNIC type for the port. Can either be `direct`,
     `direct-physical`, `macvtap`, `normal`, `baremetal` or `virtio-forwarder`.
-    Default value is `normal`.
+    Default value is `normal`. It can be updated on unbound ports only.
 
 * `vif_details` - (Computed) A map of JSON strings containing additional
     details for this specific binding.

--- a/openstack/resource_openstack_networking_port_v2_test.go
+++ b/openstack/resource_openstack_networking_port_v2_test.go
@@ -899,7 +899,7 @@ func TestAccNetworkingV2Port_portBinding_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"openstack_networking_port_v2.port_1", "binding.#", "1"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_port_v2.port_1", "binding.0.vnic_type", "baremetal"),
+						"openstack_networking_port_v2.port_1", "binding.0.vnic_type", "normal"),
 					resource.TestCheckResourceAttr(
 						"openstack_networking_port_v2.port_1", "binding.0.host_id", "localhost"),
 					resource.TestCheckResourceAttr(
@@ -2642,7 +2642,7 @@ resource "openstack_networking_port_v2" "port_1" {
 
   binding {
     host_id = "localhost"
-    vnic_type = "baremetal"
+    vnic_type = "normal"
   }
 }
 `


### PR DESCRIPTION
Binding:vnic_type can only be updated on unbound ports. Fix ci tests to not try and update it when the port is bound. Update docs as well to add info on the limitation of the update operation

This is based on api [docs](https://docs.openstack.org/api-ref/network/v2/index.html#update-port) and the logs from the failing ci:
> 2023-12-01T01:47:55.1437727Z   | Error: Error updating OpenStack Neutron Port: Expected HTTP response code [200 201] when accessing [PUT http://10.1.0.99:9696/networking/v2.0/ports/986c02ce-7133-4f36-b450-2596f058fef3], but got 409 instead
2023-12-01T01:47:55.1440317Z   | {"NeutronError": {"type": "PortInUse", "message": "Unable to complete operation on port 986c02ce-7133-4f36-b450-2596f058fef3 for network f8cb73ba-11bd-4a72-8b31-2aac3d19fe1c. Port already has an attached device .", "detail": ""}}

Not sure exactly why the ci started failing "now" and not much earlier. it only fails on `master` so maybe they have fixed something upstream on neutron side.