### PR TITLE
Remove deprecated update_at from images_image_v2

### DIFF
--- a/docs/resources/images_image_v2.md
+++ b/docs/resources/images_image_v2.md
@@ -133,7 +133,6 @@ The following attributes are exported:
    or "saving".
 * `tags` - See Argument Reference above.
 * `updated_at` - The date the image was last updated.
-* `update_at` - (**Deprecated** - use `updated_at` instead)
 * `visibility` - See Argument Reference above.
 
 ## Notes

--- a/openstack/resource_openstack_images_image_v2.go
+++ b/openstack/resource_openstack_images_image_v2.go
@@ -219,12 +219,6 @@ func resourceImagesImageV2() *schema.Resource {
 				Computed: true,
 			},
 
-			"update_at": {
-				Type:       schema.TypeString,
-				Computed:   true,
-				Deprecated: "Use updated_at instead",
-			},
-
 			"updated_at": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -391,9 +385,6 @@ func resourceImagesImageV2Read(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("tags", img.Tags)
 	d.Set("visibility", img.Visibility)
 	d.Set("region", GetRegion(d, config))
-
-	// Deprecated
-	d.Set("update_at", img.UpdatedAt.Format(time.RFC3339))
 
 	properties := resourceImagesImageV2ExpandProperties(img.Properties)
 	if err := d.Set("properties", properties); err != nil {


### PR DESCRIPTION
Remove deprecated update_at in favor of updated_at.

Part of #1660