### PR TITLE
Remove allocation_pools from networking_subnet_v2

### DIFF
--- a/docs/resources/networking_subnet_v2.md
+++ b/docs/resources/networking_subnet_v2.md
@@ -64,11 +64,6 @@ The following arguments are supported:
 * `tenant_id` - (Optional) The owner of the subnet. Required if admin wants to
     create a subnet for another tenant. Changing this creates a new subnet.
 
-* `allocation_pools` - (**Deprecated** - use `allocation_pool` instead)
-    A block declaring the start and end range of the IP addresses available for
-    use with DHCP in this subnet.
-    The `allocation_pools` block is documented below.
-
 * `allocation_pool` - (Optional) A block declaring the start and end range of
     the IP addresses available for use with DHCP in this subnet. Multiple
     `allocation_pool` blocks can be declared, providing the subnet with more
@@ -107,12 +102,6 @@ The following arguments are supported:
 
 * `tags` - (Optional) A set of string tags for the subnet.
 
-The deprecated `allocation_pools` block supports:
-
-* `start` - (Required) The starting address.
-
-* `end` - (Required) The ending address.
-
 The `allocation_pool` block supports:
 
 * `start` - (Required) The starting address.
@@ -136,7 +125,7 @@ The following attributes are exported:
 * `name` - See Argument Reference above.
 * `description` - See Argument Reference above.
 * `tenant_id` - See Argument Reference above.
-* `allocation_pools` - See Argument Reference above.
+* `allocation_pool` - See Argument Reference above.
 * `gateway_ip` - See Argument Reference above.
 * `enable_dhcp` - See Argument Reference above.
 * `dns_nameservers` - See Argument Reference above.

--- a/openstack/networking_subnet_v2.go
+++ b/openstack/networking_subnet_v2.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
@@ -62,21 +61,6 @@ func networkingSubnetV2StateRefreshFuncDelete(networkingClient *gophercloud.Serv
 	}
 }
 
-// networkingSubnetV2GetRawAllocationPoolsValueToExpand selects the resource argument to populate
-// the allocations pool value.
-func networkingSubnetV2GetRawAllocationPoolsValueToExpand(d *schema.ResourceData) []interface{} {
-	// First check allocation_pool since that is the new argument.
-	result := d.Get("allocation_pool").(*schema.Set).List()
-
-	if len(result) == 0 {
-		// If no allocation_pool was specified, check allocation_pools
-		// which is the older legacy argument.
-		result = d.Get("allocation_pools").([]interface{})
-	}
-
-	return result
-}
-
 // expandNetworkingSubnetV2AllocationPools returns a slice of subnets.AllocationPool structs.
 func expandNetworkingSubnetV2AllocationPools(allocationPools []interface{}) []subnets.AllocationPool {
 	result := make([]subnets.AllocationPool, len(allocationPools))
@@ -120,23 +104,6 @@ func expandNetworkingSubnetV2HostRoutes(rawHostRoutes []interface{}) []subnets.H
 	}
 
 	return result
-}
-
-func networkingSubnetV2AllocationPoolsCustomizeDiff(diff *schema.ResourceDiff) error {
-	if diff.Id() != "" && diff.HasChange("allocation_pools") {
-		o, n := diff.GetChange("allocation_pools")
-		oldPools := o.([]interface{})
-		newPools := n.([]interface{})
-
-		samePools := networkingSubnetV2AllocationPoolsMatch(oldPools, newPools)
-
-		if samePools {
-			log.Printf("[DEBUG] allocation_pools have not changed. clearing diff")
-			return diff.Clear("allocation_pools")
-		}
-	}
-
-	return nil
 }
 
 func networkingSubnetV2AllocationPoolsMatch(oldPools, newPools []interface{}) bool {

--- a/openstack/resource_openstack_networking_port_v2_test.go
+++ b/openstack/resource_openstack_networking_port_v2_test.go
@@ -1253,7 +1253,7 @@ resource "openstack_networking_subnet_v2" "vrrp_subnet" {
   ip_version = 4
   network_id = "${openstack_networking_network_v2.vrrp_network.id}"
 
-  allocation_pools {
+  allocation_pool {
     start = "10.0.0.2"
     end = "10.0.0.200"
   }
@@ -1325,7 +1325,7 @@ resource "openstack_networking_subnet_v2" "vrrp_subnet" {
   ip_version = 4
   network_id = "${openstack_networking_network_v2.vrrp_network.id}"
 
-  allocation_pools {
+  allocation_pool {
     start = "10.0.0.2"
     end = "10.0.0.200"
   }
@@ -1396,7 +1396,7 @@ resource "openstack_networking_subnet_v2" "vrrp_subnet" {
   ip_version = 4
   network_id = "${openstack_networking_network_v2.vrrp_network.id}"
 
-  allocation_pools {
+  allocation_pool {
     start = "10.0.0.2"
     end = "10.0.0.200"
   }
@@ -1468,7 +1468,7 @@ resource "openstack_networking_subnet_v2" "vrrp_subnet" {
   ip_version = 4
   network_id = "${openstack_networking_network_v2.vrrp_network.id}"
 
-  allocation_pools {
+  allocation_pool {
     start = "10.0.0.2"
     end = "10.0.0.200"
   }
@@ -1535,7 +1535,7 @@ resource "openstack_networking_subnet_v2" "vrrp_subnet" {
   ip_version = 4
   network_id = "${openstack_networking_network_v2.vrrp_network.id}"
 
-  allocation_pools {
+  allocation_pool {
     start = "10.0.0.2"
     end = "10.0.0.200"
   }
@@ -2022,7 +2022,7 @@ resource "openstack_networking_subnet_v2" "vrrp_subnet" {
   ip_version = 4
   network_id = "${openstack_networking_network_v2.vrrp_network.id}"
 
-  allocation_pools {
+  allocation_pool {
     start = "10.0.0.2"
     end = "10.0.0.200"
   }

--- a/openstack/resource_openstack_networking_subnet_v2_test.go
+++ b/openstack/resource_openstack_networking_subnet_v2_test.go
@@ -27,7 +27,7 @@ func TestAccNetworkingV2Subnet_basic(t *testing.T) {
 					testAccCheckNetworkingV2SubnetExists("openstack_networking_subnet_v2.subnet_1", &subnet),
 					testAccCheckNetworkingV2SubnetDNSConsistency("openstack_networking_subnet_v2.subnet_1", &subnet),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_subnet_v2.subnet_1", "allocation_pools.0.start", "192.168.199.100"),
+						"openstack_networking_subnet_v2.subnet_1", "allocation_pool.0.start", "192.168.199.100"),
 					resource.TestCheckResourceAttr(
 						"openstack_networking_subnet_v2.subnet_1", "description", "my subnet description"),
 				),
@@ -42,7 +42,7 @@ func TestAccNetworkingV2Subnet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"openstack_networking_subnet_v2.subnet_1", "enable_dhcp", "true"),
 					resource.TestCheckResourceAttr(
-						"openstack_networking_subnet_v2.subnet_1", "allocation_pools.0.start", "192.168.199.150"),
+						"openstack_networking_subnet_v2.subnet_1", "allocation_pool.0.start", "192.168.199.150"),
 					resource.TestCheckResourceAttr(
 						"openstack_networking_subnet_v2.subnet_1", "description", ""),
 				),
@@ -245,21 +245,21 @@ func TestAccNetworkingV2Subnet_multipleAllocationPools(t *testing.T) {
 				Config: testAccNetworkingV2SubnetMultipleAllocationPools1,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"openstack_networking_subnet_v2.subnet_1", "allocation_pools.#", "2"),
+						"openstack_networking_subnet_v2.subnet_1", "allocation_pool.#", "2"),
 				),
 			},
 			{
 				Config: testAccNetworkingV2SubnetMultipleAllocationPools2,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"openstack_networking_subnet_v2.subnet_1", "allocation_pools.#", "2"),
+						"openstack_networking_subnet_v2.subnet_1", "allocation_pool.#", "2"),
 				),
 			},
 			{
 				Config: testAccNetworkingV2SubnetMultipleAllocationPools3,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"openstack_networking_subnet_v2.subnet_1", "allocation_pools.#", "2"),
+						"openstack_networking_subnet_v2.subnet_1", "allocation_pool.#", "2"),
 				),
 			},
 		},
@@ -455,7 +455,7 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
 
   dns_nameservers = ["10.0.16.4", "213.186.33.99"]
 
-  allocation_pools {
+  allocation_pool {
     start = "192.168.199.100"
     end = "192.168.199.200"
   }
@@ -476,7 +476,7 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
 
   dns_nameservers = ["10.0.16.4", "213.186.33.99"]
 
-  allocation_pools {
+  allocation_pool {
     start = "192.168.199.150"
     end = "192.168.199.200"
   }
@@ -548,7 +548,7 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
   cidr = "192.168.199.0/24"
   network_id = "${openstack_networking_network_v2.network_1.id}"
 
-  allocation_pools {
+  allocation_pool {
     start = "192.168.199.100"
     end = "192.168.199.200"
   }
@@ -638,12 +638,12 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
   cidr = "10.3.0.0/16"
   network_id = "${openstack_networking_network_v2.network_1.id}"
 
-  allocation_pools {
+  allocation_pool {
     start = "10.3.0.2"
     end = "10.3.0.255"
   }
 
-  allocation_pools {
+  allocation_pool {
     start = "10.3.255.0"
     end = "10.3.255.254"
   }
@@ -661,12 +661,12 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
   cidr = "10.3.0.0/16"
   network_id = "${openstack_networking_network_v2.network_1.id}"
 
-  allocation_pools {
+  allocation_pool {
     start = "10.3.255.0"
     end = "10.3.255.254"
   }
 
-  allocation_pools {
+  allocation_pool {
     start = "10.3.0.2"
     end = "10.3.0.255"
   }
@@ -684,12 +684,12 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
   cidr = "10.3.0.0/16"
   network_id = "${openstack_networking_network_v2.network_1.id}"
 
-  allocation_pools {
+  allocation_pool {
     start = "10.3.255.10"
     end = "10.3.255.154"
   }
 
-  allocation_pools {
+  allocation_pool {
     start = "10.3.0.2"
     end = "10.3.0.255"
   }
@@ -754,7 +754,7 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
 
   dns_nameservers = ["10.0.16.4", "213.186.33.99"]
 
-  allocation_pools {
+  allocation_pool {
     start = "192.168.199.100"
     end = "192.168.199.200"
   }
@@ -772,7 +772,7 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
   cidr = "192.168.199.0/24"
   network_id = "${openstack_networking_network_v2.network_1.id}"
 
-  allocation_pools {
+  allocation_pool {
     start = "192.168.199.100"
     end = "192.168.199.200"
   }

--- a/openstack/resource_openstack_networking_tags_v2_test.go
+++ b/openstack/resource_openstack_networking_tags_v2_test.go
@@ -125,7 +125,7 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
 
   dns_nameservers = ["10.0.16.4", "213.186.33.99"]
 
-  allocation_pools {
+  allocation_pool {
     start = "192.168.199.100"
     end = "192.168.199.200"
   }


### PR DESCRIPTION
Deprecated allocation_pools is removed in favor of allocation_pool

Partially implements https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1660