### PR TITLE
DB V1: add optional volume_type field for db instance

### DIFF
--- a/docs/resources/db_instance_v1.md
+++ b/docs/resources/db_instance_v1.md
@@ -54,6 +54,8 @@ The following arguments are supported:
 
 * `size` - (Required) Specifies the volume size in GB. Changing this creates new instance.
 
+* `volume_type` - (Optional) Specifies the volume type to use. You can list the available volume types on your system by using the `cinder type- list` command. If you want to specify a volume type, you must also specify a volume size. Changing this creates new instance.
+
 * `availability_zone` - (Optional) The availability zone of the instance.
 
 * `datastore` - (Required) An array of database engine type and version. The datastore
@@ -121,6 +123,7 @@ The following attributes are exported:
 * `region` - See Argument Reference above.
 * `name` - See Argument Reference above.
 * `size` - See Argument Reference above.
+* `volume_type` - See Argument Reference above.
 * `availability_zone` - See Argument Reference above.
 * `flavor_id` - See Argument Reference above.
 * `configuration_id` - See Argument Reference above.

--- a/openstack/resource_openstack_db_instance_v1.go
+++ b/openstack/resource_openstack_db_instance_v1.go
@@ -53,6 +53,12 @@ func resourceDatabaseInstanceV1() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"volume_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"availability_zone": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -198,6 +204,11 @@ func resourceDatabaseInstanceV1Create(ctx context.Context, d *schema.ResourceDat
 		FlavorRef: d.Get("flavor_id").(string),
 		Name:      d.Get("name").(string),
 		Size:      d.Get("size").(int),
+	}
+
+	// volume_type
+	if v, ok := d.GetOkExists("volume_type"); ok {
+		createOpts.VolumeType = v.(string)
 	}
 
 	// availability_zone

--- a/openstack/resource_openstack_db_instance_v1_test.go
+++ b/openstack/resource_openstack_db_instance_v1_test.go
@@ -32,6 +32,8 @@ func TestAccDatabaseV1Instance_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPtr(
 						"openstack_db_instance_v1.basic", "name", &instance.Name),
 					resource.TestCheckResourceAttr(
+						"openstack_db_instance_v1.basic", "volume_type", "io-nvme"),
+					resource.TestCheckResourceAttr(
 						"openstack_db_instance_v1.basic", "availability_zone", "nova"),
 					resource.TestCheckResourceAttr(
 						"openstack_db_instance_v1.basic", "user.0.name", "testuser"),
@@ -130,6 +132,7 @@ resource "openstack_db_instance_v1" "basic" {
   }
 
   size = 10
+  volume_type = "io-nvme"
 
   database {
     name    = "testdb1"


### PR DESCRIPTION
### Issue

Fixes #1646

### Changes

* code: add `volume_type` to `openstack/resource_openstack_db_instance_v1.go`
* tests: add `volume_type` to `openstack/resource_openstack_db_instance_v1_test.go`
* docs - add `volume_type` field 

Dependency update with `volume_type` field: https://github.com/gophercloud/gophercloud/pull/2480