### PR TITLE
 Add `hypervisor_hostname` Option to Compute Instance

### DIFF
--- a/docs/resources/compute_instance_v2.md
+++ b/docs/resources/compute_instance_v2.md
@@ -403,8 +403,9 @@ The following arguments are supported:
     the instance should be launched. The available hints are described below.
 
 * `personality` - (Optional) Customize the personality of an instance by
-    defining one or more files and their contents. The personality structure
-    is described below. Changing this rebuilds the existing server.
+  defining one or more files and their contents. The personality structure is
+  described below. Conflicts with `hypervisor_hostname`. Changing this rebuilds
+  the existing server.
 
 * `stop_before_destroy` - (Optional) Whether to try stop instance gracefully
     before destroying it, thus giving chance for guest OS daemons to stop correctly.
@@ -426,7 +427,12 @@ The following arguments are supported:
 * `vendor_options` - (Optional) Map of additional vendor-specific options.
     Supported options are described below.
 
-* `hypervisor_hostname` - (Optional) Specifies the exact hypervisor hostname on which to create the instance. When provided, this parameter is included in the request to Nova, directing the scheduler to launch the instance on the specified host. Note: This option requires administrative privileges and a Nova microversion of 2.74 or later. Changing this value forces a new instance to be created.
+* `hypervisor_hostname` - (Optional) Specifies the exact hypervisor hostname on
+  which to create the instance. When provided, this parameter is included in
+  the request to Nova, directing the scheduler to launch the instance on the
+  specified host. Note: This option requires administrative privileges and a
+  Nova microversion of 2.74 or later. Conflicts with `personality`. Changing
+  this value forces a new instance to be created.
 
 The `network` block supports:
 

--- a/docs/resources/compute_instance_v2.md
+++ b/docs/resources/compute_instance_v2.md
@@ -426,6 +426,8 @@ The following arguments are supported:
 * `vendor_options` - (Optional) Map of additional vendor-specific options.
     Supported options are described below.
 
+* `hypervisor_hostname` - (Optional) Specifies the exact hypervisor hostname on which to create the instance. When provided, this parameter is included in the request to Nova, directing the scheduler to launch the instance on the specified host. Note: This option requires administrative privileges and a Nova microversion of 2.74 or later. Changing this value forces a new instance to be created.
+
 The `network` block supports:
 
 * `uuid` - (Required unless `port`  or `name` is provided) The network UUID to

--- a/openstack/compute_instance_v2.go
+++ b/openstack/compute_instance_v2.go
@@ -23,12 +23,13 @@ import (
 )
 
 const (
-	computeV2InstanceCreateServerWithNetworkModeMicroversion = "2.37"
-	computeV2InstanceCreateServerWithTagsMicroversion        = "2.52"
-	computeV2TagsExtensionMicroversion                       = "2.26"
-	computeV2InstanceBlockDeviceVolumeTypeMicroversion       = "2.67"
-	computeV2InstanceBlockDeviceVolumeAttachTagsMicroversion = "2.49"
-	computeV2InstanceBlockDeviceMultiattachMicroversion      = "2.60"
+	computeV2InstanceCreateServerWithNetworkModeMicroversion        = "2.37"
+	computeV2InstanceCreateServerWithTagsMicroversion               = "2.52"
+	computeV2InstanceCreateServerWithHypervisorHostnameMicroversion = "2.74"
+	computeV2TagsExtensionMicroversion                              = "2.26"
+	computeV2InstanceBlockDeviceVolumeTypeMicroversion              = "2.67"
+	computeV2InstanceBlockDeviceVolumeAttachTagsMicroversion        = "2.49"
+	computeV2InstanceBlockDeviceMultiattachMicroversion             = "2.60"
 )
 
 // InstanceNIC is a structured representation of a Gophercloud servers.Server

--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -179,10 +179,11 @@ func resourceComputeInstanceV2() *schema.Resource {
 				},
 			},
 			"hypervisor_hostname": {
-				Type:     schema.TypeString,
-				Computed: true,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Computed:      true,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"personality"},
 			},
 			"metadata": {
 				Type:     schema.TypeMap,
@@ -350,7 +351,8 @@ func resourceComputeInstanceV2() *schema.Resource {
 						},
 					},
 				},
-				Set: resourceComputeInstancePersonalityHash,
+				Set:           resourceComputeInstancePersonalityHash,
+				ConflictsWith: []string{"hypervisor_hostname"},
 			},
 			"stop_before_destroy": {
 				Type:     schema.TypeBool,
@@ -505,8 +507,8 @@ func resourceComputeInstanceV2Create(ctx context.Context, d *schema.ResourceData
 	}
 
 	var hypervisorHostname string
-	if v, ok := d.Get("hypervisor_hostname").(string); ok {
-		hypervisorHostname = v
+	if v, ok := getOkExists(d, "hypervisor_hostname"); ok {
+		hypervisorHostname = v.(string)
 		computeClient.Microversion = computeV2InstanceCreateServerWithHypervisorHostnameMicroversion
 	}
 

--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -495,6 +495,8 @@ func resourceComputeInstanceV2Create(ctx context.Context, d *schema.ResourceData
 		networks = expandInstanceNetworks(allInstanceNetworks)
 	}
 
+	hypervisorHostname := d.Get("hypervisor_hostname").(string)
+
 	configDrive := d.Get("config_drive").(bool)
 
 	// Retrieve tags and set microversion if they're provided.
@@ -516,6 +518,7 @@ func resourceComputeInstanceV2Create(ctx context.Context, d *schema.ResourceData
 		SecurityGroups:   resourceInstanceSecGroupsV2(d),
 		AvailabilityZone: availabilityZone,
 		Networks:         networks,
+		HypervisorHostname: hypervisorHostname,
 		Metadata:         resourceInstanceMetadataV2(d),
 		ConfigDrive:      &configDrive,
 		AdminPass:        d.Get("admin_pass").(string),
@@ -753,6 +756,9 @@ func resourceComputeInstanceV2Read(ctx context.Context, d *schema.ResourceData, 
 	} else {
 		computeV2InstanceReadTags(d, instanceTags)
 	}
+
+	// Set the hypervisor hostname
+	d.Set("hypervisor_hostname", server.HypervisorHostname)
 
 	return nil
 }

--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -178,6 +178,11 @@ func resourceComputeInstanceV2() *schema.Resource {
 					},
 				},
 			},
+			"hypervisor_hostname": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"metadata": {
 				Type:     schema.TypeMap,
 				Optional: true,

--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -180,6 +180,7 @@ func resourceComputeInstanceV2() *schema.Resource {
 			},
 			"hypervisor_hostname": {
 				Type:     schema.TypeString,
+				Computed: true,
 				Optional: true,
 				ForceNew: true,
 			},
@@ -495,18 +496,18 @@ func resourceComputeInstanceV2Create(ctx context.Context, d *schema.ResourceData
 		networks = expandInstanceNetworks(allInstanceNetworks)
 	}
 
-	var hypervisorHostname string
-	if v, ok := d.Get("hypervisor_hostname").(string); ok {
-		hypervisorHostname = v
-		computeClient.Microversion = computeV2InstanceCreateServerWithHypervisorHostnameMicroversion
-	}
-
 	configDrive := d.Get("config_drive").(bool)
 
 	// Retrieve tags and set microversion if they're provided.
 	instanceTags := computeV2InstanceTags(d)
 	if len(instanceTags) > 0 {
 		computeClient.Microversion = computeV2InstanceCreateServerWithTagsMicroversion
+	}
+
+	var hypervisorHostname string
+	if v, ok := d.Get("hypervisor_hostname").(string); ok {
+		hypervisorHostname = v
+		computeClient.Microversion = computeV2InstanceCreateServerWithHypervisorHostnameMicroversion
 	}
 
 	if v, ok := getOkExists(d, "availability_zone"); ok {

--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -495,7 +495,11 @@ func resourceComputeInstanceV2Create(ctx context.Context, d *schema.ResourceData
 		networks = expandInstanceNetworks(allInstanceNetworks)
 	}
 
-	hypervisorHostname := d.Get("hypervisor_hostname").(string)
+	var hypervisorHostname string
+	if v, ok := d.Get("hypervisor_hostname").(string); ok {
+		hypervisorHostname = v
+		computeClient.Microversion = computeV2InstanceCreateServerWithHypervisorHostnameMicroversion
+	}
 
 	configDrive := d.Get("config_drive").(bool)
 

--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -517,19 +517,19 @@ func resourceComputeInstanceV2Create(ctx context.Context, d *schema.ResourceData
 	}
 
 	createOpts := &servers.CreateOpts{
-		Name:             d.Get("name").(string),
-		ImageRef:         imageID,
-		FlavorRef:        flavorID,
-		SecurityGroups:   resourceInstanceSecGroupsV2(d),
-		AvailabilityZone: availabilityZone,
-		Networks:         networks,
+		Name:               d.Get("name").(string),
+		ImageRef:           imageID,
+		FlavorRef:          flavorID,
+		SecurityGroups:     resourceInstanceSecGroupsV2(d),
+		AvailabilityZone:   availabilityZone,
+		Networks:           networks,
 		HypervisorHostname: hypervisorHostname,
-		Metadata:         resourceInstanceMetadataV2(d),
-		ConfigDrive:      &configDrive,
-		AdminPass:        d.Get("admin_pass").(string),
-		UserData:         []byte(d.Get("user_data").(string)),
-		Personality:      resourceInstancePersonalityV2(d),
-		Tags:             instanceTags,
+		Metadata:           resourceInstanceMetadataV2(d),
+		ConfigDrive:        &configDrive,
+		AdminPass:          d.Get("admin_pass").(string),
+		UserData:           []byte(d.Get("user_data").(string)),
+		Personality:        resourceInstancePersonalityV2(d),
+		Tags:               instanceTags,
 	}
 
 	if vL, ok := d.GetOk("block_device"); ok {

--- a/openstack/resource_openstack_compute_instance_v2_test.go
+++ b/openstack/resource_openstack_compute_instance_v2_test.go
@@ -773,6 +773,29 @@ func TestAccComputeV2Instance_tags(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstanceV2_hypervisorHostname(t *testing.T) {
+	var instance servers.Server
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceV2HypervisorHostnameConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2InstanceExists("openstack_compute_instance_v2.instance_1", &instance),
+					resource.TestCheckResourceAttrPtr(
+						"openstack_compute_instance_v2.instance_1", "hypervisor_hostname", &instance.HypervisorHostname,
+					),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeV2InstanceDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	computeClient, err := config.ComputeV2Client(context.TODO(), osRegionName)
@@ -1681,32 +1704,17 @@ resource "openstack_compute_instance_v2" "instance_1" {
 `, osNetworkID)
 }
 
-func TestAccComputeInstanceV2_hypervisorHostname(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviders,
-		CheckDestroy:      testAccCheckComputeV2InstanceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComputeInstanceV2HypervisorHostnameConfig(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"openstack_compute_instance_v2.instance", "hypervisor_hostname", "my-hypervisor",
-					),
-				),
-			},
-		},
-	})
-}
-
 func testAccComputeInstanceV2HypervisorHostnameConfig() string {
 	return fmt.Sprintf(`
-resource "openstack_compute_instance_v2" "instance" {
+data "openstack_compute_hypervisor_v2" "host01" {
+}
+
+resource "openstack_compute_instance_v2" "instance_1" {
   name            = "test-instance"
   image_id        = "%s"
   flavor_id       = "%s"
 
-  hypervisor_hostname = "my-hypervisor"
+  hypervisor_hostname = data.openstack_compute_hypervisor_v2.host01.hostname
 
   network {
     uuid = "%s"

--- a/openstack/resource_openstack_compute_instance_v2_test.go
+++ b/openstack/resource_openstack_compute_instance_v2_test.go
@@ -1708,7 +1708,7 @@ resource "openstack_compute_instance_v2" "instance" {
 
   hypervisor_hostname = "my-hypervisor"
 
-  networks {
+  network {
     uuid = "%s"
   }
 }

--- a/openstack/resource_openstack_compute_instance_v2_test.go
+++ b/openstack/resource_openstack_compute_instance_v2_test.go
@@ -1680,3 +1680,37 @@ resource "openstack_compute_instance_v2" "instance_1" {
 }
 `, osNetworkID)
 }
+
+func TestAccComputeInstanceV2_hypervisorHostname(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceV2HypervisorHostnameConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"openstack_compute_instance_v2.instance", "hypervisor_hostname", "my-hypervisor",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccComputeInstanceV2HypervisorHostnameConfig() string {
+	return fmt.Sprintf(`
+resource "openstack_compute_instance_v2" "instance" {
+  name            = "test-instance"
+  image_id        = "%s"
+  flavor_id       = "%s"
+
+  hypervisor_hostname = "my-hypervisor"
+
+  networks {
+    uuid = "%s"
+  }
+}
+`, osImageID, osFlavorID, osNetworkID)
+}


### PR DESCRIPTION
Issue: #1745

This pull request adds the ability to specify `hypervisor_hostname` during Compute Instance creation in order to support OpenStack Nova API microversion >2.74. 
  
change :
        - Added `hypervisor_hostname` to the resource schema.
        - Introduced an acceptance test to verify that the `hypervisor_hostname` parameter is correctly processed.

Ad-hoc Test Results:
In our local OpenStack (DevStack) environment, we confirmed that:

   - The `hypervisor_hostname` is correctly included in the API request during Compute Instance creation.
   - There are no adverse effects on existing functionalities (e.g., instance creation and updates).