### PR TITLE
[networking]: add dns_publish_fixed_ip to subnet argument

### DIFF
--- a/docs/data-sources/networking_subnet_ids_v2.md
+++ b/docs/data-sources/networking_subnet_ids_v2.md
@@ -53,6 +53,8 @@ data "openstack_networking_subnet_ids_v2" "subnets" {
 
 * `subnetpool_id` - (Optional) The ID of the subnetpool associated with the subnet.
 
+* `dns_publish_fixed_ip` - (Optional) If the subnet publishes DNS records.
+
 * `tags` - (Optional) The list of subnet tags to filter.
 
 * `sort_key` - (Optional) Sort subnets based on a certain key. Defaults to none.

--- a/docs/data-sources/networking_subnet_v2.md
+++ b/docs/data-sources/networking_subnet_v2.md
@@ -51,6 +51,8 @@ data "openstack_networking_subnet_v2" "subnet_1" {
 
 * `subnetpool_id` - (Optional) The ID of the subnetpool associated with the subnet.
 
+* `dns_publish_fixed_ip` - (Optional) If the subnet publishes DNS records.
+
 * `tags` - (Optional) The list of subnet tags to filter.
 
 ## Attributes Reference

--- a/docs/resources/networking_subnet_v2.md
+++ b/docs/resources/networking_subnet_v2.md
@@ -30,21 +30,21 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
 The following arguments are supported:
 
 * `region` - (Optional) The region in which to obtain the V2 Networking client.
-    A Networking client is needed to create a Neutron subnet. If omitted, the
-    `region` argument of the provider is used. Changing this creates a new
-    subnet.
+  A Networking client is needed to create a Neutron subnet. If omitted, the
+  `region` argument of the provider is used. Changing this creates a new
+  subnet.
 
 * `network_id` - (Required) The UUID of the parent network. Changing this
-    creates a new subnet.
+  creates a new subnet.
 
 * `cidr` - (Optional) CIDR representing IP range for this subnet, based on IP
-    version. You can omit this option if you are creating a subnet from a
-    subnet pool.
+  version. You can omit this option if you are creating a subnet from a
+  subnet pool.
 
 * `prefix_length` - (Optional) The prefix length to use when creating a subnet
-    from a subnet pool. The default subnet pool prefix length that was defined
-    when creating the subnet pool will be used if not provided. Changing this
-    creates a new subnet.
+  from a subnet pool. The default subnet pool prefix length that was defined
+  when creating the subnet pool will be used if not provided. Changing this
+  creates a new subnet.
 
 * `ip_version` - (Optional) IP version, either 4 (default) or 6. Changing this creates a
     new subnet.
@@ -56,39 +56,42 @@ The following arguments are supported:
   are `dhcpv6-stateful`, `dhcpv6-stateless`, or `slaac`.
 
 * `name` - (Optional) The name of the subnet. Changing this updates the name of
-    the existing subnet.
+  the existing subnet.
 
 * `description` - (Optional) Human-readable description of the subnet. Changing this
-    updates the name of the existing subnet.
+  updates the name of the existing subnet.
 
 * `tenant_id` - (Optional) The owner of the subnet. Required if admin wants to
-    create a subnet for another tenant. Changing this creates a new subnet.
+  create a subnet for another tenant. Changing this creates a new subnet.
 
 * `allocation_pool` - (Optional) A block declaring the start and end range of
-    the IP addresses available for use with DHCP in this subnet. Multiple
-    `allocation_pool` blocks can be declared, providing the subnet with more
-    than one range of IP addresses to use with DHCP. However, each IP range
-    must be from the same CIDR that the subnet is part of.
-    The `allocation_pool` block is documented below.
+  the IP addresses available for use with DHCP in this subnet. Multiple
+  `allocation_pool` blocks can be declared, providing the subnet with more
+  than one range of IP addresses to use with DHCP. However, each IP range
+  must be from the same CIDR that the subnet is part of.
+  The `allocation_pool` block is documented below.
 
 * `gateway_ip` - (Optional)  Default gateway used by devices in this subnet.
-    Leaving this blank and not setting `no_gateway` will cause a default
-    gateway of `.1` to be used. Changing this updates the gateway IP of the
-    existing subnet.
+  Leaving this blank and not setting `no_gateway` will cause a default
+  gateway of `.1` to be used. Changing this updates the gateway IP of the
+  existing subnet.
 
 * `no_gateway` - (Optional) Do not set a gateway IP on this subnet. Changing
     this removes or adds a default gateway IP of the existing subnet.
 
 * `enable_dhcp` - (Optional) The administrative state of the network.
-    Acceptable values are "true" and "false". Changing this value enables or
-    disables the DHCP capabilities of the existing subnet. Defaults to true.
+  Acceptable values are "true" and "false". Changing this value enables or
+  disables the DHCP capabilities of the existing subnet. Defaults to true.
 
 * `dns_nameservers` - (Optional) An array of DNS name server names used by hosts
-    in this subnet. Changing this updates the DNS name servers for the existing
-    subnet.
+  in this subnet. Changing this updates the DNS name servers for the existing
+  subnet.
+
+* `dns_publish_fixed_ip` - (Optional) Whether to publish DNS records for IPs
+  from this subnet. Defaults is false.
 
 * `service_types` - (Optional) An array of service types used by the subnet.
-    Changing this updates the service types for the existing subnet.
+  Changing this updates the service types for the existing subnet.
 
 * `subnetpool_id` - (Optional) The ID of the subnetpool associated with the subnet.
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-provider-openstack/terraform-provider-openstack/v2
 go 1.20
 
 require (
-	github.com/gophercloud/gophercloud v1.9.0
+	github.com/gophercloud/gophercloud v1.13.1-0.20240711153045-e21c5631d2b1
 	github.com/gophercloud/utils v0.0.0-20230324070755-05e9e7f5ea4d
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.30.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gophercloud/gophercloud v1.1.1/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
-github.com/gophercloud/gophercloud v1.9.0 h1:zKvmHOmHuaZlnx9d2DJpEgbMxrGt/+CJ/bKOKQh9Xzo=
-github.com/gophercloud/gophercloud v1.9.0/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
+github.com/gophercloud/gophercloud v1.13.1-0.20240711153045-e21c5631d2b1 h1:MCyiHiwYlq5tYrmGAdzaL1NBfLrTK5ThWQLDQDZkst0=
+github.com/gophercloud/gophercloud v1.13.1-0.20240711153045-e21c5631d2b1/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
 github.com/gophercloud/utils v0.0.0-20230324070755-05e9e7f5ea4d h1:AfRlf5NnsYsHIW5nNxhYp+99Bmj/fLeOYwD5Z4CMlzw=
 github.com/gophercloud/utils v0.0.0-20230324070755-05e9e7f5ea4d/go.mod h1:z4Dey7xsTUXgcB1C8elMvGRKTjV1ez0eoYQlMrduG1g=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/openstack/data_source_openstack_networking_subnet_ids_v2.go
+++ b/openstack/data_source_openstack_networking_subnet_ids_v2.go
@@ -109,6 +109,11 @@ func dataSourceNetworkingSubnetIDsV2() *schema.Resource {
 				Optional: true,
 			},
 
+			"dns_publish_fixed_ip": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"tags": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -191,6 +196,11 @@ func dataSourceNetworkingSubnetIDsV2Read(ctx context.Context, d *schema.Resource
 
 	if v, ok := d.GetOk("subnetpool_id"); ok {
 		listOpts.SubnetPoolID = v.(string)
+	}
+
+	if v, ok := d.GetOk("dns_publish_fixed_ip"); ok {
+		v := v.(bool)
+		listOpts.DNSPublishFixedIP = &v
 	}
 
 	tags := networkingV2AttributesTags(d)

--- a/openstack/data_source_openstack_networking_subnet_v2.go
+++ b/openstack/data_source_openstack_networking_subnet_v2.go
@@ -79,6 +79,11 @@ func dataSourceNetworkingSubnetV2() *schema.Resource {
 				Optional: true,
 			},
 
+			"dns_publish_fixed_ip": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			// Computed values
 			"allocation_pools": {
 				Type:     schema.TypeList,
@@ -230,6 +235,11 @@ func dataSourceNetworkingSubnetV2Read(ctx context.Context, d *schema.ResourceDat
 		listOpts.SubnetPoolID = v.(string)
 	}
 
+	if v, ok := d.GetOk("dns_publish_fixed_ip"); ok {
+		v := v.(bool)
+		listOpts.DNSPublishFixedIP = &v
+	}
+
 	tags := networkingV2AttributesTags(d)
 	if len(tags) > 0 {
 		listOpts.Tags = strings.Join(tags, ",")
@@ -271,6 +281,7 @@ func dataSourceNetworkingSubnetV2Read(ctx context.Context, d *schema.ResourceDat
 	d.Set("gateway_ip", subnet.GatewayIP)
 	d.Set("enable_dhcp", subnet.EnableDHCP)
 	d.Set("subnetpool_id", subnet.SubnetPoolID)
+	d.Set("dns_publish_fixed_ip", subnet.DNSPublishFixedIP)
 	d.Set("all_tags", subnet.Tags)
 	d.Set("region", GetRegion(d, config))
 

--- a/openstack/resource_openstack_networking_subnet_v2.go
+++ b/openstack/resource_openstack_networking_subnet_v2.go
@@ -139,6 +139,11 @@ func resourceNetworkingSubnetV2() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
+			"dns_publish_fixed_ip": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"ipv6_address_mode": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -225,6 +230,11 @@ func resourceNetworkingSubnetV2Create(ctx context.Context, d *schema.ResourceDat
 			IPVersion:       gophercloud.IPVersion(d.Get("ip_version").(int)),
 		},
 		MapValueSpecs(d),
+	}
+
+	if v, ok := d.GetOk("dns_publish_fixed_ip"); ok {
+		v := v.(bool)
+		createOpts.DNSPublishFixedIP = &v
 	}
 
 	// Set CIDR if provided. Check if inferred subnet would match the provided cidr.
@@ -328,6 +338,7 @@ func resourceNetworkingSubnetV2Read(ctx context.Context, d *schema.ResourceData,
 	d.Set("ipv6_address_mode", s.IPv6AddressMode)
 	d.Set("ipv6_ra_mode", s.IPv6RAMode)
 	d.Set("subnetpool_id", s.SubnetPoolID)
+	d.Set("dns_publish_fixed_ip", s.DNSPublishFixedIP)
 
 	networkingV2ReadAttributesTags(d, s.Tags)
 
@@ -414,6 +425,12 @@ func resourceNetworkingSubnetV2Update(ctx context.Context, d *schema.ResourceDat
 	if d.HasChange("allocation_pool") {
 		hasChange = true
 		updateOpts.AllocationPools = expandNetworkingSubnetV2AllocationPools(d.Get("allocation_pool").(*schema.Set).List())
+	}
+
+	if d.HasChange("dns_publish_fixed_ip") {
+		hasChange = true
+		v := d.Get("dns_publish_fixed_ip").(bool)
+		updateOpts.DNSPublishFixedIP = &v
 	}
 
 	if hasChange {


### PR DESCRIPTION
Add `dns_publish_fixed_ip` argument to the `openstack_networking_subnet_v2` resource and `openstack_networking_subnet_v2`, `openstack_networking_subnet_ids_v2` data sources.

Resolves #1730