### PR TITLE
Remove host_route from networking_subnet_v2

### DIFF
--- a/docs/resources/networking_subnet_v2.md
+++ b/docs/resources/networking_subnet_v2.md
@@ -90,12 +90,6 @@ The following arguments are supported:
 * `service_types` - (Optional) An array of service types used by the subnet.
     Changing this updates the service types for the existing subnet.
 
-* `host_routes` - (**Deprecated** - use `openstack_networking_subnet_route_v2`
-    instead) An array of routes that should be used by devices
-    with IPs from this subnet (not including local subnet route). The host_route
-    object structure is documented below. Changing this updates the host routes
-    for the existing subnet.
-
 * `subnetpool_id` - (Optional) The ID of the subnetpool associated with the subnet.
 
 * `value_specs` - (Optional) Map of additional options.
@@ -107,12 +101,6 @@ The `allocation_pool` block supports:
 * `start` - (Required) The starting address.
 
 * `end` - (Required) The ending address.
-
-The `host_routes` block supports:
-
-* `destination_cidr` - (Required) The destination CIDR.
-
-* `next_hop` - (Required) The next hop in the route.
 
 ## Attributes Reference
 
@@ -130,7 +118,6 @@ The following attributes are exported:
 * `enable_dhcp` - See Argument Reference above.
 * `dns_nameservers` - See Argument Reference above.
 * `service_types` - See Argument Reference above.
-* `host_routes` - See Argument Reference above.
 * `subnetpool_id` - See Argument Reference above.
 * `tags` - See Argument Reference above.
 * `all_tags` - The collection of ags assigned on the subnet, which have been

--- a/openstack/networking_subnet_v2.go
+++ b/openstack/networking_subnet_v2.go
@@ -91,21 +91,6 @@ func flattenNetworkingSubnetV2AllocationPools(allocationPools []subnets.Allocati
 	return result
 }
 
-// expandNetworkingSubnetV2HostRoutes returns a slice of HostRoute structures.
-func expandNetworkingSubnetV2HostRoutes(rawHostRoutes []interface{}) []subnets.HostRoute {
-	result := make([]subnets.HostRoute, len(rawHostRoutes))
-	for i, raw := range rawHostRoutes {
-		rawMap := raw.(map[string]interface{})
-
-		result[i] = subnets.HostRoute{
-			DestinationCIDR: rawMap["destination_cidr"].(string),
-			NextHop:         rawMap["next_hop"].(string),
-		}
-	}
-
-	return result
-}
-
 func networkingSubnetV2AllocationPoolsMatch(oldPools, newPools []interface{}) bool {
 	if len(oldPools) != len(newPools) {
 		return false

--- a/openstack/networking_subnet_v2_test.go
+++ b/openstack/networking_subnet_v2_test.go
@@ -72,40 +72,6 @@ func TestUnitExpandNetworkingSubnetV2AllocationPools(t *testing.T) {
 	assert.ElementsMatch(t, expected, actual)
 }
 
-func TestUnitExpandNetworkingSubnetV2HostRoutes(t *testing.T) {
-	r := resourceNetworkingSubnetV2()
-	d := r.TestResourceData()
-	d.SetId("1")
-
-	hostRoutes := []map[string]interface{}{
-		{
-			"destination_cidr": "192.168.0.0/24",
-			"next_hop":         "10.0.0.1",
-		},
-		{
-			"destination_cidr": "10.0.0.0/8",
-			"next_hop":         "192.168.0.1",
-		},
-	}
-
-	d.Set("host_routes", hostRoutes)
-
-	expected := []subnets.HostRoute{
-		{
-			DestinationCIDR: "192.168.0.0/24",
-			NextHop:         "10.0.0.1",
-		},
-		{
-			DestinationCIDR: "10.0.0.0/8",
-			NextHop:         "192.168.0.1",
-		},
-	}
-
-	actual := expandNetworkingSubnetV2HostRoutes(d.Get("host_routes").([]interface{}))
-
-	assert.ElementsMatch(t, expected, actual)
-}
-
 func TestUnitNetworkingSubnetV2AllocationPoolsMatch(t *testing.T) {
 	oldPools := []interface{}{
 		map[string]interface{}{

--- a/openstack/resource_openstack_networking_subnet_v2.go
+++ b/openstack/resource_openstack_networking_subnet_v2.go
@@ -139,25 +139,6 @@ func resourceNetworkingSubnetV2() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
-			"host_routes": {
-				Type:       schema.TypeList,
-				Optional:   true,
-				ForceNew:   false,
-				Deprecated: "Use openstack_networking_subnet_route_v2 instead",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"destination_cidr": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"next_hop": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
-
 			"ipv6_address_mode": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -240,7 +221,6 @@ func resourceNetworkingSubnetV2Create(ctx context.Context, d *schema.ResourceDat
 			AllocationPools: expandNetworkingSubnetV2AllocationPools(allocationPool),
 			DNSNameservers:  expandToStringSlice(d.Get("dns_nameservers").([]interface{})),
 			ServiceTypes:    expandToStringSlice(d.Get("service_types").([]interface{})),
-			HostRoutes:      expandNetworkingSubnetV2HostRoutes(d.Get("host_routes").([]interface{})),
 			SubnetPoolID:    d.Get("subnetpool_id").(string),
 			IPVersion:       gophercloud.IPVersion(d.Get("ip_version").(int)),
 		},
@@ -423,12 +403,6 @@ func resourceNetworkingSubnetV2Update(ctx context.Context, d *schema.ResourceDat
 		hasChange = true
 		serviceTypes := expandToStringSlice(d.Get("service_types").([]interface{}))
 		updateOpts.ServiceTypes = &serviceTypes
-	}
-
-	if d.HasChange("host_routes") {
-		hasChange = true
-		newHostRoutes := expandNetworkingSubnetV2HostRoutes(d.Get("host_routes").([]interface{}))
-		updateOpts.HostRoutes = &newHostRoutes
 	}
 
 	if d.HasChange("enable_dhcp") {


### PR DESCRIPTION
Remove host_route from networking_subnet_v2 in favor of openstack_networking_subnet_route_v2

Partially implements https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1660