### PR TITLE
[compute] mark hostname argument optional in hypervisor data source

### DIFF
--- a/openstack/data_source_openstack_compute_hypervisor_v2.go
+++ b/openstack/data_source_openstack_compute_hypervisor_v2.go
@@ -15,7 +15,8 @@ func dataSourceComputeHypervisorV2() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"hostname": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 			},
 
 			"host_ip": {
@@ -78,7 +79,7 @@ func dataSourceComputeHypervisorV2Read(ctx context.Context, d *schema.ResourceDa
 
 	var refinedHypervisors []hypervisors.Hypervisor
 	for _, hypervisor := range allHypervisors {
-		if hypervisor.HypervisorHostname == name {
+		if len(name) == 0 || hypervisor.HypervisorHostname == name {
 			refinedHypervisors = append(refinedHypervisors, hypervisor)
 		}
 	}

--- a/openstack/data_source_openstack_compute_hypervisor_v2_test.go
+++ b/openstack/data_source_openstack_compute_hypervisor_v2_test.go
@@ -20,7 +20,6 @@ func TestAccComputeHypervisorV2DataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheckAdminOnly(t)
-			testAccPreCheckHypervisor(t)
 		},
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
@@ -28,7 +27,7 @@ func TestAccComputeHypervisorV2DataSource(t *testing.T) {
 				Config: testAccHypervisorDataSource(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeHypervisorV2DataSourceID("data.openstack_compute_hypervisor_v2.host01"),
-					resource.TestCheckResourceAttr("data.openstack_compute_hypervisor_v2.host01", "hostname", osHypervisorEnvironment),
+					resource.TestCheckResourceAttrSet("data.openstack_compute_hypervisor_v2.host01", "hostname"),
 				),
 			},
 		},


### PR DESCRIPTION
this should a allow to test `openstack_compute_hypervisor_v2` data source with devstack, when there is only one hypervizor available.