### PR TITLE
Fix all-in quota creation for resource_openstack_blockstorage_quotaset_v3

### DIFF
--- a/docs/resources/blockstorage_quotaset_v3.md
+++ b/docs/resources/blockstorage_quotaset_v3.md
@@ -16,9 +16,6 @@ Manages a V3 block storage quotaset resource within OpenStack.
 ~> **Note:** This resource has a no-op deletion so no actual actions will be done against the OpenStack API
     in case of delete call.
 
-~> **Note:** This resource has all-in creation so all optional quota arguments that were not specified are
-    created with zero value. This excludes volume type quota.
-
 ## Example Usage
 
 ```hcl

--- a/openstack/resource_openstack_blockstorage_quotaset_v3.go
+++ b/openstack/resource_openstack_blockstorage_quotaset_v3.go
@@ -103,7 +103,7 @@ func resourceBlockStorageQuotasetV3Create(ctx context.Context, d *schema.Resourc
 
 	updateOpts := quotasets.UpdateOpts{}
 	projectID := d.Get("project_id").(string)
-	if v, ok := getOkExists(d, "fixed_ips"); ok {
+	if v, ok := getOkExists(d, "volumes"); ok {
 		value := v.(int)
 		updateOpts.Volumes = &value
 	}

--- a/openstack/resource_openstack_blockstorage_quotaset_v3.go
+++ b/openstack/resource_openstack_blockstorage_quotaset_v3.go
@@ -101,30 +101,43 @@ func resourceBlockStorageQuotasetV3Create(ctx context.Context, d *schema.Resourc
 		return diag.Errorf("Error creating OpenStack block storage client: %s", err)
 	}
 
+	updateOpts := quotasets.UpdateOpts{}
 	projectID := d.Get("project_id").(string)
-	volumes := d.Get("volumes").(int)
-	snapshots := d.Get("snapshots").(int)
-	gigabytes := d.Get("gigabytes").(int)
-	perVolumeGigabytes := d.Get("per_volume_gigabytes").(int)
-	backups := d.Get("backups").(int)
-	backupGigabytes := d.Get("backup_gigabytes").(int)
-	groups := d.Get("groups").(int)
+	if v, ok := getOkExists(d, "fixed_ips"); ok {
+		value := v.(int)
+		updateOpts.Volumes = &value
+	}
+	if v, ok := getOkExists(d, "snapshots"); ok {
+		value := v.(int)
+		updateOpts.Snapshots = &value
+	}
+	if v, ok := getOkExists(d, "gigabytes"); ok {
+		value := v.(int)
+		updateOpts.Gigabytes = &value
+	}
+	if v, ok := getOkExists(d, "per_volume_gigabytes"); ok {
+		value := v.(int)
+		updateOpts.PerVolumeGigabytes = &value
+	}
+	if v, ok := getOkExists(d, "backups"); ok {
+		value := v.(int)
+		updateOpts.Backups = &value
+	}
+	if v, ok := getOkExists(d, "backup_gigabytes"); ok {
+		value := v.(int)
+		updateOpts.BackupGigabytes = &value
+	}
+	if v, ok := getOkExists(d, "groups"); ok {
+		value := v.(int)
+		updateOpts.Groups = &value
+	}
+
 	volumeTypeQuotaRaw := d.Get("volume_type_quota").(map[string]interface{})
 	volumeTypeQuota, err := blockStorageQuotasetVolTypeQuotaToInt(volumeTypeQuotaRaw)
 	if err != nil {
 		return diag.Errorf("Error parsing volume_type_quota in openstack_blockstorage_quotaset_v3: %s", err)
 	}
-
-	updateOpts := quotasets.UpdateOpts{
-		Volumes:            &volumes,
-		Snapshots:          &snapshots,
-		Gigabytes:          &gigabytes,
-		PerVolumeGigabytes: &perVolumeGigabytes,
-		Backups:            &backups,
-		BackupGigabytes:    &backupGigabytes,
-		Groups:             &groups,
-		Extra:              volumeTypeQuota,
-	}
+	updateOpts.Extra = volumeTypeQuota
 
 	q, err := quotasets.Update(ctx, blockStorageClient, projectID, updateOpts).Extract()
 	if err != nil {


### PR DESCRIPTION
This is a copy of #1316 for the blockstorage quotaset, as the issue is also present there (right now quotas are set to 0 if not set. This is documented, but not intuitive behavior). The fix seems straightforward.

There are 4 quota resources for which this behavior is different:
 - `resource_openstack_blockstorage_quotaset_v3`: Fixed with this PR
 - `resource_openstack_compute_quotaset_v2`: Fixed with #1304, however the [docs](https://github.com/terraform-provider-openstack/terraform-provider-openstack/blob/main/docs/resources/compute_quotaset_v2.md?plain=1#L19) have not been updated for that
 - `openstack_networking_quota_v2`: Fixed with #1316, however the [docs](https://github.com/terraform-provider-openstack/terraform-provider-openstack/blob/main/docs/resources/networking_quota_v2.md?plain=1#L19) have not been updated for that
 - `resource_openstack_lb_quota_v2`: Has not been fixed (still sets values on the API to 0), however I'm not planning on using that personally so I don't care too much about this [reference](https://github.com/terraform-provider-openstack/terraform-provider-openstack/blob/main/openstack/resource_openstack_lb_quota_v2.go#L106). If wanted, I could extend the scope of this PR to also include a fix on that quota

So a few questions:
1. Is this seen as a bug, such that an update is wanted?
2. Should I extend the scope of the PR to include removing the invalid notes on `resource_openstack_compute_quotaset_v2` and `openstack_networking_quota_v2`?
3. Should I extend the scope of the PR to include a fix for `resource_openstack_lb_quota_v2`?