### PR TITLE
Revert availability zone on db_instance_v1

### DIFF
--- a/docs/resources/db_instance_v1.md
+++ b/docs/resources/db_instance_v1.md
@@ -54,8 +54,6 @@ The following arguments are supported:
 
 * `size` - (Required) Specifies the volume size in GB. Changing this creates new instance.
 
-* `availability_zone` - (Optional) The availability zone of the instance.
-
 * `datastore` - (Required) An array of database engine type and version. The datastore
     object structure is documented below. Changing this creates a new instance.
 
@@ -121,7 +119,6 @@ The following attributes are exported:
 * `region` - See Argument Reference above.
 * `name` - See Argument Reference above.
 * `size` - See Argument Reference above.
-* `availability_zone` - See Argument Reference above.
 * `flavor_id` - See Argument Reference above.
 * `configuration_id` - See Argument Reference above.
 * `datastore/type` - See Argument Reference above.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-provider-openstack/terraform-provider-openstack
 go 1.20
 
 require (
-	github.com/gophercloud/gophercloud v1.8.1-0.20240119210933-51831d9ee643
+	github.com/gophercloud/gophercloud v1.8.0
 	github.com/gophercloud/utils v0.0.0-20230324070755-05e9e7f5ea4d
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.30.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gophercloud/gophercloud v1.1.1/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
-github.com/gophercloud/gophercloud v1.8.1-0.20240119210933-51831d9ee643 h1:Nc0JFnFRDE8frLNV6nTBgVaoM5ew12T4HEa3q3BsKeE=
-github.com/gophercloud/gophercloud v1.8.1-0.20240119210933-51831d9ee643/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
+github.com/gophercloud/gophercloud v1.8.0 h1:TM3Jawprb2NrdOnvcHhWJalmKmAmOGgfZElM/3oBYCk=
+github.com/gophercloud/gophercloud v1.8.0/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
 github.com/gophercloud/utils v0.0.0-20230324070755-05e9e7f5ea4d h1:AfRlf5NnsYsHIW5nNxhYp+99Bmj/fLeOYwD5Z4CMlzw=
 github.com/gophercloud/utils v0.0.0-20230324070755-05e9e7f5ea4d/go.mod h1:z4Dey7xsTUXgcB1C8elMvGRKTjV1ez0eoYQlMrduG1g=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/openstack/resource_openstack_db_instance_v1.go
+++ b/openstack/resource_openstack_db_instance_v1.go
@@ -201,7 +201,7 @@ func resourceDatabaseInstanceV1Create(ctx context.Context, d *schema.ResourceDat
 	}
 
 	// availability_zone
-	if v, ok := d.GetOk("availability_zone"); ok {
+	if v, ok := d.GetOkExists("availability_zone"); ok {
 		createOpts.AvailabilityZone = v.(string)
 	}
 

--- a/openstack/resource_openstack_db_instance_v1.go
+++ b/openstack/resource_openstack_db_instance_v1.go
@@ -53,12 +53,6 @@ func resourceDatabaseInstanceV1() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"availability_zone": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
 			"datastore": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -198,11 +192,6 @@ func resourceDatabaseInstanceV1Create(ctx context.Context, d *schema.ResourceDat
 		FlavorRef: d.Get("flavor_id").(string),
 		Name:      d.Get("name").(string),
 		Size:      d.Get("size").(int),
-	}
-
-	// availability_zone
-	if v, ok := d.GetOkExists("availability_zone"); ok {
-		createOpts.AvailabilityZone = v.(string)
 	}
 
 	// datastore

--- a/openstack/resource_openstack_db_instance_v1_test.go
+++ b/openstack/resource_openstack_db_instance_v1_test.go
@@ -32,8 +32,6 @@ func TestAccDatabaseV1Instance_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPtr(
 						"openstack_db_instance_v1.basic", "name", &instance.Name),
 					resource.TestCheckResourceAttr(
-						"openstack_db_instance_v1.basic", "availability_zone", "nova"),
-					resource.TestCheckResourceAttr(
 						"openstack_db_instance_v1.basic", "user.0.name", "testuser"),
 					resource.TestCheckResourceAttr(
 						"openstack_db_instance_v1.basic", "user.0.password", "testpassword"),
@@ -116,9 +114,8 @@ func testAccCheckDatabaseV1InstanceDestroy(s *terraform.State) error {
 func testAccDatabaseV1InstanceBasic() string {
 	return fmt.Sprintf(`
 resource "openstack_db_instance_v1" "basic" {
-  name              = "basic"
-  availability_zone = "nova"
-  configuration_id  = "${openstack_db_configuration_v1.basic.id}"
+  name             = "basic"
+  configuration_id = "${openstack_db_configuration_v1.basic.id}"
 
   datastore {
     version = "%[1]s"


### PR DESCRIPTION
Reverting the additon of availability_zone to db_instance_v1.
This has been faulty as it was not written on the state.
Explained in the discussion here: https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1647