### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,20 +64,3 @@ they will become available via the Terraform Registry.
 Before releasing, a PR updating the changelog should be made to trigger the CI 
 for all services and ensure that everything is OK. Moreover, update the example
 on `website/docs/index.html.markdown` to point to the new version.
-
-Thank You
----------
-
-We'd like to extend special thanks and appreciation to the following:
-
-### OpenLab
-
-<a href="http://openlabtesting.org/"><img src="assets/openlab.png" width="600px"></a>
-
-OpenLab is providing a full CI environment to test each PR and merge for a variety of OpenStack releases.
-
-### VEXXHOST
-
-<a href="https://vexxhost.com/"><img src="assets/vexxhost.png" width="600px"></a>
-
-VEXXHOST is providing their services to assist with the development and testing of this provider.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 Terraform OpenStack Provider
 ============================
 
-Documentation: [registry.terraform.io](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs)
+Documentation:
+- [registry.terraform.io](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs)
+- [search.opentofu.org](https://search.opentofu.org/provider/terraform-provider-openstack/openstack/latest)
 
 Requirements
 ------------
 
-- [Terraform](https://www.terraform.io/downloads.html) 1.0.x
+- [Terraform](https://www.terraform.io/downloads.html) 1.x
+- [OpenTofu](https://opentofu.org/docs/intro/install) 1.x
 - [Go](https://golang.org/doc/install) 1.22 (to build the provider plugin)
 
 Building The Provider
@@ -27,7 +30,7 @@ $ make build
 
 Using the provider
 ----------------------
-Please see the documentation at [registry.terraform.io](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs).
+Please see the documentation at [registry.terraform.io](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs) or [search.opentofu.org](https://search.opentofu.org/provider/terraform-provider-openstack/openstack/latest).
 
 Or you can browse the documentation within this repo [here](https://github.com/terraform-provider-openstack/terraform-provider-openstack/tree/main/website/docs).
 
@@ -42,7 +45,7 @@ To compile the provider, run `make build`. This will build the provider and put 
 $ make build
 ```
 
-For further details on how to work on this provider, please see the [Testing and Development](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs#testing-and-development) documentation.
+For further details on how to work on this provider, please see the [Testing and Development](https://github.com/terraform-provider-openstack/terraform-provider-openstack/blob/main/docs/index.md#testing-and-development) documentation.
 
 Releasing the Provider
 ----------------------


### PR DESCRIPTION
Add OpenTofu registry UI and remove mentioning the OpenLab and VEXXHOST, since we entirely moved to GitHub actions a while ago.