### PR TITLE
Add backup_id to openstack_blockstorage_volume_v3

### DIFF
--- a/docs/resources/blockstorage_volume_v3.md
+++ b/docs/resources/blockstorage_volume_v3.md
@@ -45,22 +45,29 @@ The following arguments are supported:
 * `description` - (Optional) A description of the volume. Changing this updates
     the volume's description.
 
-* `image_id` - (Optional) The image ID from which to create the volume.
-    Changing this creates a new volume.
-
 * `metadata` - (Optional) Metadata key/value pairs to associate with the volume.
     Changing this updates the existing volume metadata.
 
 * `name` - (Optional) A unique name for the volume. Changing this updates the
     volume's name.
 
-* `snapshot_id` - (Optional) The snapshot ID from which to create the volume.
-    Changing this creates a new volume.
-
 * `source_replica` - (Optional) The volume ID to replicate with.
 
+* `snapshot_id` - (Optional) The snapshot ID from which to create the volume.
+    Conflicts with `source_vol_id`, `image_id`, `backup_id`. Changing this
+    creates a new volume.
+
 * `source_vol_id` - (Optional) The volume ID from which to create the volume.
-    Changing this creates a new volume.
+    Conflicts with `snapshot_id`, `image_id`, `backup_id`. Changing this
+    creates a new volume.
+
+* `image_id` - (Optional) The image ID from which to create the volume.
+    Conflicts with `snapshot_id`, `source_vol_id`, `backup_id`. Changing this
+    creates a new volume.
+
+* `backup_id` - (Optional) The backup ID from which to create the volume.
+    Conflicts with `snapshot_id`, `source_vol_id`, `image_id`. Changing this
+    creates a new volume. Requires microversion >= 3.47.
 
 * `volume_type` - (Optional) The type of volume to create.
     Changing this creates a new volume.
@@ -107,6 +114,7 @@ The following attributes are exported:
 * `image_id` - See Argument Reference above.
 * `source_vol_id` - See Argument Reference above.
 * `snapshot_id` - See Argument Reference above.
+* `backup_id` - See Argument Reference above.
 * `metadata` - See Argument Reference above.
 * `volume_type` - See Argument Reference above.
 * `attachment` - If a volume is attached to an instance, this attribute will

--- a/openstack/blockstorage_volume_v3.go
+++ b/openstack/blockstorage_volume_v3.go
@@ -11,6 +11,9 @@ import (
 	"github.com/gophercloud/utils/terraform/hashcode"
 )
 
+const blockstorageV3VolumeFromBackupMicroversion = "3.47"
+const blockstorageV3ResizeOnlineInUse = "3.42"
+
 func flattenBlockStorageVolumeV3Attachments(v []volumes.Attachment) []map[string]interface{} {
 	attachments := make([]map[string]interface{}, len(v))
 	for i, attachment := range v {

--- a/openstack/provider_test.go
+++ b/openstack/provider_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 var (
+	osBackupID                   = os.Getenv("OS_BACKUP_ID")
 	osDBEnvironment              = os.Getenv("OS_DB_ENVIRONMENT")
 	osDBDatastoreVersion         = os.Getenv("OS_DB_DATASTORE_VERSION")
 	osDBDatastoreType            = os.Getenv("OS_DB_DATASTORE_TYPE")


### PR DESCRIPTION
Add support for volumes to be created from a backup_id. Moreover add a `conflictsWith` for the different type of sources that a volume can be created from.

Based on #1637  and work from @ZdenekPesek.

Close #1637 
Close #1636 