### PR TITLE
Use Go version from the go.mod file

### DIFF
--- a/.github/workflows/functional-bgpvpn.yml
+++ b/.github/workflows/functional-bgpvpn.yml
@@ -97,7 +97,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.20'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run TPO acceptance tests
         run: OS_BGPVPN_ENVIRONMENT=true ./scripts/acceptancetest.sh
         env:

--- a/.github/workflows/functional-blockstorage_v3.yml
+++ b/.github/workflows/functional-blockstorage_v3.yml
@@ -48,7 +48,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.22'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run TPO acceptance tests
         run: ./scripts/acceptancetest.sh
         env:

--- a/.github/workflows/functional-compute.yml
+++ b/.github/workflows/functional-compute.yml
@@ -46,7 +46,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.22'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run TPO acceptance tests
         run: ./scripts/acceptancetest.sh
         env:

--- a/.github/workflows/functional-containerinfra.yml
+++ b/.github/workflows/functional-containerinfra.yml
@@ -69,7 +69,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.20'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run TPO acceptance tests
         run: OS_CONTAINER_INFRA_ENVIRONMENT=true ./scripts/acceptancetest.sh
         env:

--- a/.github/workflows/functional-dns.yml
+++ b/.github/workflows/functional-dns.yml
@@ -45,7 +45,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.22'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run TPO acceptance tests
         run: OS_DNS_ENVIRONMENT=True ./scripts/acceptancetest.sh
         env:

--- a/.github/workflows/functional-fwaas_v2.yml
+++ b/.github/workflows/functional-fwaas_v2.yml
@@ -52,7 +52,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.22'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run TPO acceptance tests
         run: OS_FW_ENVIRONMENT="1" ./scripts/acceptancetest.sh
         env:

--- a/.github/workflows/functional-identity.yml
+++ b/.github/workflows/functional-identity.yml
@@ -44,7 +44,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.22'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run TPO acceptance tests
         run: ./scripts/acceptancetest.sh
         env:

--- a/.github/workflows/functional-images.yml
+++ b/.github/workflows/functional-images.yml
@@ -44,7 +44,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.22'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run TPO acceptance tests
         run: ./scripts/acceptancetest.sh
         env:

--- a/.github/workflows/functional-keymanager.yml
+++ b/.github/workflows/functional-keymanager.yml
@@ -48,7 +48,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.22'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run TPO acceptance tests
         run: OS_KEYMANAGER_ENVIRONMENT=True ./scripts/acceptancetest.sh
         env:

--- a/.github/workflows/functional-loadbalancer.yml
+++ b/.github/workflows/functional-loadbalancer.yml
@@ -47,7 +47,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.22'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run TPO acceptance tests
         run: OS_LB_ENVIRONMENT=true ./scripts/acceptancetest.sh
         env:

--- a/.github/workflows/functional-networking.yml
+++ b/.github/workflows/functional-networking.yml
@@ -59,7 +59,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.22'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run TPO acceptance tests
         run: ./scripts/acceptancetest.sh
         env:

--- a/.github/workflows/functional-objectstorage.yml
+++ b/.github/workflows/functional-objectstorage.yml
@@ -49,7 +49,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.22'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run Gophercloud acceptance tests
         run: OS_SWIFT_ENVIRONMENT=true ./scripts/acceptancetest.sh
         env:

--- a/.github/workflows/functional-orchestration.yml
+++ b/.github/workflows/functional-orchestration.yml
@@ -45,7 +45,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.22'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run TPO acceptance tests
         run: ./scripts/acceptancetest.sh
         env:

--- a/.github/workflows/functional-sharedfilesystem.yml
+++ b/.github/workflows/functional-sharedfilesystem.yml
@@ -58,7 +58,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.22'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run TPO acceptance tests
         run: OS_SFS_ENVIRONMENT=True ./scripts/acceptancetest.sh
         env:

--- a/.github/workflows/functional-vpnaas.yml
+++ b/.github/workflows/functional-vpnaas.yml
@@ -48,7 +48,8 @@ jobs:
       - name: Checkout go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.22'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run TPO acceptance tests
         run: OS_VPN_ENVIRONMENT=true ./scripts/acceptancetest.sh
         env:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,13 +10,14 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
-
-      - name: Checkout
-        uses: actions/checkout@v4
+          go-version-file: 'go.mod'
+          cache: true
 
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: 'go.mod'
+          cache: true
 
       - name: Import GPG key
         id: import_gpg

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,22 +4,19 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version:
-          - "1.22"
 
     env:
       GO111MODULE: "on"
 
     steps:
-      - name: Setup Go ${{ matrix.go-version }}
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
-
-      - uses: actions/checkout@v4
+          go-version-file: 'go.mod'
+          cache: true
 
       - name: Run go vet
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,4 @@
 run:
-  go: '1.22'
   timeout: 5m
 
 linters-settings:


### PR DESCRIPTION
I noticed that 2 GitHub Actions workflows were still using Go 1.20 for builds.

To address this, I propose updating the workflows to leverage the `go-version-file` property of the `actions/setup-go@v5` action. This property allows the action to automatically determine the Go version to use based on the version specified in the `go.mod` file.

This approach is recommended in the [Terraform Provider Scaffolding guide](https://github.com/hashicorp/terraform-provider-scaffolding/blob/main/.github/workflows/release.yml#L33).

Additionally, we can apply a similar improvement for golangci-lint by removing the  `.run.go` property. This will ensure that golangci-lint uses the Go version specified in the `go.mod` file, further aligning the versions across the project.