### PR TITLE
Add redirect_prefix and redirect_http_code to l7policy

### DIFF
--- a/docs/resources/lb_l7policy_v2.md
+++ b/docs/resources/lb_l7policy_v2.md
@@ -87,6 +87,14 @@ The following arguments are supported:
 * `redirect_url` - (Optional) Requests matching this policy will be redirected to this URL.
     Only valid if action is REDIRECT\_TO\_URL.
 
+* `redirect_prefix` - (Optional) Requests matching this policy will be redirected to 
+    this Prefix URL. Only valid if action is REDIRECT\_PREFIX.
+
+* `redirect_http_code` - (Optional) Integer. Requests matching this policy will be  
+    redirected to the specified URL or Prefix URL with the HTTP response code.  
+    Valid if action is REDIRECT\_TO\_URL or REDIRECT\_PREFIX. Valid options are: 
+    301, 302, 303, 307, or 308. Default is 302. New in octavia version 2.9
+
 * `admin_state_up` - (Optional) The administrative state of the L7 Policy.
     A valid value is true (UP) or false (DOWN).
 
@@ -104,6 +112,8 @@ The following attributes are exported:
 * `position` - See Argument Reference above.
 * `redirect_pool_id` - See Argument Reference above.
 * `redirect_url` - See Argument Reference above.
+* `redirect_prefix` - See Argument Reference above.
+* `redirect_http_code` - See Argument Reference above.
 * `admin_state_up` - See Argument Reference above.
 
 ## Import

--- a/openstack/resource_openstack_lb_l7policy_v2_test.go
+++ b/openstack/resource_openstack_lb_l7policy_v2_test.go
@@ -96,6 +96,40 @@ func TestAccLBV2L7Policy_basic(t *testing.T) {
 						regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")),
 				),
 			},
+			{
+				Config: testAccCheckLbV2L7PolicyConfigUpdate4(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLBV2L7PolicyExists("openstack_lb_l7policy_v2.l7policy_1", &l7Policy),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_l7policy_v2.l7policy_1", "name", "test_updated"),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_l7policy_v2.l7policy_1", "description", ""),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_l7policy_v2.l7policy_1", "action", "REDIRECT_PREFIX"),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_l7policy_v2.l7policy_1", "position", "1"),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_l7policy_v2.l7policy_1", "redirect_prefix", "https://foo.bar"),
+				),
+			},
+			{
+				Config: testAccCheckLbV2L7PolicyConfigUpdate5(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLBV2L7PolicyExists("openstack_lb_l7policy_v2.l7policy_1", &l7Policy),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_l7policy_v2.l7policy_1", "name", "test_updated"),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_l7policy_v2.l7policy_1", "description", ""),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_l7policy_v2.l7policy_1", "action", "REDIRECT_PREFIX"),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_l7policy_v2.l7policy_1", "position", "1"),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_l7policy_v2.l7policy_1", "redirect_prefix", "https://foo.bar.baz"),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_l7policy_v2.l7policy_1", "redirect_http_code", "307"),
+				),
+			},
 		},
 	})
 }
@@ -251,6 +285,49 @@ resource "openstack_lb_l7policy_v2" "l7policy_1" {
   action           = "REJECT"
   position         = 1
   listener_id      = "${openstack_lb_listener_v2.listener_1.id}"
+}
+`, testAccCheckLbV2L7PolicyConfig)
+}
+
+func testAccCheckLbV2L7PolicyConfigUpdate4() string {
+	return fmt.Sprintf(`
+%s
+
+resource "openstack_lb_pool_v2" "pool_1" {
+  name            = "pool_1"
+  protocol        = "HTTP"
+  lb_method       = "ROUND_ROBIN"
+  loadbalancer_id = "${openstack_lb_loadbalancer_v2.loadbalancer_1.id}"
+}
+
+resource "openstack_lb_l7policy_v2" "l7policy_1" {
+  name             = "test_updated"
+  action           = "REDIRECT_PREFIX"
+  position         = 1
+  listener_id      = "${openstack_lb_listener_v2.listener_1.id}"
+  redirect_prefix  = "https://foo.bar"
+}
+`, testAccCheckLbV2L7PolicyConfig)
+}
+
+func testAccCheckLbV2L7PolicyConfigUpdate5() string {
+	return fmt.Sprintf(`
+%s
+
+resource "openstack_lb_pool_v2" "pool_1" {
+  name            = "pool_1"
+  protocol        = "HTTP"
+  lb_method       = "ROUND_ROBIN"
+  loadbalancer_id = "${openstack_lb_loadbalancer_v2.loadbalancer_1.id}"
+}
+
+resource "openstack_lb_l7policy_v2" "l7policy_1" {
+  name               = "test_updated"
+  action             = "REDIRECT_PREFIX"
+  position           = 1
+  listener_id        = "${openstack_lb_listener_v2.listener_1.id}"
+  redirect_prefix    = "https://foo.bar.baz"
+  redirect_http_code = 307
 }
 `, testAccCheckLbV2L7PolicyConfig)
 }


### PR DESCRIPTION
Add support for redirect_prefix and redirect_http_code attributes to openstack_lb_l7_policy_v2.
Close https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1347