### PR TITLE
networking: add segment_id argument for subnets

### DIFF
--- a/docs/data-sources/networking_subnet_ids_v2.md
+++ b/docs/data-sources/networking_subnet_ids_v2.md
@@ -51,6 +51,9 @@ data "openstack_networking_subnet_ids_v2" "subnets" {
 * `ipv6_ra_mode` - (Optional) The IPv6 Router Advertisement mode. Valid values
   are `dhcpv6-stateful`, `dhcpv6-stateless`, or `slaac`.
 
+* `segment_id` - (Optional) The ID of the segment the subnet belongs to.
+  Available when neutron segment extension is enabled.
+
 * `subnetpool_id` - (Optional) The ID of the subnetpool associated with the subnet.
 
 * `dns_publish_fixed_ip` - (Optional) If the subnet publishes DNS records.

--- a/docs/data-sources/networking_subnet_v2.md
+++ b/docs/data-sources/networking_subnet_v2.md
@@ -49,6 +49,9 @@ data "openstack_networking_subnet_v2" "subnet_1" {
 * `ipv6_ra_mode` - (Optional) The IPv6 Router Advertisement mode. Valid values
   are `dhcpv6-stateful`, `dhcpv6-stateless`, or `slaac`.
 
+* `segment_id` - (Optional) The ID of the segment the subnet belongs to.
+  Available when neutron segment extension is enabled.
+
 * `subnetpool_id` - (Optional) The ID of the subnetpool associated with the subnet.
 
 * `dns_publish_fixed_ip` - (Optional) If the subnet publishes DNS records.

--- a/docs/resources/networking_subnet_v2.md
+++ b/docs/resources/networking_subnet_v2.md
@@ -93,6 +93,10 @@ The following arguments are supported:
 * `service_types` - (Optional) An array of service types used by the subnet.
   Changing this updates the service types for the existing subnet.
 
+* `segment_id` - (Optional) The segment ID of the subnet. This is used to
+  specify which segment the subnet belongs to when using Neutron's routed
+  provider networks. Available when neutron segment extension is enabled.
+
 * `subnetpool_id` - (Optional) The ID of the subnetpool associated with the subnet.
 
 * `value_specs` - (Optional) Map of additional options.
@@ -121,6 +125,7 @@ The following attributes are exported:
 * `enable_dhcp` - See Argument Reference above.
 * `dns_nameservers` - See Argument Reference above.
 * `service_types` - See Argument Reference above.
+* `segment_id` - See Argument Reference above.
 * `subnetpool_id` - See Argument Reference above.
 * `tags` - See Argument Reference above.
 * `all_tags` - The collection of ags assigned on the subnet, which have been

--- a/openstack/data_source_openstack_networking_subnet_ids_v2.go
+++ b/openstack/data_source_openstack_networking_subnet_ids_v2.go
@@ -104,6 +104,11 @@ func dataSourceNetworkingSubnetIDsV2() *schema.Resource {
 				}, false),
 			},
 
+			"segment_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"subnetpool_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -192,6 +197,10 @@ func dataSourceNetworkingSubnetIDsV2Read(ctx context.Context, d *schema.Resource
 
 	if v, ok := d.GetOk("ipv6_ra_mode"); ok {
 		listOpts.IPv6RAMode = v.(string)
+	}
+
+	if v, ok := d.GetOk("segment_id"); ok {
+		listOpts.SegmentID = v.(string)
 	}
 
 	if v, ok := d.GetOk("subnetpool_id"); ok {

--- a/openstack/data_source_openstack_networking_subnet_v2.go
+++ b/openstack/data_source_openstack_networking_subnet_v2.go
@@ -156,6 +156,12 @@ func dataSourceNetworkingSubnetV2() *schema.Resource {
 				}, false),
 			},
 
+			"segment_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+
 			"subnetpool_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -231,6 +237,10 @@ func dataSourceNetworkingSubnetV2Read(ctx context.Context, d *schema.ResourceDat
 		listOpts.IPv6RAMode = v.(string)
 	}
 
+	if v, ok := d.GetOk("segment_id"); ok {
+		listOpts.SegmentID = v.(string)
+	}
+
 	if v, ok := d.GetOk("subnetpool_id"); ok {
 		listOpts.SubnetPoolID = v.(string)
 	}
@@ -280,6 +290,7 @@ func dataSourceNetworkingSubnetV2Read(ctx context.Context, d *schema.ResourceDat
 	d.Set("ipv6_ra_mode", subnet.IPv6RAMode)
 	d.Set("gateway_ip", subnet.GatewayIP)
 	d.Set("enable_dhcp", subnet.EnableDHCP)
+	d.Set("segment_id", subnet.SegmentID)
 	d.Set("subnetpool_id", subnet.SubnetPoolID)
 	d.Set("dns_publish_fixed_ip", subnet.DNSPublishFixedIP)
 	d.Set("all_tags", subnet.Tags)

--- a/openstack/resource_openstack_networking_subnet_v2.go
+++ b/openstack/resource_openstack_networking_subnet_v2.go
@@ -164,6 +164,11 @@ func resourceNetworkingSubnetV2() *schema.Resource {
 				}, false),
 			},
 
+			"segment_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"subnetpool_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -226,6 +231,7 @@ func resourceNetworkingSubnetV2Create(ctx context.Context, d *schema.ResourceDat
 			AllocationPools: expandNetworkingSubnetV2AllocationPools(allocationPool),
 			DNSNameservers:  expandToStringSlice(d.Get("dns_nameservers").([]interface{})),
 			ServiceTypes:    expandToStringSlice(d.Get("service_types").([]interface{})),
+			SegmentID:       d.Get("segment_id").(string),
 			SubnetPoolID:    d.Get("subnetpool_id").(string),
 			IPVersion:       gophercloud.IPVersion(d.Get("ip_version").(int)),
 		},
@@ -337,6 +343,7 @@ func resourceNetworkingSubnetV2Read(ctx context.Context, d *schema.ResourceData,
 	d.Set("network_id", s.NetworkID)
 	d.Set("ipv6_address_mode", s.IPv6AddressMode)
 	d.Set("ipv6_ra_mode", s.IPv6RAMode)
+	d.Set("segment_id", s.SegmentID)
 	d.Set("subnetpool_id", s.SubnetPoolID)
 	d.Set("dns_publish_fixed_ip", s.DNSPublishFixedIP)
 
@@ -425,6 +432,12 @@ func resourceNetworkingSubnetV2Update(ctx context.Context, d *schema.ResourceDat
 	if d.HasChange("allocation_pool") {
 		hasChange = true
 		updateOpts.AllocationPools = expandNetworkingSubnetV2AllocationPools(d.Get("allocation_pool").(*schema.Set).List())
+	}
+
+	if d.HasChange("segment_id") {
+		hasChange = true
+		v := d.Get("segment_id").(string)
+		updateOpts.SegmentID = &v
 	}
 
 	if d.HasChange("dns_publish_fixed_ip") {


### PR DESCRIPTION
Part of the #1812 

This PR doesn't include tests because gophercloud doesn't yet support network segments. But setting the subnet's `segment_id` should be possible, if you know the corresponding ID.