### PR TITLE
[GH-A] Bump golangci-lint version to v1.61

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: 'v1.54'
+          version: 'v1.61'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,13 @@
 run:
-  deadline: 5m
+  go: '1.22'
+  timeout: 5m
 
 linters-settings:
-  staticcheck:
-    go: '1.22'
-  stylecheck:
-    go: '1.22'
   gci:
-    local-prefixes: github.com/gophercloud
+    sections:
+      - standard
+      - default
+      - prefix(github.com/gophercloud)
   goimports:
     local-prefixes: github.com/gophercloud
   depguard:
@@ -28,10 +28,10 @@ linters:
     - asciicheck
     - bodyclose
     - depguard
+    - copyloopvar
     - dogsled
     - errcheck
     - exhaustive
-    - exportloopref
     - gci
     - godot
     - gofmt


### PR DESCRIPTION
Changelog: https://github.com/golangci/golangci-lint/compare/v1.54.2...v1.61.0