### PR TITLE
Remove zed ci jobs as it has reached EOM status

### DIFF
--- a/.github/workflows/functional-blockstorage_v3.yml
+++ b/.github/workflows/functional-blockstorage_v3.yml
@@ -33,9 +33,6 @@ jobs:
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
-          - name: "zed"
-            openstack_version: "stable/zed"
-            ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: blockstorage_v3 on OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests
     steps:

--- a/.github/workflows/functional-compute.yml
+++ b/.github/workflows/functional-compute.yml
@@ -31,9 +31,6 @@ jobs:
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
-          - name: "zed"
-            openstack_version: "stable/zed"
-            ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: compute on OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests
     steps:

--- a/.github/workflows/functional-dns.yml
+++ b/.github/workflows/functional-dns.yml
@@ -30,9 +30,6 @@ jobs:
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
-          - name: "zed"
-            openstack_version: "stable/zed"
-            ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: dns on OpenStack ${{ matrix.name }} with Designate and run dns acceptance tests
     steps:

--- a/.github/workflows/functional-fwaas_v2.yml
+++ b/.github/workflows/functional-fwaas_v2.yml
@@ -32,9 +32,6 @@ jobs:
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
-          - name: "zed"
-            openstack_version: "stable/zed"
-            ubuntu_version: "22.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: fwaas_v2 on OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests
     steps:

--- a/.github/workflows/functional-identity.yml
+++ b/.github/workflows/functional-identity.yml
@@ -31,9 +31,6 @@ jobs:
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
-          - name: "zed"
-            openstack_version: "stable/zed"
-            ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: identity on OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests
     steps:

--- a/.github/workflows/functional-images.yml
+++ b/.github/workflows/functional-images.yml
@@ -31,9 +31,6 @@ jobs:
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
-          - name: "zed"
-            openstack_version: "stable/zed"
-            ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: images/glance on OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests
     steps:

--- a/.github/workflows/functional-keymanager.yml
+++ b/.github/workflows/functional-keymanager.yml
@@ -33,9 +33,6 @@ jobs:
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
-          - name: "zed"
-            openstack_version: "stable/zed"
-            ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: keymanager on OpenStack ${{ matrix.name }} with Barbican and run keymanager acceptance tests
     steps:

--- a/.github/workflows/functional-loadbalancer.yml
+++ b/.github/workflows/functional-loadbalancer.yml
@@ -30,9 +30,6 @@ jobs:
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
-          - name: "zed"
-            openstack_version: "stable/zed"
-            ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: loadbalancing for OpenStack ${{ matrix.name }} with Octavia and run loadbalancer acceptance tests
     steps:

--- a/.github/workflows/functional-networking.yml
+++ b/.github/workflows/functional-networking.yml
@@ -31,9 +31,6 @@ jobs:
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
-          - name: "zed"
-            openstack_version: "stable/zed"
-            ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: networking on OpenStack ${{ matrix.name }} with defaults and run basic acceptance tests
     steps:

--- a/.github/workflows/functional-objectstorage.yml
+++ b/.github/workflows/functional-objectstorage.yml
@@ -30,9 +30,6 @@ jobs:
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
-          - name: "zed"
-            openstack_version: "stable/zed"
-            ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: objectstorage OpenStack ${{ matrix.name }} with Swift and run objectstorage acceptance tests
     steps:

--- a/.github/workflows/functional-orchestration.yml
+++ b/.github/workflows/functional-orchestration.yml
@@ -30,9 +30,6 @@ jobs:
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
-          - name: "zed"
-            openstack_version: "stable/zed"
-            ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Heat and run orchestration acceptance tests
     steps:

--- a/.github/workflows/functional-sharedfilesystem.yml
+++ b/.github/workflows/functional-sharedfilesystem.yml
@@ -30,9 +30,6 @@ jobs:
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
-          - name: "zed"
-            openstack_version: "stable/zed"
-            ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: sharedfilesystem on OpenStack ${{ matrix.name }} with Manila and run sharedfilesystem acceptance tests
     steps:

--- a/.github/workflows/functional-vpnaas.yml
+++ b/.github/workflows/functional-vpnaas.yml
@@ -30,9 +30,6 @@ jobs:
           - name: "antelope"
             openstack_version: "stable/2023.1"
             ubuntu_version: "22.04"
-          - name: "zed"
-            openstack_version: "stable/zed"
-            ubuntu_version: "20.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: vpnaas on OpenStack ${{ matrix.name }} with Neutron and run vpnaas acceptance tests
     steps:


### PR DESCRIPTION
Zed has reached EOM status and is no longer maintained. CI jobs are already failing. Remove zed coverage from ci