### PR TITLE
Fix syntax for importing dns_zone with project_id

### DIFF
--- a/docs/resources/dns_zone_v2.md
+++ b/docs/resources/dns_zone_v2.md
@@ -84,5 +84,5 @@ This resource can be imported by specifying the zone ID with optional project ID
 
 ```
 $ terraform import openstack_dns_zone_v2.zone_1 zone_id
-$ terraform import openstack_dns_zone_v2.zone_1 zone_id/project_id
+$ terraform import openstack_dns_zone_v2.zone_1 zone_id:project_id
 ```


### PR DESCRIPTION
Importing a dns_zone_v2 resource with a project_id requires using ":" as a separator. The docs refactor in e1a17df3c9eccc8bde0cefc378f5d9de72cf61df mistakenly replaced the ":" with a "/". This commit reverts that mistake.