### PR TITLE
Add support for more types for lb_rule_v2

### DIFF
--- a/docs/resources/lb_l7rule_v2.md
+++ b/docs/resources/lb_l7rule_v2.md
@@ -78,7 +78,7 @@ The following arguments are supported:
 * `description` - (Optional) Human-readable description for the L7 Rule.
 
 * `type` - (Required) The L7 Rule type - can either be COOKIE, FILE\_TYPE, HEADER,
-    HOST\_NAME or PATH.
+    HOST\_NAME, PATH, SSL\_CONN\_HAS\_CERT, SSL\_VERIFY\_RESULT or SSL\_DN\_FIELD.
 
 * `compare_type` - (Required) The comparison type for the L7 rule - can either be
     CONTAINS, STARTS\_WITH, ENDS_WITH, EQUAL_TO or REGEX

--- a/openstack/resource_openstack_lb_l7rule_v2.go
+++ b/openstack/resource_openstack_lb_l7rule_v2.go
@@ -51,7 +51,9 @@ func resourceL7RuleV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"COOKIE", "FILE_TYPE", "HEADER", "HOST_NAME", "PATH",
+					"COOKIE", "FILE_TYPE", "HEADER", "HOST_NAME",
+					"PATH", "SSL_CONN_HAS_CERT", "SSL_VERIFY_RESULT",
+					"SSL_DN_FIELD",
 				}, true),
 			},
 


### PR DESCRIPTION
Add support for types "SSL_CONN_HAS_CERT", "SSL_VERIFY_RESULT", "SSL_DN_FIELD" on resource openstack_lb_l7rule_v2