### PR TITLE
Fix networking_floatingip_v2 pool argument reference

### DIFF
--- a/docs/data-sources/networking_floatingip_v2.md
+++ b/docs/data-sources/networking_floatingip_v2.md
@@ -29,7 +29,7 @@ data "openstack_networking_floatingip_v2" "floatingip_1" {
 
 * `address` - (Optional) The IP address of the floating IP.
 
-* `pool` - (Optional) The UUID of the network from which the floating IP belongs to.
+* `pool` - (Optional) The ID of the network from which the floating IP belongs to.
 
 * `port_id` - (Optional) The ID of the port the floating IP is attached.
 

--- a/docs/data-sources/networking_floatingip_v2.md
+++ b/docs/data-sources/networking_floatingip_v2.md
@@ -29,7 +29,7 @@ data "openstack_networking_floatingip_v2" "floatingip_1" {
 
 * `address` - (Optional) The IP address of the floating IP.
 
-* `pool` - (Optional) The name of the pool from which the floating IP belongs to.
+* `pool` - (Optional) The UUID of the network from which the floating IP belongs to.
 
 * `port_id` - (Optional) The ID of the port the floating IP is attached.
 


### PR DESCRIPTION
Hi! 
openstack_networking_floatingip_v2 pool argument is not pool's/network's name
Gophercloud expects network's UUID


https://github.com/terraform-provider-openstack/terraform-provider-openstack/blob/42ad5bae86f4f12a9d319098b8d866f5d8727814/openstack/data_source_openstack_networking_floatingip_v2.go#L105

https://pkg.go.dev/github.com/gophercloud/gophercloud@v1.9.0/openstack/networking/v2/extensions/layer3/floatingips#ListOpts.FloatingNetworkID

Thank you