### PR TITLE
Update 'use_octavia' deprecation message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,8 @@
-## 2.0.0 (Not released yet)
-
-BREAKING CHANGES
+## 1.54.1 (31 January, 2024)
 
 NOTES
 
-IMPROVEMENTS
-
-BUG FIXES
+* Clarify provider deprecation message for option `use_octavia`. Add info on how various users will be affected ([#1665](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1665)).
 
 ## 1.54.0 ( 29 January, 2024)
 

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -213,7 +213,7 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OS_USE_OCTAVIA", true),
 				Description: descriptions["use_octavia"],
-				Deprecated:  "This option will be removed in the next major release. Support for neutron-lbaas will be removed in next major release. Octavia will be the only option supported.",
+				Deprecated:  "Users not using loadbalancer resources can ignore this message. Support for neutron-lbaas will be removed on next major release. Octavia will be the only supported method for loadbalancer resources. Users using octavia will have to remove 'use_octavia' option from the provider configuration block. Users using neutron-lbaas will have to migrate/upgrade to octavia.",
 			},
 
 			"delayed_auth": {


### PR DESCRIPTION
Clarify provider deprecation message for option `use_octavia`. Add info on how various users will be affected. Specifically:
- users not using LB => ignore message
- users using octavia => will have to update provider config if `use_octavia` is defined
- users using neutron-lbaas => will have to upgrade/migrate to octavia Lastly, upgrade CHANGELOG.md to cut patch release

Close #1664  