### PR TITLE
add openstack_identity_project_ids_v3 datasource

### DIFF
--- a/docs/data-sources/identity_project_ids_v3.md
+++ b/docs/data-sources/identity_project_ids_v3.md
@@ -12,6 +12,9 @@ description: |-
 Use this data source to get a list of OpenStack Project IDs matching the
 specified criteria.
 
+~> **Note:** You _must_ have domain admin or cloud admin privileges in your OpenStack cloud to use
+this datasource.
+
 ## Example Usage
 
 ```hcl

--- a/docs/data-sources/identity_project_ids_v3.md
+++ b/docs/data-sources/identity_project_ids_v3.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Identity / Keystone"
+layout: "openstack"
+page_title: "OpenStack: openstack_identity_project_ids_v3"
+sidebar_current: "docs-openstack-datasource-identity-project-ids-v3"
+description: |-
+  Provides a list of OpenStack Project IDs.
+---
+
+# openstack\_identity\_project\_ids\_v3
+
+Use this data source to get a list of OpenStack Project IDs matching the
+specified criteria.
+
+## Example Usage
+
+```hcl
+data "openstack_identity_project_ids_v3" "projects" {
+  name_regex = "^prod.*"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional) The name of the project. Cannot be used simultaneously with
+  `name_regex`.
+
+* `name_regex` - (Optional) The regular expression of the name of the project.
+  Cannot be used simultaneously with `name`. Unlike filtering by `name` the
+  `name_regex` filtering does by client on the result of OpenStack search
+  query.
+
+* `domain_id` - (Optional) The domain projects belongs to.
+
+* `enabled` - (Optional) Whether the project is enabled or disabled. Valid
+  values are `true` and `false`. Default is `true`.
+
+* `name` - (Optional) The name of the project.
+
+* `parent_id` - (Optional) The parent of the project.
+
+* `tags` - (Optional) Tags for the project.
+
+## Attributes Reference
+
+`ids` is set to the list of Openstack Project IDs.

--- a/openstack/data_source_openstack_identity_projects_v3.go
+++ b/openstack/data_source_openstack_identity_projects_v3.go
@@ -1,0 +1,160 @@
+package openstack
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
+	"github.com/gophercloud/utils/terraform/hashcode"
+)
+
+func dataSourceIdentityProjectIdsV3() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIdentityProjectIdsV3Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"domain_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"is_domain": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name_regex"},
+			},
+
+			"name_regex": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ValidateFunc:  validation.StringIsValidRegExp,
+				ConflictsWith: []string{"name"},
+			},
+
+			"parent_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"tags": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
+			// Computed values
+			"ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+// dataSourceIdentityProjectIdsV3Read performs the project lookup.
+func dataSourceIdentityProjectIdsV3Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating OpenStack identity client: %s", err)
+	}
+
+	enabled := d.Get("enabled").(bool)
+	isDomain := d.Get("is_domain").(bool)
+
+	tags := []string{}
+	tagList := d.Get("tags").(*schema.Set).List()
+	for _, v := range tagList {
+		tags = append(tags, fmt.Sprint(v))
+	}
+	joinedTags := strings.Join(tags, ",")
+
+	listOpts := projects.ListOpts{
+		DomainID: d.Get("domain_id").(string),
+		Enabled:  &enabled,
+		IsDomain: &isDomain,
+		Name:     d.Get("name").(string),
+		ParentID: d.Get("parent_id").(string),
+		Tags:     joinedTags,
+	}
+
+	allPages, err := projects.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		return diag.Errorf("Unable to list projects in openstack_identity_project_ids_v3: %s", err)
+	}
+
+	allProjects, err := projects.ExtractProjects(allPages)
+	if err != nil {
+		return diag.Errorf("Unable to retrieve projects in openstack_identity_project_ids_v3: %s", err)
+	}
+
+	log.Printf("[DEBUG] Retrieved %d images in openstack_identity_project_ids_v3: %+v", len(allProjects), allProjects)
+
+	nameRegex, nameRegexOk := d.GetOk("name_regex")
+	if nameRegexOk {
+		allProjects = projectsFilterByRegex(allProjects, nameRegex.(string))
+		log.Printf("[DEBUG] Project list filtered by regex: %s", d.Get("name_regex"))
+	}
+
+	log.Printf("[DEBUG] Got %d projects after filtering in openstack_identity_project_ids_v3: %+v", len(allProjects), allProjects)
+
+	projectIDs := make([]string, len(allProjects))
+	for i, image := range allProjects {
+		projectIDs[i] = image.ID
+	}
+
+	d.SetId(fmt.Sprintf("%d", hashcode.String(strings.Join(projectIDs, ","))))
+	d.Set("ids", projectIDs)
+
+	return nil
+}
+
+func projectsFilterByRegex(projectArr []projects.Project, nameRegex string) []projects.Project {
+	var result []projects.Project
+	r := regexp.MustCompile(nameRegex)
+
+	for _, project := range projectArr {
+		if r.MatchString(project.Name) {
+			result = append(result, project)
+		}
+	}
+
+	return result
+}

--- a/openstack/data_source_openstack_identity_projects_v3.go
+++ b/openstack/data_source_openstack_identity_projects_v3.go
@@ -125,7 +125,7 @@ func dataSourceIdentityProjectIdsV3Read(ctx context.Context, d *schema.ResourceD
 		return diag.Errorf("Unable to retrieve projects in openstack_identity_project_ids_v3: %s", err)
 	}
 
-	log.Printf("[DEBUG] Retrieved %d images in openstack_identity_project_ids_v3: %+v", len(allProjects), allProjects)
+	log.Printf("[DEBUG] Retrieved %d projects in openstack_identity_project_ids_v3: %+v", len(allProjects), allProjects)
 
 	nameRegex, nameRegexOk := d.GetOk("name_regex")
 	if nameRegexOk {
@@ -139,8 +139,8 @@ func dataSourceIdentityProjectIdsV3Read(ctx context.Context, d *schema.ResourceD
 	log.Printf("[DEBUG] Got %d projects after filtering in openstack_identity_project_ids_v3: %+v", len(allProjects), allProjects)
 
 	projectIDs := make([]string, len(allProjects))
-	for i, image := range allProjects {
-		projectIDs[i] = image.ID
+	for i, project := range allProjects {
+		projectIDs[i] = project.ID
 	}
 
 	d.SetId(fmt.Sprintf("%d", hashcode.String(strings.Join(projectIDs, ","))))

--- a/openstack/data_source_openstack_identity_projects_v3_test.go
+++ b/openstack/data_source_openstack_identity_projects_v3_test.go
@@ -1,0 +1,106 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccOpenStackIdentityProjectIDsV3DataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpenStackIdentityProjectIDsV3DataSourceEmpty(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.openstack_identity_project_ids_v2.projects_empty", "ids.#", "0"),
+				),
+			},
+			{
+				Config: testAccOpenStackIdentityProjectIDsV3DataSourceName(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.openstack_identity_project_ids_v2.projects_by_name", "ids.#", "1"),
+					resource.TestCheckResourceAttrPair(
+						"data.openstack_identity_project_ids_v2.projects_by_name", "ids.0",
+						"openstack_identity_project_v3.project_1", "id"),
+				),
+			},
+			{
+				Config: testAccOpenStackIdentityProjectIDsV3DataSourceRegex(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.openstack_identity_project_ids_v2.projects_by_name_regex", "ids.#", "2"),
+					resource.TestCheckResourceAttrPair(
+						"data.openstack_identity_project_ids_v2.projects_by_name_regex", "ids.0",
+						"openstack_identity_project_v3.project_2", "id"),
+				),
+			},
+			{
+				Config: testAccOpenStackIdentityProjectIDsV3DataSourceTags(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.openstack_identity_project_ids_v2.projects_by_tag", "ids.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+const testAccOpenStackIdentityProjectIDsV3DataSourceProjects = `
+	resource "openstack_identity_project_v3" "project_1" {
+	  name = "project_1"
+	  tags = ["dev", "product1"]
+	}
+
+	resource "openstack_identity_project_v3" "project_2" {
+	  name = "project_2"
+	  tags = ["prod", "product1"]
+	}
+`
+
+func testAccOpenStackIdentityProjectIDsV3DataSourceEmpty() string {
+	return fmt.Sprintf(`
+%s
+
+data "openstack_identity_project_ids_v3" "projects_empty" {
+    name = "non-existed-project"
+}
+`, testAccOpenStackIdentityProjectIDsV3DataSourceProjects)
+}
+
+func testAccOpenStackIdentityProjectIDsV3DataSourceName() string {
+	return fmt.Sprintf(`
+%s
+
+data "openstack_identity_project_ids_v3" "projects_by_name" {
+	name = "${openstack_identity_project_v3.project_1.name}"
+}
+`, testAccOpenStackIdentityProjectIDsV3DataSourceProjects)
+}
+
+func testAccOpenStackIdentityProjectIDsV3DataSourceRegex() string {
+	return fmt.Sprintf(`
+%s
+
+data "openstack_identity_project_ids_v3" "projects_by_name_regex" {
+	name_regex = "^.+_2$"
+}
+`, testAccOpenStackIdentityProjectIDsV3DataSourceProjects)
+}
+
+func testAccOpenStackIdentityProjectIDsV3DataSourceTags() string {
+	return fmt.Sprintf(`
+%s
+
+data "openstack_identity_project_ids_v3" "projects_by_tag" {
+	tags = ["product1"]
+}
+`, testAccOpenStackIdentityProjectIDsV3DataSourceProjects)
+}

--- a/openstack/data_source_openstack_identity_projects_v3_test.go
+++ b/openstack/data_source_openstack_identity_projects_v3_test.go
@@ -19,16 +19,16 @@ func TestAccOpenStackIdentityProjectIDsV3DataSource_basic(t *testing.T) {
 				Config: testAccOpenStackIdentityProjectIDsV3DataSourceEmpty(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"data.openstack_identity_project_ids_v2.projects_empty", "ids.#", "0"),
+						"data.openstack_identity_project_ids_v3.projects_empty", "ids.#", "0"),
 				),
 			},
 			{
 				Config: testAccOpenStackIdentityProjectIDsV3DataSourceName(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"data.openstack_identity_project_ids_v2.projects_by_name", "ids.#", "1"),
+						"data.openstack_identity_project_ids_v3.projects_by_name", "ids.#", "1"),
 					resource.TestCheckResourceAttrPair(
-						"data.openstack_identity_project_ids_v2.projects_by_name", "ids.0",
+						"data.openstack_identity_project_ids_v3.projects_by_name", "ids.0",
 						"openstack_identity_project_v3.project_1", "id"),
 				),
 			},
@@ -36,9 +36,9 @@ func TestAccOpenStackIdentityProjectIDsV3DataSource_basic(t *testing.T) {
 				Config: testAccOpenStackIdentityProjectIDsV3DataSourceRegex(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"data.openstack_identity_project_ids_v2.projects_by_name_regex", "ids.#", "2"),
+						"data.openstack_identity_project_ids_v3.projects_by_name_regex", "ids.#", "2"),
 					resource.TestCheckResourceAttrPair(
-						"data.openstack_identity_project_ids_v2.projects_by_name_regex", "ids.0",
+						"data.openstack_identity_project_ids_v3.projects_by_name_regex", "ids.0",
 						"openstack_identity_project_v3.project_2", "id"),
 				),
 			},
@@ -46,7 +46,7 @@ func TestAccOpenStackIdentityProjectIDsV3DataSource_basic(t *testing.T) {
 				Config: testAccOpenStackIdentityProjectIDsV3DataSourceTags(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"data.openstack_identity_project_ids_v2.projects_by_tag", "ids.#", "2"),
+						"data.openstack_identity_project_ids_v3.projects_by_tag", "ids.#", "2"),
 				),
 			},
 		},

--- a/openstack/data_source_openstack_identity_projects_v3_test.go
+++ b/openstack/data_source_openstack_identity_projects_v3_test.go
@@ -36,7 +36,7 @@ func TestAccOpenStackIdentityProjectIDsV3DataSource_basic(t *testing.T) {
 				Config: testAccOpenStackIdentityProjectIDsV3DataSourceRegex(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"data.openstack_identity_project_ids_v3.projects_by_name_regex", "ids.#", "2"),
+						"data.openstack_identity_project_ids_v3.projects_by_name_regex", "ids.#", "1"),
 					resource.TestCheckResourceAttrPair(
 						"data.openstack_identity_project_ids_v3.projects_by_name_regex", "ids.0",
 						"openstack_identity_project_v3.project_2", "id"),

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -284,6 +284,7 @@ func Provider() *schema.Provider {
 			"openstack_fw_rule_v2":                               dataSourceFWRuleV2(),
 			"openstack_identity_role_v3":                         dataSourceIdentityRoleV3(),
 			"openstack_identity_project_v3":                      dataSourceIdentityProjectV3(),
+			"openstack_identity_project_ids_v3":                  dataSourceIdentityProjectIdsV3(),
 			"openstack_identity_user_v3":                         dataSourceIdentityUserV3(),
 			"openstack_identity_auth_scope_v3":                   dataSourceIdentityAuthScopeV3(),
 			"openstack_identity_endpoint_v3":                     dataSourceIdentityEndpointV3(),


### PR DESCRIPTION
Allowing to get list of projects, it's useful when you have to apply certain role assignments to certain group of projects 