### PR TITLE
fix: correct resource and floating_ip names in floating IP association

### DIFF
--- a/docs/resources/compute_instance_v2.md
+++ b/docs/resources/compute_instance_v2.md
@@ -205,8 +205,8 @@ data "openstack_networking_port_v2" "vm-port" {
   network_id = openstack_compute_instance_v2.multi-net.network.1.uuid
 }
 
-resource "openstack_networking_floatingip_associate_v2" "myip" {
-  floating_ip = openstack_networking_floatingip_v2.fip_vm.address
+resource "openstack_networking_floatingip_associate_v2" "fip_vm" {
+  floating_ip = openstack_networking_floatingip_v2.myip.address
   port_id     = data.openstack_networking_port_v2.vm-port.id
 }
 ```


### PR DESCRIPTION
**Description:**
This pull request fixes an issue with the `resource` and `floating_ip` name in the `openstack_networking_floatingip_associate_v2` resource in the Terraform OpenStack provider `compute_instance_v2` documentation. The original configuration had the `resource name` and `floating_ip name` incorrectly swapped, which caused issues when associating the floating IP to the correct port.