### PR TITLE
feat: add alias any protocol to sec group rules

### DIFF
--- a/docs/resources/networking_secgroup_rule_v2.md
+++ b/docs/resources/networking_secgroup_rule_v2.md
@@ -74,6 +74,7 @@ The following arguments are supported:
   * __sctp__
   * __udplite__
   * __vrrp__
+  * __any__
 
 * `port_range_min` - (Optional) The lower part of the allowed port range, valid
     integer value needs to be between 1 and 65535. Changing this creates a new

--- a/openstack/networking_secgroup_rule_v2.go
+++ b/openstack/networking_secgroup_rule_v2.go
@@ -91,6 +91,8 @@ func resourceNetworkingSecGroupRuleV2Protocol(protocol string) (rules.RuleProtoc
 		return rules.ProtocolUDPLite, nil
 	case string(rules.ProtocolVRRP):
 		return rules.ProtocolVRRP, nil
+	case string(rules.ProtocolAny):
+		return rules.ProtocolAny, nil
 	}
 
 	// If the protocol wasn't matched above, see if it's an integer.

--- a/openstack/networking_secgroup_rule_v2_test.go
+++ b/openstack/networking_secgroup_rule_v2_test.go
@@ -81,6 +81,7 @@ func TestUnitResourceNetworkingSecGroupRuleV2ProtocolString(t *testing.T) {
 		string(rules.ProtocolUDP):       rules.ProtocolUDP,
 		string(rules.ProtocolUDPLite):   rules.ProtocolUDPLite,
 		string(rules.ProtocolVRRP):      rules.ProtocolVRRP,
+		string(rules.ProtocolAny):       rules.ProtocolAny,
 	}
 
 	for name, expected := range protocols {

--- a/openstack/resource_openstack_networking_secgroup_rule_v2_test.go
+++ b/openstack/resource_openstack_networking_secgroup_rule_v2_test.go
@@ -118,6 +118,7 @@ func TestAccNetworkingV2SecGroupRule_protocols(t *testing.T) {
 	var secgroupRuleSctp rules.SecGroupRule
 	var secgroupRuleUdplite rules.SecGroupRule
 	var secgroupRuleVrrp rules.SecGroupRule
+	var secgroupRuleAny rules.SecGroupRule
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -168,6 +169,8 @@ func TestAccNetworkingV2SecGroupRule_protocols(t *testing.T) {
 						"openstack_networking_secgroup_rule_v2.secgroup_rule_udplite", &secgroupRuleUdplite),
 					testAccCheckNetworkingV2SecGroupRuleExists(
 						"openstack_networking_secgroup_rule_v2.secgroup_rule_vrrp", &secgroupRuleVrrp),
+					testAccCheckNetworkingV2SecGroupRuleExists(
+						"openstack_networking_secgroup_rule_v2.secgroup_rule_any", &secgroupRuleAny),
 					resource.TestCheckResourceAttr(
 						"openstack_networking_secgroup_rule_v2.secgroup_rule_ah", "protocol", "ah"),
 					resource.TestCheckResourceAttr(
@@ -204,6 +207,8 @@ func TestAccNetworkingV2SecGroupRule_protocols(t *testing.T) {
 						"openstack_networking_secgroup_rule_v2.secgroup_rule_udplite", "protocol", "udplite"),
 					resource.TestCheckResourceAttr(
 						"openstack_networking_secgroup_rule_v2.secgroup_rule_vrrp", "protocol", "vrrp"),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_secgroup_rule_v2.secgroup_rule_any", "protocol", "any"),
 				),
 			},
 		},
@@ -526,6 +531,13 @@ resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_vrrp" {
   direction = "ingress"
   ethertype = "IPv4"
   protocol = "vrrp"
+  remote_ip_prefix = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.secgroup_1.id}"
+}
+resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_any" {
+  direction = "ingress"
+  ethertype = "IPv4"
+  protocol = "any"
   remote_ip_prefix = "0.0.0.0/0"
   security_group_id = "${openstack_networking_secgroup_v2.secgroup_1.id}"
 }


### PR DESCRIPTION
Fix option "Any" in security group rules, according the [documentaion](https://docs.openstack.org/python-openstackclient/latest/cli/command-objects/security-group-rule.html#cmdoption-openstack-security-group-rule-create-protocol):

Network version 2:
IP protocol (ah, dccp, egp, esp, gre, icmp, igmp, ipv6-encap, ipv6-frag, ipv6-icmp, ipv6-nonxt, ipv6-opts, ipv6-route, ospf, pgm, rsvp, sctp, tcp, udp, udplite, vrrp and integer representations [0-255] or any; default: any (all protocols))
Need 2 update https://github.com/gophercloud/gophercloud/pull/3157 be4 test will pass

Instead of [PR](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1342)