### PR TITLE
fix(objectstorage-container-v1): set ForceNew to true for container name

### DIFF
--- a/openstack/resource_openstack_objectstorage_container_v1.go
+++ b/openstack/resource_openstack_objectstorage_container_v1.go
@@ -46,7 +46,7 @@ func resourceObjectStorageContainerV1() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: false,
+				ForceNew: true,
 			},
 			"container_read": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
According to the openstack_objectstorage_container_v1 documentation for the name argument, changing the name should result in creating a new container. However, the existing behavior does not reflect this, as changes to the name attribute are not applied. This issue arises because the ForceNew property for the name field is set to false, preventing the expected recreation of the container when the name changes.

This update sets ForceNew to true for the name attribute, ensuring that any name change triggers the creation of a new container. It’s important to note that if there are objects present in the container, the deletion will not be allowed, which aligns with the standard behavior of OpenStack Object Storage to prevent data loss.

Resolves #1769 