### PR TITLE
Remove IPv6 bracket notation of openstack_compute_instance_v2.access_…

### DIFF
--- a/openstack/compute_instance_v2.go
+++ b/openstack/compute_instance_v2.go
@@ -291,7 +291,7 @@ func getInstanceAddresses(addresses map[string]interface{}) []InstanceAddresses 
 			if v["OS-EXT-IPS:type"] == "fixed" || v["OS-EXT-IPS:type"] == nil {
 				switch v["version"].(float64) {
 				case 6:
-					instanceNIC.FixedIPv6 = fmt.Sprintf("[%s]", v["addr"].(string))
+					instanceNIC.FixedIPv6 = v["addr"].(string)
 				default:
 					instanceNIC.FixedIPv4 = v["addr"].(string)
 				}

--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -204,14 +204,10 @@ func resourceComputeInstanceV2() *schema.Resource {
 			"access_ip_v4": {
 				Type:     schema.TypeString,
 				Computed: true,
-				Optional: true,
-				ForceNew: false,
 			},
 			"access_ip_v6": {
 				Type:     schema.TypeString,
 				Computed: true,
-				Optional: true,
-				ForceNew: false,
 			},
 			"key_pair": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
…ip_v6

The access_ip_v6 attribute of openstack_compute_instance_v2 usesd IPv6 bracket notion. This is troublesome to use with other Terraform, including but not limited to OpenStack provider, resources.

E.g. the following resources expect a non bracket notation:

* openstack_networking_secgroup_rule_v2.remote_ip_prefix
* openstack_lb_members_v2.address

Fixes #1357