### PR TITLE
Deprecate various nova resources

### DIFF
--- a/docs/resources/compute_floatingip_associate_v2.md
+++ b/docs/resources/compute_floatingip_associate_v2.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Compute / Nova"
+subcategory: "Deprecated"
 layout: "openstack"
 page_title: "OpenStack: openstack_compute_floatingip_associate_v2"
 sidebar_current: "docs-openstack-resource-compute-floatingip-associate-v2"

--- a/docs/resources/compute_floatingip_v2.md
+++ b/docs/resources/compute_floatingip_v2.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Compute / Nova"
+subcategory: "Deprecated"
 layout: "openstack"
 page_title: "OpenStack: openstack_compute_floatingip_v2"
 sidebar_current: "docs-openstack-resource-compute-floatingip-v2"

--- a/docs/resources/compute_secgroup_v2.md
+++ b/docs/resources/compute_secgroup_v2.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Compute / Nova"
+subcategory: "Deprecated"
 layout: "openstack"
 page_title: "OpenStack: openstack_compute_secgroup_v2"
 sidebar_current: "docs-openstack-resource-compute-secgroup-v2"

--- a/openstack/resource_openstack_compute_floatingip_associate_v2.go
+++ b/openstack/resource_openstack_compute_floatingip_associate_v2.go
@@ -28,6 +28,7 @@ func resourceComputeFloatingIPAssociateV2() *schema.Resource {
 			Create: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		DeprecationMessage: "use openstack_networking_floatingip_associate_v2 resource instead",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/openstack/resource_openstack_compute_floatingip_associate_v2_test.go
+++ b/openstack/resource_openstack_compute_floatingip_associate_v2_test.go
@@ -20,6 +20,7 @@ func TestAccComputeV2FloatingIPAssociate_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
+			testAccSkipReleasesAbove(t, "stable/newton")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckComputeV2FloatingIPAssociateDestroy,
@@ -52,6 +53,7 @@ func TestAccComputeV2FloatingIPAssociate_fixedIP(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
+			testAccSkipReleasesAbove(t, "stable/newton")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckComputeV2FloatingIPAssociateDestroy,
@@ -122,6 +124,7 @@ func TestAccComputeV2FloatingIPAssociate_attachNew(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
+			testAccSkipReleasesAbove(t, "stable/newton")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckComputeV2FloatingIPAssociateDestroy,
@@ -156,6 +159,7 @@ func TestAccComputeV2FloatingIPAssociate_waitUntilAssociated(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
+			testAccSkipReleasesAbove(t, "stable/newton")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckComputeV2FloatingIPAssociateDestroy,

--- a/openstack/resource_openstack_compute_floatingip_v2.go
+++ b/openstack/resource_openstack_compute_floatingip_v2.go
@@ -19,6 +19,7 @@ func resourceComputeFloatingIPV2() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
+		DeprecationMessage: "use openstack_networking_floatingip_v2 resource instead",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/openstack/resource_openstack_compute_floatingip_v2_test.go
+++ b/openstack/resource_openstack_compute_floatingip_v2_test.go
@@ -17,6 +17,7 @@ func TestAccComputeV2FloatingIP_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
+			testAccSkipReleasesAbove(t, "stable/newton")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckComputeV2FloatingIPDestroy,

--- a/openstack/resource_openstack_compute_secgroup_v2.go
+++ b/openstack/resource_openstack_compute_secgroup_v2.go
@@ -28,6 +28,7 @@ func resourceComputeSecGroupV2() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		DeprecationMessage: "use openstack_networking_secgroup_v2 resource instead",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/openstack/resource_openstack_compute_secgroup_v2_test.go
+++ b/openstack/resource_openstack_compute_secgroup_v2_test.go
@@ -17,6 +17,7 @@ func TestAccComputeV2SecGroup_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
+			testAccSkipReleasesAbove(t, "stable/newton")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckComputeV2SecGroupDestroy,
@@ -38,6 +39,7 @@ func TestAccComputeV2SecGroup_update(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
+			testAccSkipReleasesAbove(t, "stable/newton")
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckComputeV2SecGroupDestroy,
@@ -63,7 +65,11 @@ func TestAccComputeV2SecGroup_groupID(t *testing.T) {
 	var secgroup1, secgroup2, secgroup3 secgroups.SecurityGroup
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckNonAdminOnly(t)
+			testAccSkipReleasesAbove(t, "stable/newton")
+		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckComputeV2SecGroupDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
Mark compute_floatingip_associate_v2, compute_floatingip_v2, compute_secgroup_v2 as deprecated. Add a deprecation message to point to the related neutron resources to be used instead. Move their doc pages into the `Deprecated` subcategory.