### PR TITLE
Add support for JSON orchestration parameters

### DIFF
--- a/openstack/resource_openstack_orchestration_stack_v1.go
+++ b/openstack/resource_openstack_orchestration_stack_v1.go
@@ -60,6 +60,9 @@ func resourceOrchestrationStackV1() *schema.Resource {
 			"parameters": {
 				Type:     schema.TypeMap,
 				Optional: true,
+				Computed: true,
+				DiffSuppressOnRefresh: true,
+				DiffSuppressFunc: suppressEquivalentNestedParametersDiff,
 			},
 
 			"timeout": {
@@ -403,3 +406,4 @@ func resourceOrchestrationStackV1Delete(ctx context.Context, d *schema.ResourceD
 	log.Printf("[INFO] openstack_orchestration_stack_v1 %s delete complete", d.Id())
 	return nil
 }
+


### PR DESCRIPTION
Fix #1772

Add a DiffSuppressFunc to compare orchestration parameters passed to OpenStack as `jsonencode()`’d values, instead of doing a direct string compare that fails due to OpenStack emitting JSON that is not minified in the same way as Terraform.

This is an initial pass at a fix, and passes my simple manual testing, but does not have implemented unit tests.