### PR TITLE
Add a flag to allow parallel network API calls

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -164,6 +164,9 @@ The following arguments are supported:
   service (Octavia) instead of the Networking service (Neutron).
   If omitted, the `OS_USE_OCTAVIA` environment variable is checked.
 
+* `use_mutex` - (Optional) If set to `true`, attempt to workaround race conditions
+  in some API endpoints by using a mutex. Defaults to `true`.
+
 * `disable_no_cache_header` - (Optional) If set to `true`, the HTTP
   `Cache-Control: no-cache` header will not be added by default to all API requests.
   If omitted this header is added to all API requests to force HTTP caches (if any)

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -18,6 +18,7 @@ import (
 // Config struct.
 type Config struct {
 	auth.Config
+	UseMutex bool
 }
 
 // Provider returns a schema.Provider for OpenStack.
@@ -262,6 +263,13 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				Default:     false,
 				Description: descriptions["enable_logging"],
+			},
+
+			"use_mutex": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: descriptions["use_mutex"],
 			},
 		},
 
@@ -519,6 +527,9 @@ func init() {
 		"max_retries": "How many times HTTP connection should be retried until giving up.",
 
 		"enable_logging": "Outputs very verbose logs with all calls made to and responses from OpenStack",
+
+		"use_mutex": "If set to `true`, attempt to workaround race conditions\n" +
+			"in some API endpoints by using mutex. Defaults to `true`.",
 	}
 }
 
@@ -538,7 +549,7 @@ func configureProvider(d *schema.ResourceData, terraformVersion string) (interfa
 	}
 
 	config := Config{
-		auth.Config{
+		Config: auth.Config{
 			CACertFile:                  d.Get("cacert_file").(string),
 			ClientCertFile:              d.Get("cert").(string),
 			ClientKeyFile:               d.Get("key").(string),
@@ -575,6 +586,7 @@ func configureProvider(d *schema.ResourceData, terraformVersion string) (interfa
 			MutexKV:                     mutexkv.NewMutexKV(),
 			EnableLogger:                enableLogging,
 		},
+		UseMutex:                            d.Get("use_mutex").(bool),
 	}
 
 	v, ok := d.GetOkExists("insecure")

--- a/openstack/provider_test.go
+++ b/openstack/provider_test.go
@@ -526,6 +526,7 @@ func testAccAuthFromEnv() (*Config, error) {
 			AuthOpts:                    authOpts,
 			MutexKV:                     mutexkv.NewMutexKV(),
 		},
+		UseMutex:                            true,
 	}
 
 	if err := config.LoadAndValidate(); err != nil {

--- a/openstack/resource_openstack_networking_router_route_v2.go
+++ b/openstack/resource_openstack_networking_router_route_v2.go
@@ -56,8 +56,10 @@ func resourceNetworkingRouterRouteV2Create(ctx context.Context, d *schema.Resour
 	}
 
 	routerID := d.Get("router_id").(string)
-	config.MutexKV.Lock(routerID)
-	defer config.MutexKV.Unlock(routerID)
+	if config.UseMutex {
+		config.MutexKV.Lock(routerID)
+		defer config.MutexKV.Unlock(routerID)
+	}
 
 	r, err := routers.Get(networkingClient, routerID).Extract()
 	if err != nil {
@@ -147,8 +149,10 @@ func resourceNetworkingRouterRouteV2Delete(ctx context.Context, d *schema.Resour
 	}
 
 	routerID := d.Get("router_id").(string)
-	config.MutexKV.Lock(routerID)
-	defer config.MutexKV.Unlock(routerID)
+	if config.UseMutex {
+		config.MutexKV.Lock(routerID)
+		defer config.MutexKV.Unlock(routerID)
+	}
 
 	r, err := routers.Get(networkingClient, routerID).Extract()
 	if err != nil {

--- a/openstack/resource_openstack_networking_router_v2.go
+++ b/openstack/resource_openstack_networking_router_v2.go
@@ -387,8 +387,10 @@ func resourceNetworkingRouterV2Update(ctx context.Context, d *schema.ResourceDat
 	}
 
 	routerID := d.Id()
-	config.MutexKV.Lock(routerID)
-	defer config.MutexKV.Unlock(routerID)
+	if config.UseMutex {
+		config.MutexKV.Lock(routerID)
+		defer config.MutexKV.Unlock(routerID)
+	}
 
 	var hasChange bool
 	var updateOpts routers.UpdateOpts

--- a/openstack/resource_openstack_networking_secgroup_rule_v2.go
+++ b/openstack/resource_openstack_networking_secgroup_rule_v2.go
@@ -115,8 +115,10 @@ func resourceNetworkingSecGroupRuleV2Create(ctx context.Context, d *schema.Resou
 	}
 
 	securityGroupID := d.Get("security_group_id").(string)
-	config.MutexKV.Lock(securityGroupID)
-	defer config.MutexKV.Unlock(securityGroupID)
+	if config.UseMutex {
+		config.MutexKV.Lock(securityGroupID)
+		defer config.MutexKV.Unlock(securityGroupID)
+	}
 
 	portRangeMin := d.Get("port_range_min").(int)
 	portRangeMax := d.Get("port_range_max").(int)
@@ -212,8 +214,10 @@ func resourceNetworkingSecGroupRuleV2Delete(ctx context.Context, d *schema.Resou
 	}
 
 	securityGroupID := d.Get("security_group_id").(string)
-	config.MutexKV.Lock(securityGroupID)
-	defer config.MutexKV.Unlock(securityGroupID)
+	if config.UseMutex {
+		config.MutexKV.Lock(securityGroupID)
+		defer config.MutexKV.Unlock(securityGroupID)
+	}
 
 	if err := rules.Delete(networkingClient, d.Id()).ExtractErr(); err != nil {
 		return diag.FromErr(CheckDeleted(d, err, "Error deleting openstack_networking_secgroup_rule_v2"))

--- a/openstack/resource_openstack_networking_subnet_route_v2.go
+++ b/openstack/resource_openstack_networking_subnet_route_v2.go
@@ -57,8 +57,10 @@ func resourceNetworkingSubnetRouteV2Create(ctx context.Context, d *schema.Resour
 	}
 
 	subnetID := d.Get("subnet_id").(string)
-	config.MutexKV.Lock(subnetID)
-	defer config.MutexKV.Unlock(subnetID)
+	if config.UseMutex {
+		config.MutexKV.Lock(subnetID)
+		defer config.MutexKV.Unlock(subnetID)
+	}
 
 	subnet, err := subnets.Get(networkingClient, subnetID).Extract()
 	if err != nil {
@@ -163,8 +165,10 @@ func resourceNetworkingSubnetRouteV2Delete(ctx context.Context, d *schema.Resour
 	}
 
 	subnetID := d.Get("subnet_id").(string)
-	config.MutexKV.Lock(subnetID)
-	defer config.MutexKV.Unlock(subnetID)
+	if config.UseMutex {
+		config.MutexKV.Lock(subnetID)
+		defer config.MutexKV.Unlock(subnetID)
+	}
 
 	subnet, err := subnets.Get(networkingClient, subnetID).Extract()
 	if err != nil {


### PR DESCRIPTION
This PR adds a configuration option `use_mutex` which defaults to true. When set to true, a mutex is used to serialize network API calls. If the user overrides this by setting `use_mutex` to false, then parallel network operations are allowed. This greatly improves performance when using terraform-provider-openstack to manage a large number of network resources.

Provides a workaround for #1626.