### PR TITLE
[GH-A] Add dalmatian jobs to ci

### DIFF
--- a/.github/workflows/functional-bgpvpn.yml
+++ b/.github/workflows/functional-bgpvpn.yml
@@ -21,6 +21,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "dalmatian"
+            openstack_version: "stable/2024.2"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-blockstorage_v3.yml
+++ b/.github/workflows/functional-blockstorage_v3.yml
@@ -24,6 +24,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "dalmatian"
+            openstack_version: "stable/2024.2"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-compute.yml
+++ b/.github/workflows/functional-compute.yml
@@ -22,6 +22,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "dalmatian"
+            openstack_version: "stable/2024.2"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-containerinfra.yml
+++ b/.github/workflows/functional-containerinfra.yml
@@ -28,6 +28,13 @@ jobs:
               enable_plugin magnum https://github.com/openstack/magnum master
               MAGNUMCLIENT_BRANCH=master
             additional_services: "openstack-cli-server"
+          - name: "dalmatian"
+            openstack_version: "stable/2024.2"
+            ubuntu_version: "22.04"
+            devstack_conf_overrides: |
+              enable_plugin magnum https://github.com/openstack/magnum stable/2024.2
+              MAGNUMCLIENT_BRANCH=stable/2024.2
+            additional_services: ""
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-dns.yml
+++ b/.github/workflows/functional-dns.yml
@@ -21,6 +21,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "dalmatian"
+            openstack_version: "stable/2024.2"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-fwaas_v2.yml
+++ b/.github/workflows/functional-fwaas_v2.yml
@@ -23,6 +23,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "dalmatian"
+            openstack_version: "stable/2024.2"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-identity.yml
+++ b/.github/workflows/functional-identity.yml
@@ -22,6 +22,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "dalmatian"
+            openstack_version: "stable/2024.2"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-images.yml
+++ b/.github/workflows/functional-images.yml
@@ -22,6 +22,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "dalmatian"
+            openstack_version: "stable/2024.2"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-keymanager.yml
+++ b/.github/workflows/functional-keymanager.yml
@@ -24,6 +24,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "dalmatian"
+            openstack_version: "stable/2024.2"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-loadbalancer.yml
+++ b/.github/workflows/functional-loadbalancer.yml
@@ -21,6 +21,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "dalmatian"
+            openstack_version: "stable/2024.2"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-networking.yml
+++ b/.github/workflows/functional-networking.yml
@@ -22,6 +22,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "dalmatian"
+            openstack_version: "stable/2024.2"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-objectstorage.yml
+++ b/.github/workflows/functional-objectstorage.yml
@@ -21,6 +21,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "dalmatian"
+            openstack_version: "stable/2024.2"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-orchestration.yml
+++ b/.github/workflows/functional-orchestration.yml
@@ -21,6 +21,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "dalmatian"
+            openstack_version: "stable/2024.2"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-sharedfilesystem.yml
+++ b/.github/workflows/functional-sharedfilesystem.yml
@@ -21,6 +21,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "dalmatian"
+            openstack_version: "stable/2024.2"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"

--- a/.github/workflows/functional-vpnaas.yml
+++ b/.github/workflows/functional-vpnaas.yml
@@ -21,6 +21,9 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "dalmatian"
+            openstack_version: "stable/2024.2"
+            ubuntu_version: "22.04"
           - name: "caracal"
             openstack_version: "stable/2024.1"
             ubuntu_version: "22.04"


### PR DESCRIPTION
OpenStack 2024.2 (Dalmatian) has been released recently (2024-10-02).

This PR enables the build for OpenStack Dalmatian to the GitHub Actions workflows.