### PR TITLE
fix(image_cache): include decompress flag in cache key for image uploads

### DIFF
--- a/openstack/images_image_v2.go
+++ b/openstack/images_image_v2.go
@@ -105,7 +105,7 @@ func resourceImagesImageV2File(client *gophercloud.ServiceClient, d *schema.Reso
 	}
 
 	// calculate the hashsum and create a lock to prevent simultaneous file access
-	md5sum := fmt.Sprintf("%x", md5.Sum([]byte(furl)))
+	md5sum := fmt.Sprintf("%x", md5.Sum([]byte(fmt.Sprintf("%s%t", furl, d.Get("decompress").(bool)))))
 	mutexKV.Lock(md5sum)
 	defer mutexKV.Unlock(md5sum)
 


### PR DESCRIPTION
Previously, the cache key for image uploads was based solely on the image URL, causing issues when the decompress flag was added or changed. This commit updates the cache key generation to include the decompress flag, ensuring that changes to this flag trigger a cache refresh and the correct image is uploaded.

resolve #1801 