### PR TITLE
Allow Magnum node_count=0 for cluster update

### DIFF
--- a/openstack/resource_openstack_containerinfra_cluster_v1.go
+++ b/openstack/resource_openstack_containerinfra_cluster_v1.go
@@ -448,6 +448,11 @@ func resourceContainerInfraClusterV1Update(ctx context.Context, d *schema.Resour
 
 	if d.HasChange("node_count") {
 		nodeCount := d.Get("node_count").(int)
+
+		if nodeCount == 0 {
+			containerInfraClient.Microversion = containerInfraV1ZeroNodeCountMicroversion
+		}
+
 		updateOpts = append(updateOpts, clusters.UpdateOpts{
 			Op:    clusters.ReplaceOp,
 			Path:  strings.Join([]string{"/", "node_count"}, ""),


### PR DESCRIPTION
Since  1.10 Magnum allow cluster creation with worker node count set to 0. This one  set the correct microversion to allow node_count=0 on cluster update.