### PR TITLE
Use Go standard module naming

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-provider-openstack/terraform-provider-openstack
+module github.com/terraform-provider-openstack/terraform-provider-openstack/v2
 
 go 1.20
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
-	"github.com/terraform-provider-openstack/terraform-provider-openstack/openstack"
+	"github.com/terraform-provider-openstack/terraform-provider-openstack/v2/openstack"
 )
 
 const providerAddr = "registry.terraform.io/terraform-provider-openstack/openstack"

--- a/openstack/provider_test.go
+++ b/openstack/provider_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-provider-openstack/terraform-provider-openstack/openstack/internal/pathorcontents"
+	"github.com/terraform-provider-openstack/terraform-provider-openstack/v2/openstack/internal/pathorcontents"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/utils/terraform/auth"


### PR DESCRIPTION
Update module name to v2 to match GitHub versioning

Fixes #1727 