### PR TITLE
Document the secgroup_rule port-range exception

### DIFF
--- a/docs/resources/networking_secgroup_rule_v2.md
+++ b/docs/resources/networking_secgroup_rule_v2.md
@@ -32,6 +32,9 @@ resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_1" {
 }
 ```
 
+~> **Note:** To expose the full port-range 1:65535, use `0` for `port_range_min`
+and `port_range_max`.
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
When you supply the full port-range 1:65535 neutron does something "clever" and sets port_range_min and port_range_max to None. So when the provider goes back to read out the port-range it comes out 0:0 instead of the expected 1:65535, and the rule gets replaced.

Every.
Single.
Time.

The solution of setting min and max to 0 is staring you right in the face. But documenting this strange exception would be beneficial to denser minds such as mine.