### PR TITLE
Use Go standard module naming

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-provider-openstack/terraform-provider-openstack
+module github.com/terraform-provider-openstack/terraform-provider-openstack/v2
 
 go 1.20
 
@@ -8,6 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.30.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/stretchr/testify v1.7.2
+	github.com/terraform-provider-openstack/terraform-provider-openstack v1.54.1
 	github.com/ulikunitz/xz v0.5.11
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
+github.com/terraform-provider-openstack/terraform-provider-openstack v1.54.1 h1:M5KvCjQf2eBkd8N24FTGCu7cGoPoBi/N0FG90WjMpPo=
+github.com/terraform-provider-openstack/terraform-provider-openstack v1.54.1/go.mod h1:F142rYNEJIEEQ4WNGvFcRpl5qKPMwrF5xvZF5zhe3b4=
 github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=
 github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
Updates go.mod package name to `v2` extension to match GitHub versioning.

Fixes #1727.

