### PR TITLE
[manila] [tests] enforce sharev2 manila client service type

### DIFF
--- a/openstack/provider_test.go
+++ b/openstack/provider_test.go
@@ -58,6 +58,10 @@ var (
 )
 
 func init() {
+	// ensure that only "sharev2" service type endpoint is used for shared-file-system
+	// see https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1847
+	gophercloud.ServiceTypeAliases["shared-file-system"] = []string{"sharev2"}
+
 	testAccProvider = Provider()
 	testAccProviders = map[string]func() (*schema.Provider, error){
 		"openstack": func() (*schema.Provider, error) {


### PR DESCRIPTION
Resolves #1847 

fixes issues with service type aliases in devstack environment with the following catalog:

```
$ openstack catalog list
+--------------------+--------------------+----------------------------------------------------------------------------+
| Name               | Type               | Endpoints                                                                  |
+--------------------+--------------------+----------------------------------------------------------------------------+
| manila             | share              | RegionOne                                                                  |
|                    |                    |   public: http://10.180.142.47/share/v1/f8ec9151c3eb4ed488668bf05f3784af   |
|                    |                    |                                                                            |
| placement          | placement          | RegionOne                                                                  |
|                    |                    |   public: http://10.180.142.47/placement                                   |
|                    |                    |                                                                            |
| shared-file-system | shared-file-system | RegionOne                                                                  |
|                    |                    |   public: http://10.180.142.47/share/v2                                    |
|                    |                    |                                                                            |
| manilav2           | sharev2            | RegionOne                                                                  |
|                    |                    |   public: http://10.180.142.47/share/v2                                    |
|                    |                    |                                                                            |
| manilav2_legacy    | sharev2_legacy     | RegionOne                                                                  |
|                    |                    |   public: http://10.180.142.47/share/v2/f8ec9151c3eb4ed488668bf05f3784af   |
|                    |                    |                                                                            |
| neutron            | network            | RegionOne                                                                  |
|                    |                    |   public: http://10.180.142.47:9696/networking                             |
|                    |                    |                                                                            |
| nova               | compute            | RegionOne                                                                  |
|                    |                    |   public: http://10.180.142.47/compute/v2.1                                |
|                    |                    |                                                                            |
| keystone           | identity           | RegionOne                                                                  |
|                    |                    |   public: http://10.180.142.47/identity                                    |
|                    |                    |                                                                            |
| glance             | image              | RegionOne                                                                  |
|                    |                    |   public: http://10.180.142.47/image                                       |
|                    |                    |                                                                            |
| nova_legacy        | compute_legacy     | RegionOne                                                                  |
|                    |                    |   public: http://10.180.142.47/compute/v2/f8ec9151c3eb4ed488668bf05f3784af |
|                    |                    |                                                                            |
+--------------------+--------------------+----------------------------------------------------------------------------+
```

A new gophercloud feature ends up with the first endpoint found, when:

https://github.com/gophercloud/gophercloud/blob/908ce172717ef96ddea87a969e405e2190a18371/endpoint_search.go#L48

```go
// ServiceTypeAliases contains a mapping of service types to any aliases, as
// defined by the OpenStack Service Types Authority. Only service types that
// we support are included.
var ServiceTypeAliases = map[string][]string{
        "shared-file-system":                  {"sharev2", "share"},
}
```

And according to https://github.com/gophercloud/gophercloud/blob/908ce172717ef96ddea87a969e405e2190a18371/openstack/endpoint_location.go#L97-L103 only the first endpoint is being picked up.

Therefore terraform tries to use an outdated v1 endpoint, which doesn't support microversions.

cc @stephenfin