### PR TITLE
Add references between compute_servergroup and compute_instance docs

### DIFF
--- a/docs/resources/compute_instance_v2.md
+++ b/docs/resources/compute_instance_v2.md
@@ -397,6 +397,8 @@ The following arguments are supported:
 
 * `scheduler_hints` - (Optional) Provide the Nova scheduler with hints on how
     the instance should be launched. The available hints are described below.
+    See [reference](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/compute_servergroup_v2)
+    for details on managing servergroup resources
 
 * `personality` - (Optional) Customize the personality of an instance by
     defining one or more files and their contents. The personality structure

--- a/docs/resources/compute_instance_v2.md
+++ b/docs/resources/compute_instance_v2.md
@@ -397,8 +397,6 @@ The following arguments are supported:
 
 * `scheduler_hints` - (Optional) Provide the Nova scheduler with hints on how
     the instance should be launched. The available hints are described below.
-    See [reference](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/compute_servergroup_v2)
-    for details on managing servergroup resources
 
 * `personality` - (Optional) Customize the personality of an instance by
     defining one or more files and their contents. The personality structure
@@ -489,7 +487,8 @@ The `block_device` block supports:
 The `scheduler_hints` block supports:
 
 * `group` - (Optional) A UUID of a Server Group. The instance will be placed
-    into that group.
+    into that group. See [reference](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/compute_servergroup_v2)
+    for details on managing servergroup resources
 
 * `different_host` - (Optional) A list of instance UUIDs. The instance will
     be scheduled on a different host than all other instances.

--- a/docs/resources/compute_servergroup_v2.md
+++ b/docs/resources/compute_servergroup_v2.md
@@ -10,6 +10,8 @@ description: |-
 # openstack\_compute\_servergroup\_v2
 
 Manages a V2 Server Group resource within OpenStack.
+See [reference](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/compute_instance_v2)
+for details on using servergroups as compute_instance scheduler_hints
 
 ## Example Usage
 

--- a/docs/resources/compute_servergroup_v2.md
+++ b/docs/resources/compute_servergroup_v2.md
@@ -10,8 +10,6 @@ description: |-
 # openstack\_compute\_servergroup\_v2
 
 Manages a V2 Server Group resource within OpenStack.
-See [reference](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/compute_instance_v2)
-for details on using servergroups as compute_instance scheduler_hints
 
 ## Example Usage
 
@@ -21,6 +19,20 @@ for details on using servergroups as compute_instance scheduler_hints
 resource "openstack_compute_servergroup_v2" "test-sg" {
   name     = "my-sg"
   policies = ["anti-affinity"]
+}
+
+resource "openstack_compute_instance_v2" "test-instance" {
+  name      = "my-instance"
+  image_id  = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+  flavor_id = "3"
+
+  scheduler_hints {
+    group = openstack_compute_servergroup_v2.test-sg.id
+  }
+
+  network {
+    name = "my_network"
+  }
 }
 ```
 
@@ -32,6 +44,20 @@ resource "openstack_compute_servergroup_v2" "test-sg" {
   policies = ["anti-affinity"]
   rules {
       max_server_per_host = 3
+  }
+}
+
+resource "openstack_compute_instance_v2" "test-instance" {
+  name      = "my-instance"
+  image_id  = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+  flavor_id = "3"
+
+  scheduler_hints {
+    group = openstack_compute_servergroup_v2.test-sg.id
+  }
+
+  network {
+    name = "my_network"
   }
 }
 ```


### PR DESCRIPTION
docs/resources/compute_instance_v2.md: Add reference to servergroups resource docs for instance resource attribute
docs/resources/compute_servergroup_v2.md: Add reference to instance resource attribute in overview