### PR TITLE
Update lb_quota to drop neutron-lbaas

### DIFF
--- a/docs/resources/lb_quota_v2.md
+++ b/docs/resources/lb_quota_v2.md
@@ -13,8 +13,6 @@ Manages a V2 load balancer quota resource within OpenStack.
 
 ~> **Note:** This usually requires admin privileges.
 
-~> **Note:** This resource is only available for Octavia.
-
 ~> **Note:** This resource has a no-op deletion so no actual actions will be done against the OpenStack
    API in case of delete call.
 

--- a/openstack/resource_openstack_lb_quota_v2.go
+++ b/openstack/resource_openstack_lb_quota_v2.go
@@ -90,7 +90,7 @@ func resourceLoadBalancerQuotaV2() *schema.Resource {
 
 func resourceLoadBalancerQuotaV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.LoadBalancerV2Client(GetRegion(d, config))
 	if err != nil {
 		return diag.Errorf("Error creating OpenStack loadbalancing client: %s", err)
 	}
@@ -143,7 +143,7 @@ func resourceLoadBalancerQuotaV2Create(ctx context.Context, d *schema.ResourceDa
 func resourceLoadBalancerQuotaV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*Config)
 	region := GetRegion(d, config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.LoadBalancerV2Client(GetRegion(d, config))
 	if err != nil {
 		return diag.Errorf("Error creating OpenStack loadbalancing client: %s", err)
 	}
@@ -177,7 +177,7 @@ func resourceLoadBalancerQuotaV2Read(ctx context.Context, d *schema.ResourceData
 
 func resourceLoadBalancerQuotaV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.LoadBalancerV2Client(GetRegion(d, config))
 	if err != nil {
 		return diag.Errorf("Error creating OpenStack loadbalancing client: %s", err)
 	}


### PR DESCRIPTION
Remove note from docs as neutron-lbaas support will be dropped. Moreover update the client of the resource to only use octavia.

Part of #1638 