### PR TITLE
fix(openstack_blockstorage_volume_v3) : Allow image_id to be imported when other ids are not present

### DIFF
--- a/openstack/import_openstack_blockstorage_volume_v3_test.go
+++ b/openstack/import_openstack_blockstorage_volume_v3_test.go
@@ -29,3 +29,27 @@ func TestAccBlockStorageV3Volume_importBasic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccBlockStorageV3Volume_importImage(t *testing.T) {
+	resourceName := "openstack_blockstorage_volume_v3.volume_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckNonAdminOnly(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckBlockStorageV3VolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBlockStorageV3VolumeImage(),
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/openstack/resource_openstack_blockstorage_volume_v3.go
+++ b/openstack/resource_openstack_blockstorage_volume_v3.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -23,7 +24,7 @@ func resourceBlockStorageVolumeV3() *schema.Resource {
 		UpdateContext: resourceBlockStorageVolumeV3Update,
 		DeleteContext: resourceBlockStorageVolumeV3Delete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceBlockStorageVolumeV3Import,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -283,16 +284,6 @@ func resourceBlockStorageVolumeV3Read(ctx context.Context, d *schema.ResourceDat
 		d.Set("volume_retype_policy", "never")
 	}
 
-	// As we can have a snapshot_id with an image_id if the VolumeImageMetadata is stored in the snapshot for exemple,
-	// we want to exclude image_id when one of the others ids are used
-	_, snapshotExists := d.GetOk("snapshot_id")
-	_, backupExists := d.GetOk("backup_id")
-	_, sourcevolExists := d.GetOk("source_vol_id")
-
-	if !snapshotExists && !backupExists && !sourcevolExists {
-		d.Set("image_id", v.VolumeImageMetadata["image_id"])
-	}
-
 	attachments := flattenBlockStorageVolumeV3Attachments(v.Attachments)
 	log.Printf("[DEBUG] openstack_blockstorage_volume_v3 %s attachments: %#v", d.Id(), attachments)
 	if err := d.Set("attachment", attachments); err != nil {
@@ -489,4 +480,31 @@ func resourceBlockStorageVolumeV3Delete(ctx context.Context, d *schema.ResourceD
 	}
 
 	return nil
+}
+
+func resourceBlockStorageVolumeV3Import(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	config := meta.(*Config)
+	blockStorageClient, err := config.BlockStorageV3Client(ctx, GetRegion(d, config))
+	if err != nil {
+		return nil, fmt.Errorf("error creating OpenStack block storage client: %s", err)
+	}
+
+	v, err := volumes.Get(ctx, blockStorageClient, d.Id()).Extract()
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving openstack_blockstorage_volume_v3 %s: %s", d.Id(), err)
+	}
+
+	log.Printf("[DEBUG] Retrieved openstack_blockstorage_volume_v3 %s: %#v", d.Id(), v)
+
+	// As we can have a snapshot_id and a image_id when the VolumeImageMetadata is stored in the snapshot for example,
+	// we want to exclude image_id when one of the others ids is used
+	_, snapshotExists := d.GetOk("snapshot_id")
+	_, backupExists := d.GetOk("backup_id")
+	_, sourcevolExists := d.GetOk("source_vol_id")
+
+	if v.VolumeImageMetadata != nil && !snapshotExists && !backupExists && !sourcevolExists {
+		d.Set("image_id", v.VolumeImageMetadata["image_id"])
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/openstack/resource_openstack_blockstorage_volume_v3.go
+++ b/openstack/resource_openstack_blockstorage_volume_v3.go
@@ -283,6 +283,16 @@ func resourceBlockStorageVolumeV3Read(ctx context.Context, d *schema.ResourceDat
 		d.Set("volume_retype_policy", "never")
 	}
 
+	// As we can have a snapshot_id with an image_id if the VolumeImageMetadata is stored in the snapshot for exemple,
+	// we want to exclude image_id when one of the others ids are used
+	_, snapshotExists := d.GetOk("snapshot_id")
+	_, backupExists := d.GetOk("backup_id")
+	_, sourcevolExists := d.GetOk("source_vol_id")
+
+	if !snapshotExists && !backupExists && !sourcevolExists {
+		d.Set("image_id", v.VolumeImageMetadata["image_id"])
+	}
+
 	attachments := flattenBlockStorageVolumeV3Attachments(v.Attachments)
 	log.Printf("[DEBUG] openstack_blockstorage_volume_v3 %s attachments: %#v", d.Id(), attachments)
 	if err := d.Set("attachment", attachments); err != nil {


### PR DESCRIPTION
This should fix the problem with image_id that was not imported into the state by adding it in the importing process. But this comes with two catches:

- The first one happens when image_id and at other id is present at the same time because of OpenStack keeping ``ImageMetadata`` when using a snapshot or another volume as base, therefore making a conflict who the two ids. To make sure that they are not conflicting each other, image_id is only set if the other ids are not present.
- As of today, OpenStack are accepting an image name on image_id field as there are resolving it internally[1]. But in this scenario, as the import function imports the ID and not the name in ``image_id`` field, Terraform will try to force-recreate the volume when applying. For a workaround, user should be using directly a image_id or get it from ``openstack_images_image_v2`` datasource.

As this is my first contribution, I am not sure if this is the correct solution, so I am open to comment if this PR needs improvement.

Fixes #1265

[1]: https://github.com/openstack/cinder/blob/635bdab2c0d44e95e499a1d13296446171d5e4ef/cinder/api/v3/volumes.py#L364 and https://github.com/openstack/cinder/blob/635bdab2c0d44e95e499a1d13296446171d5e4ef/cinder/api/v2/volumes.py#L136