### PR TITLE
Update docs for lb_quota and lb_members

### DIFF
--- a/docs/resources/lb_members_v2.md
+++ b/docs/resources/lb_members_v2.md
@@ -14,10 +14,6 @@ Manages a V2 members resource within OpenStack (batch members update).
 ~> **Note:** This resource has attributes that depend on octavia minor versions.
 Please ensure your Openstack cloud supports the required [minor version](../#octavia-api-versioning).
 
-~> **Note:** This resource works only within [Octavia API](../#use_octavia). For
-legacy Neutron LBaaS v2 extension please use
-[openstack_lb_member_v2](lb_member_v2.html) resource.
-
 ## Example Usage
 
 ```hcl

--- a/docs/resources/lb_quota_v2.md
+++ b/docs/resources/lb_quota_v2.md
@@ -13,8 +13,6 @@ Manages a V2 load balancer quota resource within OpenStack.
 
 ~> **Note:** This usually requires admin privileges.
 
-~> **Note:** This resource is only available for Octavia.
-
 ~> **Note:** This resource has a no-op deletion so no actual actions will be done against the OpenStack
    API in case of delete call.
 


### PR DESCRIPTION
The above resources support only octavia. As neutron-lbaas will be removed, octavia will the one only supported option. Update the docs to remove unneccessary notes.

Part of #1638 