### PR TITLE
[bgpvpn]: use getOkExists helper to detect bool arguments

### DIFF
--- a/.github/workflows/functional-bgpvpn.yml
+++ b/.github/workflows/functional-bgpvpn.yml
@@ -35,15 +35,64 @@ jobs:
     steps:
       - name: Checkout TPO
         uses: actions/checkout@v4
+      - name: Create additional neutron policies
+        run: |
+          mkdir /tmp/neutron-policies
+          cat << EOF >> /tmp/neutron-policies/bgpvpn.yaml
+          ---
+          "create_bgpvpn": "rule:admin_or_owner"
+          "update_bgpvpn": "rule:admin_or_owner"
+          "delete_bgpvpn": "rule:admin_or_owner"
+          "get_bgpvpn": "rule:admin_or_owner"
+          "get_bgpvpn:tenant_id": "rule:admin_or_owner"
+          "get_bgpvpn:route_targets": "rule:admin_or_owner"
+          "get_bgpvpn:import_targets": "rule:admin_or_owner"
+          "get_bgpvpn:export_targets": "rule:admin_or_owner"
+          "get_bgpvpn:route_distinguishers": "rule:admin_or_owner"
+          "get_bgpvpn:vni": "rule:admin_or_owner"
+          "create_bgpvpn:tenant_id": "rule:admin_or_owner"
+          "create_bgpvpn:route_targets": "rule:admin_or_owner"
+          "create_bgpvpn:name": "rule:admin_or_owner"
+          "create_bgpvpn:import_targets": "rule:admin_or_owner"
+          "create_bgpvpn:export_targets": "rule:admin_or_owner"
+          "create_bgpvpn:route_distinguishers": "rule:admin_or_owner"
+          "create_bgpvpn:type": "rule:admin_or_owner"
+          "create_bgpvpn:local_pref": "rule:admin_or_owner"
+          "create_bgpvpn:vni": "rule:admin_or_owner"
+          "update_bgpvpn:tenant_id": "rule:admin_or_owner"
+          "update_bgpvpn:route_targets": "rule:admin_or_owner"
+          "update_bgpvpn:import_targets": "rule:admin_or_owner"
+          "update_bgpvpn:export_targets": "rule:admin_or_owner"
+          "update_bgpvpn:route_distinguishers": "rule:admin_or_owner"
+          "update_bgpvpn:vni": "rule:admin_or_owner"
+          "create_bgpvpn_network_association": "rule:admin_or_owner"
+          "update_bgpvpn_network_association": "rule:admin_or_owner"
+          "delete_bgpvpn_network_association": "rule:admin_or_owner"
+          "get_bgpvpn_network_association": "rule:admin_or_owner"
+          "get_bgpvpn_network_association:tenant_id": "rule:admin_or_owner"
+          "create_bgpvpn_port_association": "rule:admin_or_owner"
+          "update_bgpvpn_port_association": "rule:admin_or_owner"
+          "delete_bgpvpn_port_association": "rule:admin_or_owner"
+          "get_bgpvpn_port_association": "rule:admin_or_owner"
+          "get_bgpvpn_port_association:tenant_id": "rule:admin_or_owner"
+          "create_bgpvpn_router_association": "rule:admin_or_owner"
+          "update_bgpvpn_router_association": "rule:admin_or_owner"
+          "delete_bgpvpn_router_association": "rule:admin_or_owner"
+          "get_bgpvpn_router_association": "rule:admin_or_owner"
+          "get_bgpvpn_router_association:tenant_id": "rule:admin_or_owner"
+          EOF
       - name: Deploy devstack
         uses: EmilienM/devstack-action@v0.15
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
             Q_ML2_PLUGIN_EXT_DRIVERS=qos,port_security,dns_domain_keywords
-              enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing ${{ matrix.openstack_version }}
-              enable_plugin networking-bgpvpn https://github.com/openstack/networking-bgpvpn.git ${{ matrix.openstack_version }}
-            ${{ matrix.devstack_conf_overrides }}
+            enable_plugin neutron-dynamic-routing https://github.com/openstack/neutron-dynamic-routing ${{ matrix.openstack_version }}
+            enable_plugin networking-bgpvpn https://github.com/openstack/networking-bgpvpn.git ${{ matrix.openstack_version }}
+
+            [[post-config|\$NEUTRON_CONF]]
+            [oslo_policy]
+            policy_dirs = /tmp/neutron-policies
           enabled_services: 'neutron-dns,neutron-qos,neutron-segments,neutron-trunk,neutron-uplink-status-propagation,neutron-network-segment-range,neutron-port-forwarding'
       - name: Checkout go
         uses: actions/setup-go@v5

--- a/openstack/resource_openstack_bgpvpn_network_associate_v2_test.go
+++ b/openstack/resource_openstack_bgpvpn_network_associate_v2_test.go
@@ -16,6 +16,7 @@ func TestAccBGPVPNNetworkAssociateV2_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckNonAdminOnly(t)
 			testAccPreCheckBGPVPN(t)
 		},
 		ProviderFactories: testAccProviders,

--- a/openstack/resource_openstack_bgpvpn_network_associate_v2_test.go
+++ b/openstack/resource_openstack_bgpvpn_network_associate_v2_test.go
@@ -16,7 +16,6 @@ func TestAccBGPVPNNetworkAssociateV2_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckAdminOnly(t)
 			testAccPreCheckBGPVPN(t)
 		},
 		ProviderFactories: testAccProviders,

--- a/openstack/resource_openstack_bgpvpn_port_associate_v2.go
+++ b/openstack/resource_openstack_bgpvpn_port_associate_v2.go
@@ -48,7 +48,7 @@ func resourceBGPVPNPortAssociateV2() *schema.Resource {
 			"advertise_fixed_ips": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+				Computed: true,
 			},
 			"routes": {
 				Type:     schema.TypeSet,
@@ -98,7 +98,7 @@ func resourceBGPVPNPortAssociateV2Create(ctx context.Context, d *schema.Resource
 		ProjectID: d.Get("project_id").(string),
 		Routes:    expandBGPVPNPortAssociateRoutesV2(routes),
 	}
-	if v, ok := d.GetOk("advertise_fixed_ips"); ok {
+	if v, ok := getOkExists(d, "advertise_fixed_ips"); ok {
 		v := v.(bool)
 		opts.AdvertiseFixedIPs = &v
 	}

--- a/openstack/resource_openstack_bgpvpn_port_associate_v2_test.go
+++ b/openstack/resource_openstack_bgpvpn_port_associate_v2_test.go
@@ -16,7 +16,6 @@ func TestAccBGPVPNPortAssociateV2_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckAdminOnly(t)
 			testAccPreCheckBGPVPN(t)
 		},
 		ProviderFactories: testAccProviders,
@@ -31,6 +30,29 @@ func TestAccBGPVPNPortAssociateV2_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("openstack_bgpvpn_port_associate_v2.association_1", "advertise_fixed_ips", "true"),
 				),
 			},
+			{
+				Config: testAccBGPVPNPortAssociateV2ConfigUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBGPVPNPortAssociateV2Exists(
+						"openstack_bgpvpn_port_associate_v2.association_1", &pa),
+					resource.TestCheckResourceAttrPtr("openstack_bgpvpn_port_associate_v2.association_1", "port_id", &pa.PortID),
+					resource.TestCheckResourceAttr("openstack_bgpvpn_port_associate_v2.association_1", "advertise_fixed_ips", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBGPVPNPortAssociateV2_no_fixed_ips_advertise(t *testing.T) {
+	var pa bgpvpns.PortAssociation
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckBGPVPN(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckBGPVPNPortAssociateV2Destroy,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccBGPVPNPortAssociateV2ConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(

--- a/openstack/resource_openstack_bgpvpn_port_associate_v2_test.go
+++ b/openstack/resource_openstack_bgpvpn_port_associate_v2_test.go
@@ -16,6 +16,7 @@ func TestAccBGPVPNPortAssociateV2_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckNonAdminOnly(t)
 			testAccPreCheckBGPVPN(t)
 		},
 		ProviderFactories: testAccProviders,
@@ -48,6 +49,7 @@ func TestAccBGPVPNPortAssociateV2_no_fixed_ips_advertise(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckNonAdminOnly(t)
 			testAccPreCheckBGPVPN(t)
 		},
 		ProviderFactories: testAccProviders,

--- a/openstack/resource_openstack_bgpvpn_router_associate_v2.go
+++ b/openstack/resource_openstack_bgpvpn_router_associate_v2.go
@@ -47,7 +47,7 @@ func resourceBGPVPNRouterAssociateV2() *schema.Resource {
 			"advertise_extra_routes": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+				Computed: true,
 			},
 		},
 	}
@@ -66,7 +66,7 @@ func resourceBGPVPNRouterAssociateV2Create(ctx context.Context, d *schema.Resour
 		RouterID:  routerID,
 		ProjectID: d.Get("project_id").(string),
 	}
-	if v, ok := d.GetOk("advertise_extra_routes"); ok {
+	if v, ok := getOkExists(d, "advertise_extra_routes"); ok {
 		v := v.(bool)
 		opts.AdvertiseExtraRoutes = &v
 	}

--- a/openstack/resource_openstack_bgpvpn_router_associate_v2_test.go
+++ b/openstack/resource_openstack_bgpvpn_router_associate_v2_test.go
@@ -16,7 +16,6 @@ func TestAccBGPVPNRouterAssociateV2_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckAdminOnly(t)
 			testAccPreCheckBGPVPN(t)
 		},
 		ProviderFactories: testAccProviders,
@@ -31,6 +30,30 @@ func TestAccBGPVPNRouterAssociateV2_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("openstack_bgpvpn_router_associate_v2.association_1", "advertise_extra_routes", "true"),
 				),
 			},
+			{
+				Config: testAccBGPVPNRouterAssociateV2ConfigUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBGPVPNRouterAssociateV2Exists(
+						"openstack_bgpvpn_router_associate_v2.association_1", &ra),
+					resource.TestCheckResourceAttrPtr("openstack_bgpvpn_router_associate_v2.association_1", "router_id", &ra.RouterID),
+					resource.TestCheckResourceAttr("openstack_bgpvpn_router_associate_v2.association_1", "advertise_extra_routes", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBGPVPNRouterAssociateV2_no_routes_advertise(t *testing.T) {
+	var ra bgpvpns.RouterAssociation
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckBGPVPN(t)
+			t.Skip(`bug in OpenStack which ignores {"advertise_extra_routes": false} on POST request, while handles on PUT request.`)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckBGPVPNRouterAssociateV2Destroy,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccBGPVPNRouterAssociateV2ConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(

--- a/openstack/resource_openstack_bgpvpn_router_associate_v2_test.go
+++ b/openstack/resource_openstack_bgpvpn_router_associate_v2_test.go
@@ -16,6 +16,7 @@ func TestAccBGPVPNRouterAssociateV2_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckNonAdminOnly(t)
 			testAccPreCheckBGPVPN(t)
 		},
 		ProviderFactories: testAccProviders,
@@ -48,6 +49,7 @@ func TestAccBGPVPNRouterAssociateV2_no_routes_advertise(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckNonAdminOnly(t)
 			testAccPreCheckBGPVPN(t)
 			t.Skip(`bug in OpenStack which ignores {"advertise_extra_routes": false} on POST request, while handles on PUT request.`)
 		},

--- a/openstack/resource_openstack_bgpvpn_v2_test.go
+++ b/openstack/resource_openstack_bgpvpn_v2_test.go
@@ -16,6 +16,7 @@ func TestAccBGPVPNV2_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckNonAdminOnly(t)
 			testAccPreCheckBGPVPN(t)
 		},
 		ProviderFactories: testAccProviders,

--- a/openstack/resource_openstack_bgpvpn_v2_test.go
+++ b/openstack/resource_openstack_bgpvpn_v2_test.go
@@ -16,7 +16,6 @@ func TestAccBGPVPNV2_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckAdminOnly(t)
 			testAccPreCheckBGPVPN(t)
 		},
 		ProviderFactories: testAccProviders,


### PR DESCRIPTION
Without the `GetOkExists` port or router associations cannot be created without the advertisements.

Depends on #1759

ref #1188

https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1738#discussion_r1683010644
https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1738#discussion_r1683026442