### PR TITLE
Add volume attach tag with nova microversion 2.49

### DIFF
--- a/docs/resources/compute_volume_attach_v2.md
+++ b/docs/resources/compute_volume_attach_v2.md
@@ -156,6 +156,10 @@ The following arguments are supported:
 
 * `multiattach` - (Optional) Enable attachment of multiattach-capable volumes.
 
+* `tag` - (Optional) Add a device role tag that is applied to the volume when
+  attaching it to the VM. Changing this creates a new volume attachment with
+  the new tag. Requires microversion >= 2.49.
+
 * `vendor_options` - (Optional) Map of additional vendor-specific options.
   Supported options are described below.
 

--- a/openstack/compute_instance_v2.go
+++ b/openstack/compute_instance_v2.go
@@ -28,6 +28,7 @@ const (
 	computeV2InstanceCreateServerWithTagsMicroversion        = "2.52"
 	computeV2TagsExtensionMicroversion                       = "2.26"
 	computeV2InstanceBlockDeviceVolumeTypeMicroversion       = "2.67"
+	computeV2InstanceBlockDeviceVolumeAttachTagsMicroversion = "2.49"
 	computeV2InstanceBlockDeviceMultiattachMicroversion      = "2.60"
 )
 

--- a/openstack/resource_openstack_compute_volume_attach_v2.go
+++ b/openstack/resource_openstack_compute_volume_attach_v2.go
@@ -60,6 +60,12 @@ func resourceComputeVolumeAttachV2() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"tag": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"vendor_options": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -116,6 +122,13 @@ func resourceComputeVolumeAttachV2Create(ctx context.Context, d *schema.Resource
 	attachOpts := volumeattach.CreateOpts{
 		Device:   device,
 		VolumeID: volumeID,
+	}
+
+	// tag requires nova microversion 2.49. Only set when specified.
+	if v, ok := d.GetOk("tag"); ok {
+		tag := v.(string)
+		attachOpts.Tag = tag
+		computeClient.Microversion = computeV2InstanceBlockDeviceVolumeAttachTagsMicroversion
 	}
 
 	log.Printf("[DEBUG] openstack_compute_volume_attach_v2 attach options %s: %#v", instanceID, attachOpts)

--- a/openstack/resource_openstack_compute_volume_attach_v2_test.go
+++ b/openstack/resource_openstack_compute_volume_attach_v2_test.go
@@ -212,6 +212,7 @@ resource "openstack_compute_instance_v2" "instance_1" {
 resource "openstack_compute_volume_attach_v2" "va_1" {
   instance_id = "${openstack_compute_instance_v2.instance_1.id}"
   volume_id = "${openstack_blockstorage_volume_v3.volume_1.id}"
+  tag = "test"
   vendor_options {
     ignore_volume_confirmation = true
   }


### PR DESCRIPTION
The API is 
https://docs.openstack.org/api-ref/compute/#attach-a-volume-to-an-instance

and the opts in gophercloud is 
https://github.com/gophercloud/gophercloud/blob/master/openstack/compute/v2/volumeattach/requests.go#L34