### PR TITLE
Deprecate support for neutron lbaas

### DIFF
--- a/.github/workflows/functional-loadbalancer.yml
+++ b/.github/workflows/functional-loadbalancer.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           go-version: '^1.20'
       - name: Run TPO acceptance tests
-        run: OS_LB_ENVIRONMENT=true OS_USE_OCTAVIA=true ./scripts/acceptancetest.sh
+        run: OS_LB_ENVIRONMENT=true ./scripts/acceptancetest.sh
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           ACCEPTANCE_TESTS_FILTER: "lb.*v2|v2.*lb"

--- a/docs/index.md
+++ b/docs/index.md
@@ -160,10 +160,6 @@ The following arguments are supported:
   Finally, set `auth_url` as the location of the Swift service. Note that this
   will only work when used with the OpenStack Object Storage resources.
 
-* `use_octavia` - (Optional) If set to `true`, API requests will go the Load Balancer
-  service (Octavia) instead of the Networking service (Neutron).
-  If omitted, the `OS_USE_OCTAVIA` environment variable is checked.
-
 * `disable_no_cache_header` - (Optional) If set to `true`, the HTTP
   `Cache-Control: no-cache` header will not be added by default to all API requests.
   If omitted this header is added to all API requests to force HTTP caches (if any)

--- a/openstack/data_source_openstack_lb_flavor_v2_test.go
+++ b/openstack/data_source_openstack_lb_flavor_v2_test.go
@@ -13,7 +13,7 @@ func TestAccLBV2FlavorDataSource_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
-			testAccPreCheckUseOctavia(t)
+			testAccPreCheckLB(t)
 		},
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{

--- a/openstack/import_openstack_lb_members_v2_test.go
+++ b/openstack/import_openstack_lb_members_v2_test.go
@@ -13,7 +13,7 @@ func TestAccLBV2Members_importBasic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
-			testAccPreCheckUseOctavia(t)
+			testAccPreCheckLB(t)
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckLBV2MembersDestroy,

--- a/openstack/lb_v2_shared.go
+++ b/openstack/lb_v2_shared.go
@@ -18,8 +18,6 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 )
 
-const octaviaLBClientType = "load-balancer"
-
 const (
 	lbPendingCreate = "PENDING_CREATE"
 	lbPendingUpdate = "PENDING_UPDATE"

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -208,14 +208,6 @@ func Provider() *schema.Provider {
 				Description: descriptions["swauth"],
 			},
 
-			"use_octavia": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_USE_OCTAVIA", true),
-				Description: descriptions["use_octavia"],
-				Deprecated:  "Users not using loadbalancer resources can ignore this message. Support for neutron-lbaas will be removed on next major release. Octavia will be the only supported method for loadbalancer resources. Users using octavia will have to remove 'use_octavia' option from the provider configuration block. Users using neutron-lbaas will have to migrate/upgrade to octavia.",
-			},
-
 			"delayed_auth": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -506,9 +498,6 @@ func init() {
 		"swauth": "Use Swift's authentication system instead of Keystone. Only used for\n" +
 			"interaction with Swift.",
 
-		"use_octavia": "If set to `true`, API requests will go the Load Balancer\n" +
-			"service (Octavia) instead of the Networking service (Neutron).",
-
 		"disable_no_cache_header": "If set to `true`, the HTTP `Cache-Control: no-cache` header will not be added by default to all API requests.",
 
 		"delayed_auth": "If set to `false`, OpenStack authorization will be perfomed,\n" +
@@ -562,10 +551,10 @@ func configureProvider(d *schema.ResourceData, terraformVersion string) (interfa
 			UserDomainName:              d.Get("user_domain_name").(string),
 			Username:                    d.Get("user_name").(string),
 			UserID:                      d.Get("user_id").(string),
+			UseOctavia:                  true,
 			ApplicationCredentialID:     d.Get("application_credential_id").(string),
 			ApplicationCredentialName:   d.Get("application_credential_name").(string),
 			ApplicationCredentialSecret: d.Get("application_credential_secret").(string),
-			UseOctavia:                  d.Get("use_octavia").(bool),
 			DelayedAuth:                 d.Get("delayed_auth").(bool),
 			AllowReauth:                 d.Get("allow_reauth").(bool),
 			AuthOpts:                    authOpts,

--- a/openstack/provider_test.go
+++ b/openstack/provider_test.go
@@ -38,7 +38,6 @@ var (
 	osLbFlavorName               = os.Getenv("OS_LB_FLAVOR_NAME")
 	osFwEnvironment              = os.Getenv("OS_FW_ENVIRONMENT")
 	osVpnEnvironment             = os.Getenv("OS_VPN_ENVIRONMENT")
-	osUseOctavia                 = os.Getenv("OS_USE_OCTAVIA")
 	osContainerInfraEnvironment  = os.Getenv("OS_CONTAINER_INFRA_ENVIRONMENT")
 	osSfsEnvironment             = os.Getenv("OS_SFS_ENVIRONMENT")
 	osTransparentVlanEnvironment = os.Getenv("OS_TRANSPARENT_VLAN_ENVIRONMENT")
@@ -152,14 +151,6 @@ func testAccPreCheckBlockStorageV2(t *testing.T) {
 
 	if osBlockStorageV2 == "" {
 		t.Skip("This environment does not support BlockStorageV2 tests")
-	}
-}
-
-func testAccPreCheckUseOctavia(t *testing.T) {
-	testAccPreCheckRequiredEnvVars(t)
-
-	if osUseOctavia == "" {
-		t.Skip("This environment does not support Octavia tests")
 	}
 }
 
@@ -522,10 +513,10 @@ func testAccAuthFromEnv() (*Config, error) {
 			UserDomainName:              os.Getenv("OS_USER_DOMAIN_NAME"),
 			Username:                    os.Getenv("OS_USERNAME"),
 			UserID:                      os.Getenv("OS_USER_ID"),
+			UseOctavia:                  true,
 			ApplicationCredentialID:     os.Getenv("OS_APPLICATION_CREDENTIAL_ID"),
 			ApplicationCredentialName:   os.Getenv("OS_APPLICATION_CREDENTIAL_NAME"),
 			ApplicationCredentialSecret: os.Getenv("OS_APPLICATION_CREDENTIAL_SECRET"),
-			UseOctavia:                  testGetenvBool("OS_USE_OCTAVIA"),
 			DelayedAuth:                 testGetenvBool("OS_DELAYED_AUTH"),
 			AllowReauth:                 testGetenvBool("OS_ALLOW_REAUTH"),
 			AuthOpts:                    authOpts,

--- a/openstack/resource_openstack_lb_listener_v2_test.go
+++ b/openstack/resource_openstack_lb_listener_v2_test.go
@@ -51,7 +51,6 @@ func TestAccLBV2Listener_octavia(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
 			testAccPreCheckLB(t)
-			testAccPreCheckUseOctavia(t)
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckLBV2ListenerDestroy,
@@ -105,7 +104,6 @@ func TestAccLBV2Listener_octavia_udp(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
 			testAccPreCheckLB(t)
-			testAccPreCheckUseOctavia(t)
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckLBV2ListenerDestroy,
@@ -130,7 +128,6 @@ func TestAccLBV2ListenerConfig_octavia_insert_headers(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
 			testAccPreCheckLB(t)
-			testAccPreCheckUseOctavia(t)
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckLBV2ListenerDestroy,

--- a/openstack/resource_openstack_lb_loadbalancer_v2_test.go
+++ b/openstack/resource_openstack_lb_loadbalancer_v2_test.go
@@ -120,7 +120,6 @@ func TestAccLBV2LoadBalancer_vip_network(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
 			testAccPreCheckLB(t)
-			testAccPreCheckUseOctavia(t)
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckLBV2LoadBalancerDestroy,
@@ -144,7 +143,6 @@ func TestAccLBV2LoadBalancer_vip_port_id(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
 			testAccPreCheckLB(t)
-			testAccPreCheckUseOctavia(t)
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckLBV2LoadBalancerDestroy,

--- a/openstack/resource_openstack_lb_member_v2_test.go
+++ b/openstack/resource_openstack_lb_member_v2_test.go
@@ -52,7 +52,6 @@ func TestAccLBV2Member_monitor(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
 			testAccPreCheckLB(t)
-			testAccPreCheckUseOctavia(t)
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckLBV2MemberDestroy,

--- a/openstack/resource_openstack_lb_members_v2_test.go
+++ b/openstack/resource_openstack_lb_members_v2_test.go
@@ -38,7 +38,6 @@ func TestAccLBV2Members_basic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
 			testAccPreCheckLB(t)
-			testAccPreCheckUseOctavia(t)
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckLBV2MembersDestroy,

--- a/openstack/resource_openstack_lb_monitor_v2_test.go
+++ b/openstack/resource_openstack_lb_monitor_v2_test.go
@@ -49,7 +49,6 @@ func TestAccLBV2Monitor_octavia(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
 			testAccPreCheckLB(t)
-			testAccPreCheckUseOctavia(t)
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckLBV2MonitorDestroy,
@@ -81,7 +80,6 @@ func TestAccLBV2Monitor_octavia_udp(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
 			testAccPreCheckLB(t)
-			testAccPreCheckUseOctavia(t)
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckLBV2MonitorDestroy,

--- a/openstack/resource_openstack_lb_pool_v2_test.go
+++ b/openstack/resource_openstack_lb_pool_v2_test.go
@@ -46,7 +46,6 @@ func TestAccLBV2Pool_octavia_udp(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckNonAdminOnly(t)
 			testAccPreCheckLB(t)
-			testAccPreCheckUseOctavia(t)
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckLBV2PoolDestroy,

--- a/openstack/resource_openstack_lb_quota_v2.go
+++ b/openstack/resource_openstack_lb_quota_v2.go
@@ -95,10 +95,6 @@ func resourceLoadBalancerQuotaV2Create(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf("Error creating OpenStack loadbalancing client: %s", err)
 	}
 
-	if lbClient.Type != octaviaLBClientType {
-		return diag.Errorf("Error creating openstack_lb_quota_v2: Only available when using octavia")
-	}
-
 	region := GetRegion(d, config)
 	projectID := d.Get("project_id").(string)
 	loadbalancer := d.Get("loadbalancer").(int)
@@ -148,10 +144,6 @@ func resourceLoadBalancerQuotaV2Read(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf("Error creating OpenStack loadbalancing client: %s", err)
 	}
 
-	if lbClient.Type != octaviaLBClientType {
-		return diag.Errorf("Error creating openstack_lb_quota_v2: Only available when using octavia")
-	}
-
 	// Pase projectID from resource id that is <project_id>/<region>
 	projectID := strings.Split(d.Id(), "/")[0]
 
@@ -180,10 +172,6 @@ func resourceLoadBalancerQuotaV2Update(ctx context.Context, d *schema.ResourceDa
 	lbClient, err := config.LoadBalancerV2Client(GetRegion(d, config))
 	if err != nil {
 		return diag.Errorf("Error creating OpenStack loadbalancing client: %s", err)
-	}
-
-	if lbClient.Type != octaviaLBClientType {
-		return diag.Errorf("Error creating openstack_lb_quota_v2: Only available when using octavia")
 	}
 
 	var (


### PR DESCRIPTION
Remove deprecation message and `use_octavia` option from client. Update docs and ci tests.

Part of #1638 