### PR TITLE
[glance]: add disk and container formats filter to image data sources

### DIFF
--- a/docs/data-sources/images_image_ids_v2.md
+++ b/docs/data-sources/images_image_ids_v2.md
@@ -27,45 +27,50 @@ data "openstack_images_image_ids_v2" "images" {
 
 ## Argument Reference
 
-* `region` - (Optional) The region in which to obtain the V2 Glance client.
-    A Glance client is needed to create an Image that can be used with
-    a compute instance. If omitted, the `region` argument of the provider
-    is used.
+* `region` - (Optional) The region in which to obtain the V2 Glance client. A
+  Glance client is needed to create an Image that can be used with a compute
+  instance. If omitted, the `region` argument of the provider is used.
 
 * `member_status` - (Optional) The status of the image. Must be one of
-   "accepted", "pending", "rejected", or "all".
+  "accepted", "pending", "rejected", or "all".
 
-* `name` - (Optional) The name of the image. Cannot be used simultaneously
-    with `name_regex`.
+* `name` - (Optional) The name of the image. Cannot be used simultaneously with
+  `name_regex`.
 
 * `name_regex` - (Optional) The regular expressian of the name of the image.
-    Cannot be used simultaneously with `name`. Unlike filtering by `name` the    
-    `name_regex` filtering does by client on the result of OpenStack search
-    query.
+  Cannot be used simultaneously with `name`. Unlike filtering by `name` the
+  `name_regex` filtering does by client on the result of OpenStack search
+  query.
 
 * `owner` - (Optional) The owner (UUID) of the image.
 
 * `properties` - (Optional) a map of key/value pairs to match an image with.
-    All specified properties must be matched. Unlike other options filtering    
-    by `properties` does by client on the result of OpenStack search query.
+  All specified properties must be matched. Unlike other options filtering by
+  `properties` does by client on the result of OpenStack search query.
 
 * `size_min` - (Optional) The minimum size (in bytes) of the image to return.
 
 * `size_max` - (Optional) The maximum size (in bytes) of the image to return.
 
 * `sort` - (Optional) Sorts the response by one or more attribute and sort
-    direction combinations. You can also set multiple sort keys and directions.
-    Default direction is `desc`. Use the comma (,) character to separate
-    multiple values. For example expression `sort = "name:asc,status"`
-    sorts ascending by name and descending by status.
+  direction combinations. You can also set multiple sort keys and directions.
+  Default direction is `desc`. Use the comma (,) character to separate multiple
+  values. For example expression `sort = "name:asc,status"` sorts ascending by
+  name and descending by status.
 
 * `tag` - (Optional) Search for images with a specific tag.
 
-* `tags` - (Optional) A list of tags required to be set on the image
-      (all specified tags must be in the images tag list for it to be matched).
+* `tags` - (Optional) A list of tags required to be set on the image (all
+  specified tags must be in the images tag list for it to be matched).
 
 * `visibility` - (Optional) The visibility of the image. Must be one of
-   "public", "private", "community", or "shared". Defaults to "private".
+  "public", "private", "community", or "shared". Defaults to "private".
+
+* `hidden` - (Optional) Whether or not the image is hidden from public list.
+
+* `container_format` - (Optional) The container format of the image.
+
+* `disk_format` - (Optional) The disk format of the image.
 
 ## Attributes Reference
 

--- a/docs/data-sources/images_image_v2.md
+++ b/docs/data-sources/images_image_v2.md
@@ -26,52 +26,55 @@ data "openstack_images_image_v2" "ubuntu" {
 
 ## Argument Reference
 
-* `region` - (Optional) The region in which to obtain the V2 Glance client.
-    A Glance client is needed to create an Image that can be used with
-    a compute instance. If omitted, the `region` argument of the provider
-    is used.
+* `region` - (Optional) The region in which to obtain the V2 Glance client. A
+  Glance client is needed to create an Image that can be used with a compute
+  instance. If omitted, the `region` argument of the provider is used.
 
 * `most_recent` - (Optional) If more than one result is returned, use the most
   recent image.
 
-* `name` - (Optional) The name of the image. Cannot be used simultaneously
-    with `name_regex`.
+* `name` - (Optional) The name of the image. Cannot be used simultaneously with
+  `name_regex`.
 
 * `name_regex` - (Optional) The regular expressian of the name of the image.
-    Cannot be used simultaneously with `name`. Unlike filtering by `name` the
-    `name_regex` filtering does by client on the result of OpenStack search
-    query.
+  Cannot be used simultaneously with `name`. Unlike filtering by `name` the
+  `name_regex` filtering does by client on the result of OpenStack search
+  query.
 
 * `owner` - (Optional) The owner (UUID) of the image.
 
 * `properties` - (Optional) a map of key/value pairs to match an image with.
-    All specified properties must be matched. Unlike other options filtering
-    by `properties` does by client on the result of OpenStack search query.
-    Filtering is applied if server responce contains at least 2 images. In
-    case there is only one image the `properties` ignores.
+  All specified properties must be matched. Unlike other options filtering by
+  `properties` does by client on the result of OpenStack search query.
+  Filtering is applied if server responce contains at least 2 images. In case
+  there is only one image the `properties` ignores.
 
 * `size_min` - (Optional) The minimum size (in bytes) of the image to return.
 
 * `size_max` - (Optional) The maximum size (in bytes) of the image to return.
 
 * `sort` - (Optional) Sorts the response by one or more attribute and sort
-    direction combinations. You can also set multiple sort keys and directions.
-    Default direction is `desc`. Use the comma (,) character to separate
-    multiple values. For example expression `sort = "name:asc,status"`
-    sorts ascending by name and descending by status.
+  direction combinations. You can also set multiple sort keys and directions.
+  Default direction is `desc`. Use the comma (,) character to separate multiple
+  values. For example expression `sort = "name:asc,status"` sorts ascending by
+  name and descending by status.
 
 * `tag` - (Optional) Search for images with a specific tag.
 
-* `tags` - (Optional) A list of tags required to be set on the image 
-      (all specified tags must be in the images tag list for it to be matched).
+* `tags` - (Optional) A list of tags required to be set on the image all
+  specified tags must be in the images tag list for it to be matched).
 
 * `visibility` - (Optional) The visibility of the image. Must be one of
-   "public", "private", "community", or "shared". Defaults to "private".
+  "public", "private", "community", or "shared". Defaults to "private".
 
 * `hidden` - (Optional) Whether or not the image is hidden from public list.
 
 * `member_status` - (Optional) The status of the image. Must be one of
-   "accepted", "pending", "rejected", or "all".
+  "accepted", "pending", "rejected", or "all".
+
+* `container_format` - (Optional) The container format of the image.
+
+* `disk_format` - (Optional) The disk format of the image.
 
 ## Attributes Reference
 
@@ -83,16 +86,15 @@ are exported:
 * `container_format`: The format of the image's container.
 * `disk_format`: The format of the image's disk.
 * `file` - the trailing path after the glance endpoint that represent the
-location of the image or the path to retrieve it.
-* `metadata` - The metadata associated with the image.
-   Image metadata allow for meaningfully define the image properties
-   and tags. See https://docs.openstack.org/glance/latest/user/metadefs-concepts.html.
+  location of the image or the path to retrieve it.
+* `metadata` - The metadata associated with the image. Image metadata allow for
+  meaningfully define the image properties and tags. See
+  https://docs.openstack.org/glance/latest/user/metadefs-concepts.html.
 * `min_disk_gb` - The minimum amount of disk space required to use the image.
 * `min_ram_mb` - The minimum amount of ram required to use the image.
 * `properties` - Freeform information about the image.
 * `protected` - Whether or not the image is protected.
-* `schema` - The path to the JSON-schema that represent
-   the image or image
+* `schema` - The path to the JSON-schema that represent the image
 * `size_bytes` - The size of the image (in bytes).
 * `tags` - The tags list of the image.
 * `updated_at` - The date the image was last updated.

--- a/docs/data-sources/images_image_v2.md
+++ b/docs/data-sources/images_image_v2.md
@@ -61,7 +61,7 @@ data "openstack_images_image_v2" "ubuntu" {
 
 * `tag` - (Optional) Search for images with a specific tag.
 
-* `tags` - (Optional) A list of tags required to be set on the image all
+* `tags` - (Optional) A list of tags required to be set on the image (all
   specified tags must be in the images tag list for it to be matched).
 
 * `visibility` - (Optional) The visibility of the image. Must be one of

--- a/openstack/data_source_openstack_images_image_ids_v2.go
+++ b/openstack/data_source_openstack_images_image_ids_v2.go
@@ -95,6 +95,13 @@ func dataSourceImagesImageIDsV2() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"hidden": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: false,
+				Default:  false,
+			},
+
 			"name_regex": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -108,6 +115,16 @@ func dataSourceImagesImageIDsV2() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
+			},
+
+			"container_format": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"disk_format": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 
 			// Computed values
@@ -147,15 +164,18 @@ func dataSourceImagesImageIdsV2Read(ctx context.Context, d *schema.ResourceData,
 	}
 
 	listOpts := images.ListOpts{
-		Name:         d.Get("name").(string),
-		Visibility:   visibility,
-		Owner:        d.Get("owner").(string),
-		Status:       images.ImageStatusActive,
-		SizeMin:      int64(d.Get("size_min").(int)),
-		SizeMax:      int64(d.Get("size_max").(int)),
-		Sort:         d.Get("sort").(string),
-		Tags:         tags,
-		MemberStatus: memberStatus,
+		Name:            d.Get("name").(string),
+		Visibility:      visibility,
+		Hidden:          d.Get("hidden").(bool),
+		Owner:           d.Get("owner").(string),
+		Status:          images.ImageStatusActive,
+		SizeMin:         int64(d.Get("size_min").(int)),
+		SizeMax:         int64(d.Get("size_max").(int)),
+		Sort:            d.Get("sort").(string),
+		ContainerFormat: d.Get("container_format").(string),
+		DiskFormat:      d.Get("disk_format").(string),
+		Tags:            tags,
+		MemberStatus:    memberStatus,
 	}
 
 	log.Printf("[DEBUG] List Options in openstack_images_image_ids_v2: %#v", listOpts)

--- a/openstack/data_source_openstack_images_image_v2.go
+++ b/openstack/data_source_openstack_images_image_v2.go
@@ -117,17 +117,17 @@ func dataSourceImagesImageV2() *schema.Resource {
 				ConflictsWith: []string{"name"},
 			},
 
-			// Computed values
 			"container_format": {
 				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
 			},
 
 			"disk_format": {
 				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
 			},
 
+			// Computed values
 			"min_disk_gb": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -212,16 +212,18 @@ func dataSourceImagesImageV2Read(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	listOpts := images.ListOpts{
-		Name:         d.Get("name").(string),
-		Visibility:   visibility,
-		Hidden:       d.Get("hidden").(bool),
-		Owner:        d.Get("owner").(string),
-		Status:       images.ImageStatusActive,
-		SizeMin:      int64(d.Get("size_min").(int)),
-		SizeMax:      int64(d.Get("size_max").(int)),
-		Sort:         d.Get("sort").(string),
-		Tags:         tags,
-		MemberStatus: memberStatus,
+		Name:            d.Get("name").(string),
+		Visibility:      visibility,
+		Hidden:          d.Get("hidden").(bool),
+		Owner:           d.Get("owner").(string),
+		Status:          images.ImageStatusActive,
+		SizeMin:         int64(d.Get("size_min").(int)),
+		SizeMax:         int64(d.Get("size_max").(int)),
+		Sort:            d.Get("sort").(string),
+		ContainerFormat: d.Get("container_format").(string),
+		DiskFormat:      d.Get("disk_format").(string),
+		Tags:            tags,
+		MemberStatus:    memberStatus,
 	}
 
 	log.Printf("[DEBUG] List Options: %#v", listOpts)


### PR DESCRIPTION
Add `container_format` and `disk_format` filters to the `openstack_images_image_v2` data source
Add `container_format` , `disk_format` and `hidden` filters to the `openstack_images_image_ids_v2` data source