### PR TITLE
[networking]: use rules.ProtocolAny for "any" secgroup protocol

### DIFF
--- a/openstack/networking_secgroup_rule_v2.go
+++ b/openstack/networking_secgroup_rule_v2.go
@@ -74,7 +74,7 @@ func resourceNetworkingSecGroupRuleV2Protocol(v interface{}, k string) ([]string
 		rules.ProtocolUDPLite,
 		rules.ProtocolVRRP,
 		rules.ProtocolIPIP,
-		"": // rules.ProtocolAny
+		rules.ProtocolAny:
 		return nil, nil
 	}
 


### PR DESCRIPTION
cosmetic change. use `rules.ProtocolAny` instead of empty string.