### PR TITLE
[neutron]: add stateful argument to security groups

### DIFF
--- a/docs/data-sources/networking_secgroup_v2.md
+++ b/docs/data-sources/networking_secgroup_v2.md
@@ -35,6 +35,8 @@ data "openstack_networking_secgroup_v2" "secgroup" {
 
 * `tenant_id` - (Optional) The owner of the security group.
 
+* `stateful` - (Optional) Whether the security group is stateful or not.
+
 ## Attributes Reference
 
 `id` is set to the ID of the found security group. In addition, the following
@@ -44,3 +46,4 @@ attributes are exported:
 * `description`- See Argument Reference above.
 * `all_tags` - The set of string tags applied on the security group.
 * `region` - See Argument Reference above.
+* `stateful` - See Argument Reference above.

--- a/docs/resources/networking_secgroup_v2.md
+++ b/docs/resources/networking_secgroup_v2.md
@@ -27,21 +27,26 @@ resource "openstack_networking_secgroup_v2" "secgroup_1" {
 The following arguments are supported:
 
 * `region` - (Optional) The region in which to obtain the V2 networking client.
-    A networking client is needed to create a port. If omitted, the
-    `region` argument of the provider is used. Changing this creates a new
-    security group.
+  A networking client is needed to create a port. If omitted, the
+  `region` argument of the provider is used. Changing this creates a new
+  security group.
 
 * `name` - (Required) A unique name for the security group.
 
 * `description` - (Optional) A unique name for the security group.
 
 * `tenant_id` - (Optional) The owner of the security group. Required if admin
-    wants to create a port for another tenant. Changing this creates a new
-    security group.
+  wants to create a port for another tenant. Changing this creates a new
+  security group.
 
 * `delete_default_rules` - (Optional) Whether or not to delete the default
-    egress security rules. This is `false` by default. See the below note
-    for more information.
+  egress security rules. This is `false` by default. See the below note
+  for more information.
+
+* `stateful` - (Optional) Indicates if the security group is stateful or
+  stateless. Update of the stateful argument is allowed when there is no port
+  associated with the security group. Available only in OpenStack environments
+  with the `stateful-security-group` extension. Defaults to true.
 
 * `tags` - (Optional) A set of string tags for the security group.
 

--- a/openstack/data_source_openstack_networking_secgroup_v2.go
+++ b/openstack/data_source_openstack_networking_secgroup_v2.go
@@ -40,6 +40,11 @@ func dataSourceNetworkingSecGroupV2() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
+			"stateful": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 			"tags": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -66,6 +71,10 @@ func dataSourceNetworkingSecGroupV2Read(ctx context.Context, d *schema.ResourceD
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
 		TenantID:    d.Get("tenant_id").(string),
+	}
+	if v, ok := getOkExists(d, "stateful"); ok {
+		v := v.(bool)
+		listOpts.Stateful = &v
 	}
 
 	tags := networkingV2AttributesTags(d)
@@ -99,6 +108,7 @@ func dataSourceNetworkingSecGroupV2Read(ctx context.Context, d *schema.ResourceD
 	d.Set("name", secGroup.Name)
 	d.Set("description", secGroup.Description)
 	d.Set("tenant_id", secGroup.TenantID)
+	d.Set("stateful", secGroup.Stateful)
 	d.Set("all_tags", secGroup.Tags)
 	d.Set("region", GetRegion(d, config))
 

--- a/openstack/data_source_openstack_networking_secgroup_v2_test.go
+++ b/openstack/data_source_openstack_networking_secgroup_v2_test.go
@@ -64,6 +64,41 @@ func TestAccOpenStackNetworkingSecGroupV2DataSource_secGroupID(t *testing.T) {
 	})
 }
 
+func TestAccOpenStackNetworkingSecGroupV2DataSource_stateful(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpenStackNetworkingSecGroupV2DataSourceStatefulNotSet,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingSecGroupV2DataSourceID("data.openstack_networking_secgroup_v2.secgroup_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_secgroup_v2.secgroup_1", "stateful", "true"),
+				),
+			},
+			{
+				Config: testAccOpenStackNetworkingSecGroupV2DataSourceStatefulSetFalse,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingSecGroupV2DataSourceID("data.openstack_networking_secgroup_v2.secgroup_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_secgroup_v2.secgroup_1", "stateful", "false"),
+				),
+			},
+			{
+				Config: testAccOpenStackNetworkingSecGroupV2DataSourceStatefulSetTrue,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingSecGroupV2DataSourceID("data.openstack_networking_secgroup_v2.secgroup_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_secgroup_v2.secgroup_1", "stateful", "false"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkingSecGroupV2DataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -115,3 +150,47 @@ data "openstack_networking_secgroup_v2" "secgroup_1" {
 }
 `, testAccOpenStackNetworkingSecGroupV2DataSourceGroup)
 }
+
+const testAccOpenStackNetworkingSecGroupV2DataSourceStatefulNotSet = `
+resource "openstack_networking_secgroup_v2" "secgroup_1" {
+  name        = "secgroup_not_stateful_1"
+  description = "My neutron security group"
+}
+
+data "openstack_networking_secgroup_v2" "secgroup_1" {
+  name = "${openstack_networking_secgroup_v2.secgroup_1.name}"
+}
+`
+
+const testAccOpenStackNetworkingSecGroupV2DataSourceStatefulSetFalse = `
+resource "openstack_networking_secgroup_v2" "secgroup_1" {
+  name        = "secgroup_not_stateful_1"
+  description = "My neutron security group"
+  stateful    = false
+}
+
+data "openstack_networking_secgroup_v2" "secgroup_1" {
+  name     = "${openstack_networking_secgroup_v2.secgroup_1.name}"
+  stateful = false
+}
+`
+
+const testAccOpenStackNetworkingSecGroupV2DataSourceStatefulSetTrue = `
+resource "openstack_networking_secgroup_v2" "secgroup_1" {
+  name        = "secgroup_stateful_1"
+  description = "My neutron security group"
+  stateful    = true
+}
+
+resource "openstack_networking_secgroup_v2" "secgroup_2" {
+  name        = "secgroup_stateful_1"
+  description = "My neutron security group"
+  stateful    = false
+}
+
+data "openstack_networking_secgroup_v2" "secgroup_1" {
+  name     = "${openstack_networking_secgroup_v2.secgroup_2.name}"
+  description = "${openstack_networking_secgroup_v2.secgroup_1.description}"
+  stateful = false
+}
+`

--- a/openstack/resource_openstack_networking_secgroup_v2_test.go
+++ b/openstack/resource_openstack_networking_secgroup_v2_test.go
@@ -26,6 +26,7 @@ func TestAccNetworkingV2SecGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2SecGroupExists("openstack_networking_secgroup_v2.secgroup_1", &securityGroup),
 					testAccCheckNetworkingV2SecGroupRuleCount(&securityGroup, 2),
+					resource.TestCheckResourceAttr("openstack_networking_secgroup_v2.secgroup_1", "stateful", "true"),
 				),
 			},
 			{
@@ -33,6 +34,7 @@ func TestAccNetworkingV2SecGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPtr("openstack_networking_secgroup_v2.secgroup_1", "id", &securityGroup.ID),
 					resource.TestCheckResourceAttr("openstack_networking_secgroup_v2.secgroup_1", "name", "security_group_2"),
+					resource.TestCheckResourceAttr("openstack_networking_secgroup_v2.secgroup_1", "stateful", "false"),
 				),
 			},
 		},
@@ -62,13 +64,91 @@ func TestAccNetworkingV2SecGroup_noDefaultRules(t *testing.T) {
 	})
 }
 
+func TestAccNetworkingV2SecGroup_statefulNotSet(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckNetworkingV2SecGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2SecGroupStatefulNotSet,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("openstack_networking_secgroup_v2.secgroup_1", "name", "security_group_1"),
+					resource.TestCheckResourceAttr("openstack_networking_secgroup_v2.secgroup_1", "stateful", "true"),
+				),
+			},
+			{
+				Config: testAccNetworkingV2SecGroupStatefulNotSetUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("openstack_networking_secgroup_v2.secgroup_1", "name", "security_group_1"),
+					resource.TestCheckResourceAttr("openstack_networking_secgroup_v2.secgroup_1", "stateful", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2SecGroup_statefulSetTrue(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckNonAdminOnly(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckNetworkingV2SecGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2SecGroupStatefulSetTrue,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("openstack_networking_secgroup_v2.secgroup_1", "name", "security_group_1"),
+					resource.TestCheckResourceAttr("openstack_networking_secgroup_v2.secgroup_1", "stateful", "true"),
+				),
+			},
+			{
+				Config: testAccNetworkingV2SecGroupStatefulSetTrueUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("openstack_networking_secgroup_v2.secgroup_1", "name", "security_group_1"),
+					resource.TestCheckResourceAttr("openstack_networking_secgroup_v2.secgroup_1", "stateful", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2SecGroup_statefulSetFalse(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckNetworkingV2SecGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2SecGroupStatefulSetFalse,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("openstack_networking_secgroup_v2.secgroup_1", "name", "security_group_1"),
+					resource.TestCheckResourceAttr("openstack_networking_secgroup_v2.secgroup_1", "stateful", "false"),
+				),
+			},
+			{
+				Config: testAccNetworkingV2SecGroupStatefulSetFalseUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("openstack_networking_secgroup_v2.secgroup_1", "name", "security_group_1"),
+					resource.TestCheckResourceAttr("openstack_networking_secgroup_v2.secgroup_1", "stateful", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNetworkingV2SecGroup_timeout(t *testing.T) {
 	var securityGroup groups.SecGroup
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckNonAdminOnly(t)
 		},
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckNetworkingV2SecGroupDestroy,
@@ -159,6 +239,7 @@ const testAccNetworkingV2SecGroupUpdate = `
 resource "openstack_networking_secgroup_v2" "secgroup_1" {
   name = "security_group_2"
   description = "terraform security group acceptance test"
+  stateful    = false
 }
 `
 
@@ -178,5 +259,52 @@ resource "openstack_networking_secgroup_v2" "secgroup_1" {
   timeouts {
     delete = "5m"
   }
+}
+`
+
+const testAccNetworkingV2SecGroupStatefulNotSet = `
+resource "openstack_networking_secgroup_v2" "secgroup_1" {
+  name = "security_group_1"
+  description = "stateful flag not set, expect true"
+}
+`
+
+const testAccNetworkingV2SecGroupStatefulNotSetUpdate = `
+resource "openstack_networking_secgroup_v2" "secgroup_1" {
+  name = "security_group_1"
+  description = "stateful flag updated to false"
+  stateful = false
+}
+`
+
+const testAccNetworkingV2SecGroupStatefulSetTrue = `
+resource "openstack_networking_secgroup_v2" "secgroup_1" {
+  name = "security_group_1"
+  description = "stateful flag set to true"
+  stateful = true
+}
+`
+
+const testAccNetworkingV2SecGroupStatefulSetTrueUpdate = `
+resource "openstack_networking_secgroup_v2" "secgroup_1" {
+  name = "security_group_1"
+  description = "stateful flag updated to false"
+  stateful = false
+}
+`
+
+const testAccNetworkingV2SecGroupStatefulSetFalse = `
+resource "openstack_networking_secgroup_v2" "secgroup_1" {
+  name = "security_group_1"
+  description = "stateful flag explicitly set to false"
+  stateful = false
+}
+`
+
+const testAccNetworkingV2SecGroupStatefulSetFalseUpdate = `
+resource "openstack_networking_secgroup_v2" "secgroup_1" {
+  name = "security_group_1"
+  description = "stateful flag updated to true"
+  stateful = true
 }
 `


### PR DESCRIPTION
Resolves #1735 
Depends on #1759

@nikParasyr this is a good example of why we need to use `GetOkExists`. If you use just `GetOk`, then tests will fail for both resources and data sources.

ref #1188 