### PR TITLE
Add Terraform Registry manifest file and include in goreleaser configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,6 +34,9 @@ archives:
   - format: zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
+  extra_files:
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 signs:
@@ -49,6 +52,9 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
+  extra_files:
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   # Visit your project's GitHub Releases page to publish this release.
   draft: true
 changelog:

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "metadata": {
+    "protocol_versions": ["5.0"]
+  }
+}


### PR DESCRIPTION
Goal of this PR is to add the Terraform Registry manifest file and include it in the goreleaser configuration.

> While not strictly necessary for publishing protocol version 5 providers as the Terraform Registry currently defaults to that version when a manifest file is not found in the release assets, this change prepares future projects for the ability to configure an existing manifest file rather than need to discover this configuration later on.

See

* https://github.com/hashicorp/terraform-provider-scaffolding/blob/main/terraform-registry-manifest.json
* https://github.com/hashicorp/terraform-provider-scaffolding/commit/44f39a790c003f49bbf75a2a7f91d64e6e0bf022