### PR TITLE
Remove deprecated sort_key and sort_dir from glance data sources

### DIFF
--- a/docs/data-sources/images_image_ids_v2.md
+++ b/docs/data-sources/images_image_ids_v2.md
@@ -57,16 +57,7 @@ data "openstack_images_image_ids_v2" "images" {
     direction combinations. You can also set multiple sort keys and directions.
     Default direction is `desc`. Use the comma (,) character to separate
     multiple values. For example expression `sort = "name:asc,status"`
-    sorts ascending by name and descending by status. `sort` cannot be used
-    simultaneously with `sort_key`. If both are present in a configuration
-    then only `sort` will be used.
-
-* `sort_direction` - (Optional) Order the results in either `asc` or `desc`.
-    Can be applied only with `sort_key`. Defaults to `asc`
-
-* `sort_key` - (Optional) Sort images based on a certain key. Defaults to
-    `name`. `sort_key` cannot be used simultaneously with `sort`. If both
-    are present in a configuration then only `sort` will be used.
+    sorts ascending by name and descending by status.
 
 * `tag` - (Optional) Search for images with a specific tag.
 

--- a/docs/data-sources/images_image_v2.md
+++ b/docs/data-sources/images_image_v2.md
@@ -54,9 +54,11 @@ data "openstack_images_image_v2" "ubuntu" {
 
 * `size_max` - (Optional) The maximum size (in bytes) of the image to return.
 
-* `sort_direction` - (Optional) Order the results in either `asc` or `desc`.
-
-* `sort_key` - (Optional) Sort images based on a certain key. Defaults to `name`.
+* `sort` - (Optional) Sorts the response by one or more attribute and sort
+    direction combinations. You can also set multiple sort keys and directions.
+    Default direction is `desc`. Use the comma (,) character to separate
+    multiple values. For example expression `sort = "name:asc,status"`
+    sorts ascending by name and descending by status.
 
 * `tag` - (Optional) Search for images with a specific tag.
 

--- a/openstack/data_source_openstack_images_image_ids_v2_test.go
+++ b/openstack/data_source_openstack_images_image_ids_v2_test.go
@@ -109,7 +109,7 @@ func testAccOpenStackImagesV2ImageIDsDataSourceEmpty() string {
 %s
 
 data "openstack_images_image_ids_v2" "images_empty" {
-        name = "non-existed-image"
+    name = "non-existed-image"
 	visibility = "private"
 }
 `, testAccOpenStackImagesV2ImageIDsDataSourceCirros)

--- a/openstack/data_source_openstack_images_image_v2.go
+++ b/openstack/data_source_openstack_images_image_v2.go
@@ -75,21 +75,12 @@ func dataSourceImagesImageV2() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"sort_key": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  "name",
-			},
-
-			"sort_direction": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  "asc",
-				ValidateFunc: validation.StringInSlice([]string{
-					"asc", "desc",
-				}, false),
+			"sort": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      "name:asc",
+				ValidateFunc: dataSourceValidateImageSortFilter,
 			},
 
 			"tag": {
@@ -228,8 +219,7 @@ func dataSourceImagesImageV2Read(ctx context.Context, d *schema.ResourceData, me
 		Status:       images.ImageStatusActive,
 		SizeMin:      int64(d.Get("size_min").(int)),
 		SizeMax:      int64(d.Get("size_max").(int)),
-		SortKey:      d.Get("sort_key").(string),
-		SortDir:      d.Get("sort_direction").(string),
+		Sort:         d.Get("sort").(string),
 		Tags:         tags,
 		MemberStatus: memberStatus,
 	}

--- a/openstack/images_image_v2.go
+++ b/openstack/images_image_v2.go
@@ -372,3 +372,42 @@ func imagesFilterByProperties(v []images.Image, p map[string]string) []images.Im
 
 	return result
 }
+
+// dataSourceValidateImageSortFilter checks that the sorting filter passed
+// by a user follows the glance API definition of "sort_key:sort_dir,sort_key:sort_dir:.."
+// where sort_dir is optional. For more details, check the glance api docs
+// https://docs.openstack.org/api-ref/image/v2/index.html#list-images
+// at the `sorting` section.
+func dataSourceValidateImageSortFilter(v interface{}, k string) (ws []string, errors []error) {
+	validSortKeys := []string{
+		"name",
+		"owner",
+		"protected",
+		"status",
+		"tag",
+		"visibility",
+		"container_format",
+		"disk_format",
+		"os_hidden",
+		"member_status",
+		"created_at",
+		"updated_at",
+	}
+	validSortDirections := []string{
+		"asc",
+		"desc",
+	}
+
+	sortPairs := strings.Split(v.(string), ",")
+	for _, sortPair := range sortPairs {
+		parts := strings.Split(sortPair, ":")
+		if !strSliceContains(validSortKeys, parts[0]) {
+			errors = append(errors, fmt.Errorf("Invalid sorting key: %s. Has to be one of: %+q", parts[0], validSortKeys))
+		}
+		if len(parts) > 1 && !strSliceContains(validSortDirections, parts[1]) {
+			errors = append(errors, fmt.Errorf("Invalid sorting direction: %s. Has to be one of: %+q", parts[0], validSortDirections))
+		}
+	}
+
+	return ws, errors
+}

--- a/openstack/images_image_v2_test.go
+++ b/openstack/images_image_v2_test.go
@@ -1,0 +1,40 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnitDataSourceValidateImageSortFilter(t *testing.T) {
+	var valid1 interface{} = "name:asc"
+	var valid2 interface{} = "name:asc,status"
+	var valid3 interface{} = "name:desc,owner,created_at:asc"
+
+	var invalid1 interface{} = "hello"
+	var invalid2 interface{} = "hello:world"
+	var invalid3 interface{} = "name,hello:asc,owner:world"
+
+	_, errs := dataSourceValidateImageSortFilter(valid1, "sort")
+	assert.Len(t, errs, 0)
+
+	_, errs = dataSourceValidateImageSortFilter(valid2, "sort")
+	assert.Len(t, errs, 0)
+
+	_, errs = dataSourceValidateImageSortFilter(valid3, "sort")
+	assert.Len(t, errs, 0)
+
+	_, errs = dataSourceValidateImageSortFilter(invalid1, "sort")
+	assert.Len(t, errs, 1)
+	assert.Error(t, errs[0])
+
+	_, errs = dataSourceValidateImageSortFilter(invalid2, "sort")
+	assert.Len(t, errs, 2)
+	assert.Error(t, errs[0])
+	assert.Error(t, errs[1])
+
+	_, errs = dataSourceValidateImageSortFilter(invalid3, "sort")
+	assert.Len(t, errs, 2)
+	assert.Error(t, errs[0])
+	assert.Error(t, errs[1])
+}


### PR DESCRIPTION
Glance data sources allowed sorting in 2 different ways. Sort or sort_key + sort_dir. Sort can fully replace the sort_key + sort_dir combination and is capable of providing multiple sorting criteria. sort_key and sort_dir are marked as deprecated on the provider. Update glance data sources to use solely `sort` and remove support for the deprecated (in the provider) sort_key + sort_dir

Part of #1660 