### PR TITLE
Fix: Delete URL validation from identity_endpoint parameters

### DIFF
--- a/openstack/resource_openstack_identity_endpoint_v3.go
+++ b/openstack/resource_openstack_identity_endpoint_v3.go
@@ -2,9 +2,7 @@ package openstack
 
 import (
 	"context"
-	"fmt"
 	"log"
-	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -46,14 +44,6 @@ func resourceIdentityEndpointV3() *schema.Resource {
 			"url": {
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					_, err := url.ParseRequestURI(value)
-					if err != nil {
-						errors = append(errors, fmt.Errorf("URL is not valid: %s", err))
-					}
-					return
-				},
 			},
 
 			"interface": {

--- a/openstack/resource_openstack_identity_endpoint_v3_test.go
+++ b/openstack/resource_openstack_identity_endpoint_v3_test.go
@@ -152,7 +152,7 @@ resource "openstack_identity_endpoint_v3" "endpoint_1" {
   name = "%s"
   service_id = "${openstack_identity_service_v3.service_1.id}"
   endpoint_region = "${openstack_identity_service_v3.service_1.region}"
-  url = "http://myservice.local"
+  url = "http://myservice.local/v1.0/%%(tenant_id)s"
 }
   `, endpointName)
 }
@@ -168,7 +168,7 @@ resource "openstack_identity_endpoint_v3" "endpoint_1" {
   name = "%s"
   service_id = "${openstack_identity_service_v3.service_1.id}"
   endpoint_region = "interstate76"
-  url = "http://my-new-service.local"
+  url = "http://my-new-service/v1.0/%%(tenant_id)s"
 }
   `, endpointName)
 }

--- a/openstack/resource_openstack_identity_endpoint_v3_test.go
+++ b/openstack/resource_openstack_identity_endpoint_v3_test.go
@@ -37,7 +37,7 @@ func TestAccIdentityV3Endpoint_basic(t *testing.T) {
 						"openstack_identity_service_v3.service_1", "region",
 						"openstack_identity_endpoint_v3.endpoint_1", "endpoint_region"),
 					resource.TestCheckResourceAttr(
-						"openstack_identity_endpoint_v3.endpoint_1", "url", "http://myservice.local/v1.0/%%(tenant_id)s"),
+						"openstack_identity_endpoint_v3.endpoint_1", "url", "http://myservice.local/v1.0/%(tenant_id)s"),
 				),
 			},
 			{
@@ -168,7 +168,7 @@ resource "openstack_identity_endpoint_v3" "endpoint_1" {
   name = "%s"
   service_id = "${openstack_identity_service_v3.service_1.id}"
   endpoint_region = "interstate76"
-  url = "http://my-new-service/v1.0/%(tenant_id)s"
+  url = "http://my-new-service/v1.0/%%(tenant_id)s"
 }
   `, endpointName)
 }

--- a/openstack/resource_openstack_identity_endpoint_v3_test.go
+++ b/openstack/resource_openstack_identity_endpoint_v3_test.go
@@ -37,7 +37,7 @@ func TestAccIdentityV3Endpoint_basic(t *testing.T) {
 						"openstack_identity_service_v3.service_1", "region",
 						"openstack_identity_endpoint_v3.endpoint_1", "endpoint_region"),
 					resource.TestCheckResourceAttr(
-						"openstack_identity_endpoint_v3.endpoint_1", "url", "http://myservice.local"),
+						"openstack_identity_endpoint_v3.endpoint_1", "url", "http://myservice.local/v1.0/%%(tenant_id)s"),
 				),
 			},
 			{
@@ -52,7 +52,7 @@ func TestAccIdentityV3Endpoint_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"openstack_identity_endpoint_v3.endpoint_1", "endpoint_region", "interstate76"),
 					resource.TestCheckResourceAttr(
-						"openstack_identity_endpoint_v3.endpoint_1", "url", "http://my-new-service.local"),
+						"openstack_identity_endpoint_v3.endpoint_1", "url", "http://my-new-service/v1.0/%(tenant_id)s"),
 				),
 			},
 		},
@@ -168,7 +168,7 @@ resource "openstack_identity_endpoint_v3" "endpoint_1" {
   name = "%s"
   service_id = "${openstack_identity_service_v3.service_1.id}"
   endpoint_region = "interstate76"
-  url = "http://my-new-service/v1.0/%%(tenant_id)s"
+  url = "http://my-new-service/v1.0/%(tenant_id)s"
 }
   `, endpointName)
 }


### PR DESCRIPTION
## Why

The `url` parameter in resource_openstack_identity_endpoint_v3 may contain non-url encoded strings such as `%(tenant_id)s`. 

Ref: https://docs.openstack.org/ocata/admin-guide/networking-auth.html

This means that url validation may prevent normal configurations.

## Changes

* Delete URL validation func
* Add % string to test case