### PR TITLE
[networking]: enforce bool type for bool "value_specs"

### DIFF
--- a/openstack/util.go
+++ b/openstack/util.go
@@ -53,6 +53,11 @@ func GetRegion(d *schema.ResourceData, config *Config) string {
 func AddValueSpecs(body map[string]interface{}) map[string]interface{} {
 	if body["value_specs"] != nil {
 		for k, v := range body["value_specs"].(map[string]interface{}) {
+			// this hack allows to pass boolean values as strings
+			if v == "true" || v == "false" {
+				body[k] = v == "true"
+				continue
+			}
 			body[k] = v
 		}
 		delete(body, "value_specs")

--- a/openstack/util_test.go
+++ b/openstack/util_test.go
@@ -81,3 +81,26 @@ func TestUnitMapDiffWithNilValues(t *testing.T) {
 	assert.Equal(t, result["c"], "3")
 	assert.Equal(t, len(result), 3)
 }
+
+func TestBuildRequestBoolType(t *testing.T) {
+	v := SubnetCreateOpts{
+		ValueSpecs: map[string]string{
+			"key1": "value1",
+			"key2": "true",
+			"key3": "false",
+		},
+	}
+
+	req, err := BuildRequest(v, "")
+	assert.Nil(t, err)
+
+	expected := map[string]interface{}{
+		"": map[string]interface{}{
+			"key1":       "value1",
+			"key2":       true,
+			"key3":       false,
+			"network_id": "",
+		},
+	}
+	assert.Equal(t, expected, req)
+}


### PR DESCRIPTION
This PR enforces bool type for key value `value_specs`  which correspond to `"true"` or `"false"` strings.

Resolves #1730