### PR TITLE
Add extra attribute to identity_project_v3

### DIFF
--- a/docs/resources/identity_project_v3.md
+++ b/docs/resources/identity_project_v3.md
@@ -50,6 +50,8 @@ The following arguments are supported:
 * `tags` - (Optional) Tags for the project. Changing this updates the existing
     project.
 
+* `extra` - (Optional) Free-form key/value pairs of extra information.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -61,6 +63,7 @@ The following attributes are exported:
 * `name` - See Argument Reference above.
 * `parent_id` - See Argument Reference above.
 * `tags` - See Argument Reference above.
+* `extra` - See Argument Reference above.
 * `region` - See Argument Reference above.
 
 ## Import

--- a/openstack/resource_openstack_identity_project_v3.go
+++ b/openstack/resource_openstack_identity_project_v3.go
@@ -71,6 +71,11 @@ func resourceIdentityProjectV3() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
+
+			"extra": {
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -90,6 +95,7 @@ func resourceIdentityProjectV3Create(ctx context.Context, d *schema.ResourceData
 		Enabled:     &enabled,
 		IsDomain:    &isDomain,
 		Name:        d.Get("name").(string),
+		Extra:       d.Get("extra").(map[string]interface{}),
 		ParentID:    d.Get("parent_id").(string),
 	}
 
@@ -128,6 +134,7 @@ func resourceIdentityProjectV3Read(ctx context.Context, d *schema.ResourceData, 
 	d.Set("enabled", project.Enabled)
 	d.Set("is_domain", project.IsDomain)
 	d.Set("name", project.Name)
+	d.Set("extra", project.Extra)
 	d.Set("parent_id", project.ParentID)
 	d.Set("region", GetRegion(d, config))
 	d.Set("tags", project.Tags)
@@ -176,6 +183,11 @@ func resourceIdentityProjectV3Update(ctx context.Context, d *schema.ResourceData
 		hasChange = true
 		description := d.Get("description").(string)
 		updateOpts.Description = &description
+	}
+
+	if d.HasChange("extra") {
+		hasChange = true
+		updateOpts.Extra = d.Get("extra").(map[string]interface{})
 	}
 
 	if d.HasChange("tags") {

--- a/openstack/resource_openstack_identity_project_v3_test.go
+++ b/openstack/resource_openstack_identity_project_v3_test.go
@@ -37,6 +37,8 @@ func TestAccIdentityV3Project_basic(t *testing.T) {
 						"openstack_identity_project_v3.project_1", "enabled", "true"),
 					resource.TestCheckResourceAttr(
 						"openstack_identity_project_v3.project_1", "is_domain", "false"),
+					resource.TestCheckResourceAttr(
+						"openstack_identity_project_v3.project_1", "extra.foo", "foo"),
 				),
 			},
 			{
@@ -53,6 +55,8 @@ func TestAccIdentityV3Project_basic(t *testing.T) {
 						"openstack_identity_project_v3.project_1", "enabled", "false"),
 					resource.TestCheckResourceAttr(
 						"openstack_identity_project_v3.project_1", "is_domain", "false"),
+					resource.TestCheckResourceAttr(
+						"openstack_identity_project_v3.project_1", "extra.foo", "bar"),
 					testAccCheckIdentityV3ProjectHasTag("openstack_identity_project_v3.project_1", "tag1"),
 					testAccCheckIdentityV3ProjectHasTag("openstack_identity_project_v3.project_1", "tag2"),
 					testAccCheckIdentityV3ProjectTagCount("openstack_identity_project_v3.project_1", 2),
@@ -190,6 +194,9 @@ func testAccIdentityV3ProjectBasic(projectName string) string {
     resource "openstack_identity_project_v3" "project_1" {
       name = "%s"
       description = "A project"
+	  extra = {
+		foo = "foo"
+	  }
     }
   `, projectName)
 }
@@ -200,6 +207,9 @@ func testAccIdentityV3ProjectUpdate(projectName string) string {
       name = "%s"
       description = "Some project"
 	  enabled = false
+	  extra = {
+		foo = "bar"
+	  }
 	  tags = ["tag1","tag2"]
     }
   `, projectName)


### PR DESCRIPTION
Update identity_project_v3 resource to support the extra attribute for free-form key/value pairs of
extra information.

Partially implements: https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1702
(options still missing but should be added in separate MR)