### PR TITLE
Fix getting value for floating_ip_enabled from resource_openstack_containerinfra_cluster_v1

### DIFF
--- a/openstack/data_source_openstack_containerinfra_cluster_v1_test.go
+++ b/openstack/data_source_openstack_containerinfra_cluster_v1_test.go
@@ -15,6 +15,8 @@ func TestAccContainerInfraV1ClusterDataSource_basic(t *testing.T) {
 	clusterName := acctest.RandomWithPrefix("tf-acc-cluster")
 	keypairName := acctest.RandomWithPrefix("tf-acc-keypair")
 	clusterTemplateName := acctest.RandomWithPrefix("tf-acc-clustertemplate")
+	floatingIPEnabledClusterTemplate := "true"
+	floatingIPEnabledCluster := "null"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -25,11 +27,11 @@ func TestAccContainerInfraV1ClusterDataSource_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckContainerInfraV1ClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerInfraV1ClusterBasic(keypairName, clusterTemplateName, clusterName, 1),
+				Config: testAccContainerInfraV1ClusterBasic(keypairName, clusterTemplateName, clusterName, floatingIPEnabledClusterTemplate, floatingIPEnabledCluster, 1),
 			},
 			{
 				Config: testAccContainerInfraV1ClusterDataSourceBasic(
-					testAccContainerInfraV1ClusterBasic(keypairName, clusterTemplateName, clusterName, 1),
+					testAccContainerInfraV1ClusterBasic(keypairName, clusterTemplateName, clusterName, floatingIPEnabledClusterTemplate, floatingIPEnabledCluster, 1),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerInfraV1ClusterDataSourceID(resourceName),
@@ -55,7 +57,7 @@ func TestAccContainerInfraV1ClusterDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "master_addresses.#", strconv.Itoa(1)),
 					resource.TestCheckResourceAttr(resourceName, "node_addresses.#", strconv.Itoa(1)),
 					resource.TestCheckResourceAttrSet(resourceName, "stack_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "floating_ip_enabled"),
+					resource.TestCheckResourceAttr(resourceName, "floating_ip_enabled", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "kubeconfig"),
 				),
 			},

--- a/openstack/import_openstack_containerinfra_cluster_v1_test.go
+++ b/openstack/import_openstack_containerinfra_cluster_v1_test.go
@@ -12,6 +12,8 @@ func TestAccContainerInfraV1ClusterImport_basic(t *testing.T) {
 	clusterName := acctest.RandomWithPrefix("tf-acc-cluster")
 	keypairName := acctest.RandomWithPrefix("tf-acc-keypair")
 	clusterTemplateName := acctest.RandomWithPrefix("tf-acc-clustertemplate")
+	floatingIPEnabledClusterTemplate := "true"
+	floatingIPEnabledCluster := "null"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -23,7 +25,7 @@ func TestAccContainerInfraV1ClusterImport_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckContainerInfraV1ClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerInfraV1ClusterBasic(keypairName, clusterTemplateName, clusterName, 1),
+				Config: testAccContainerInfraV1ClusterBasic(keypairName, clusterTemplateName, clusterName, floatingIPEnabledClusterTemplate, floatingIPEnabledCluster, 1),
 			},
 			{
 				ResourceName:            resourceName,

--- a/openstack/resource_openstack_containerinfra_cluster_v1.go
+++ b/openstack/resource_openstack_containerinfra_cluster_v1.go
@@ -243,9 +243,6 @@ func resourceContainerInfraClusterV1Create(ctx context.Context, d *schema.Resour
 		return diag.Errorf("Unable to determine openstack_containerinfra_cluster_v1 master_flavor")
 	}
 
-	// Get boolean parameters that will be passed by reference.
-	floatingIPEnabled := d.Get("floating_ip_enabled").(bool)
-
 	createOpts := clusters.CreateOpts{
 		ClusterTemplateID: d.Get("cluster_template_id").(string),
 		DiscoveryURL:      d.Get("discovery_url").(string),
@@ -256,7 +253,13 @@ func resourceContainerInfraClusterV1Create(ctx context.Context, d *schema.Resour
 		Name:              d.Get("name").(string),
 		FixedNetwork:      d.Get("fixed_network").(string),
 		FixedSubnet:       d.Get("fixed_subnet").(string),
-		FloatingIPEnabled: &floatingIPEnabled,
+	}
+
+	// Get boolean value if parameter was provided
+	if v, ok := getOkExists(d, "floating_ip_enabled"); ok {
+		if v, ok := v.(bool); ok {
+			createOpts.FloatingIPEnabled = &v
+		}
 	}
 
 	// Set int parameters that will be passed by reference.

--- a/openstack/resource_openstack_containerinfra_cluster_v1_test.go
+++ b/openstack/resource_openstack_containerinfra_cluster_v1_test.go
@@ -19,6 +19,8 @@ func TestAccContainerInfraV1Cluster_basic(t *testing.T) {
 	clusterName := acctest.RandomWithPrefix("tf-acc-cluster")
 	keypairName := acctest.RandomWithPrefix("tf-acc-keypair")
 	clusterTemplateName := acctest.RandomWithPrefix("tf-acc-clustertemplate")
+	floatingIPEnabledClusterTemplate := "true"
+	floatingIPEnabledCluster := "null"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -30,7 +32,7 @@ func TestAccContainerInfraV1Cluster_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckContainerInfraV1ClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerInfraV1ClusterBasic(keypairName, clusterTemplateName, clusterName, 1),
+				Config: testAccContainerInfraV1ClusterBasic(keypairName, clusterTemplateName, clusterName, floatingIPEnabledClusterTemplate, floatingIPEnabledCluster, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerInfraV1ClusterExists(resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, "region", osRegionName),
@@ -64,7 +66,7 @@ func TestAccContainerInfraV1Cluster_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccContainerInfraV1ClusterBasic(keypairName, clusterTemplateName, clusterName, 2),
+				Config: testAccContainerInfraV1ClusterBasic(keypairName, clusterTemplateName, clusterName, floatingIPEnabledClusterTemplate, floatingIPEnabledCluster, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContainerInfraV1ClusterExists(resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, "region", osRegionName),
@@ -336,7 +338,7 @@ func testAccCheckContainerInfraV1ClusterDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccContainerInfraV1ClusterBasic(keypairName, clusterTemplateName, clusterName string, nodeCount int) string {
+func testAccContainerInfraV1ClusterBasic(keypairName, clusterTemplateName, clusterName, floatingIPEnabledClusterTemplate, floatingIPEnabledCluster string, nodeCount int) string {
 	return fmt.Sprintf(`
 resource "openstack_compute_keypair_v2" "keypair_1" {
   name = "%s"
@@ -346,7 +348,7 @@ resource "openstack_containerinfra_clustertemplate_v1" "clustertemplate_1" {
   name                  = "%s"
   image                 = "%s"
   coe                   = "kubernetes"
-  floating_ip_enabled   = false
+  floating_ip_enabled   = %s
   volume_driver         = "cinder"
   docker_storage_driver = "overlay2"
   docker_volume_size    = 5
@@ -373,9 +375,9 @@ resource "openstack_containerinfra_cluster_v1" "cluster_1" {
   keypair              = "${openstack_compute_keypair_v2.keypair_1.name}"
   master_count         = 1
   node_count           = %d
-  floating_ip_enabled  = true
+  floating_ip_enabled  = %s
 }
-`, keypairName, clusterTemplateName, osMagnumImage, osExtGwID, osMagnumHTTPProxy, osMagnumHTTPSProxy, osMagnumNoProxy, osMagnumLabels, osRegionName, clusterName, osMagnumFlavor, osMagnumFlavor, nodeCount)
+`, keypairName, clusterTemplateName, osMagnumImage, floatingIPEnabledClusterTemplate, osExtGwID, osMagnumHTTPProxy, osMagnumHTTPSProxy, osMagnumNoProxy, osMagnumLabels, osRegionName, clusterName, osMagnumFlavor, osMagnumFlavor, nodeCount, floatingIPEnabledCluster)
 }
 
 func testAccContainerInfraV1ClusterLabels(keypairName, clusterTemplateName, clusterName string, nodeCount int, mergeLabels bool) string {


### PR DESCRIPTION
This PR fixes error with getting `floating_ip_enabled` value from `resource_openstack_containerinfra_cluster_v1`.

Fixes #1731