### PR TITLE
[core]: add provider version to user-agent

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+      - '-s -w -X github.com/terraform-provider-openstack/terraform-provider-openstack/v2/openstack.version={{.Version}}'
     goos:
       - freebsd
       - windows

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -14,6 +14,8 @@ import (
 	"github.com/gophercloud/utils/terraform/mutexkv"
 )
 
+var version = "dev"
+
 // Use openstackbase.Config as the base/foundation of this provider's
 // Config struct.
 type Config struct {
@@ -580,7 +582,7 @@ func configureProvider(d *schema.ResourceData, terraformVersion string) (interfa
 			MaxRetries:                  d.Get("max_retries").(int),
 			DisableNoCacheHeader:        d.Get("disable_no_cache_header").(bool),
 			TerraformVersion:            terraformVersion,
-			SDKVersion:                  getSDKVersion(),
+			SDKVersion:                  getSDKVersion() + " Terraform Provider OpenStack/" + version,
 			MutexKV:                     mutexkv.NewMutexKV(),
 			EnableLogger:                enableLogging,
 		},


### PR DESCRIPTION
Resolves #604
Depends on #1759 

This change will build a user-agent header like:

`
User-Agent: HashiCorp Terraform/1.4.4 (+https://www.terraform.io) Terraform Plugin SDK/2.30.0 Terraform Provider OpenStack/2.0.0 gophercloud/v1.13.0
`