### PR TITLE
core: remove initial delay before refresh state func

### DIFF
--- a/openstack/lb_v2_shared.go
+++ b/openstack/lb_v2_shared.go
@@ -179,7 +179,7 @@ func waitForLBV2L7Rule(ctx context.Context, lbClient *gophercloud.ServiceClient,
 		Pending:    pending,
 		Refresh:    resourceLBV2L7RuleRefreshFunc(ctx, lbClient, lbID, parentL7policy.ID, l7rule),
 		Timeout:    timeout,
-		Delay:      1 * time.Second,
+		Delay:      0,
 		MinTimeout: 1 * time.Second,
 	}
 
@@ -259,7 +259,7 @@ func waitForLBV2Listener(ctx context.Context, lbClient *gophercloud.ServiceClien
 		Pending:    pending,
 		Refresh:    resourceLBV2ListenerRefreshFunc(ctx, lbClient, lbID, listener),
 		Timeout:    timeout,
-		Delay:      1 * time.Second,
+		Delay:      0,
 		MinTimeout: 1 * time.Second,
 	}
 
@@ -335,7 +335,7 @@ func waitForLBV2Pool(ctx context.Context, lbClient *gophercloud.ServiceClient, p
 		Pending:    pending,
 		Refresh:    resourceLBV2PoolRefreshFunc(ctx, lbClient, lbID, pool),
 		Timeout:    timeout,
-		Delay:      1 * time.Second,
+		Delay:      0,
 		MinTimeout: 1 * time.Second,
 	}
 
@@ -483,7 +483,7 @@ func waitForLBV2L7Policy(ctx context.Context, lbClient *gophercloud.ServiceClien
 		Pending:    pending,
 		Refresh:    resourceLBV2L7PolicyRefreshFunc(ctx, lbClient, lbID, l7policy),
 		Timeout:    timeout,
-		Delay:      1 * time.Second,
+		Delay:      0,
 		MinTimeout: 1 * time.Second,
 	}
 
@@ -538,7 +538,7 @@ func waitForLBV2Member(ctx context.Context, lbClient *gophercloud.ServiceClient,
 		Pending:    pending,
 		Refresh:    resourceLBV2MemberRefreshFunc(ctx, lbClient, lbID, parentPool.ID, member),
 		Timeout:    timeout,
-		Delay:      1 * time.Second,
+		Delay:      0,
 		MinTimeout: 1 * time.Second,
 	}
 
@@ -593,7 +593,7 @@ func waitForLBV2Monitor(ctx context.Context, lbClient *gophercloud.ServiceClient
 		Pending:    pending,
 		Refresh:    resourceLBV2MonitorRefreshFunc(ctx, lbClient, lbID, monitor),
 		Timeout:    timeout,
-		Delay:      1 * time.Second,
+		Delay:      0,
 		MinTimeout: 1 * time.Second,
 	}
 

--- a/openstack/networking_secgroup_v2.go
+++ b/openstack/networking_secgroup_v2.go
@@ -15,34 +15,34 @@ func networkingSecgroupV2StateRefreshFuncDelete(ctx context.Context, networkingC
 	return func() (any, string, error) {
 		log.Printf("[DEBUG] Attempting to delete openstack_networking_secgroup_v2 %s", id)
 
-		r, err := groups.Get(ctx, networkingClient, id).Extract()
+		err := groups.Delete(ctx, networkingClient, id).ExtractErr()
 		if err != nil {
 			if gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
 				log.Printf("[DEBUG] Successfully deleted openstack_networking_secgroup_v2 %s", id)
 
-				return r, "DELETED", nil
-			}
-
-			return r, "ACTIVE", err
-		}
-
-		err = groups.Delete(ctx, networkingClient, id).ExtractErr()
-		if err != nil {
-			if gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
-				log.Printf("[DEBUG] Successfully deleted openstack_networking_secgroup_v2 %s", id)
-
-				return r, "DELETED", nil
+				return "", "DELETED", nil
 			}
 
 			if gophercloud.ResponseCodeIs(err, http.StatusConflict) {
-				return r, "ACTIVE", nil
+				return "", "ACTIVE", nil
 			}
 
-			return r, "ACTIVE", err
+			return "", "ACTIVE", err
+		}
+
+		_, err = groups.Get(ctx, networkingClient, id).Extract()
+		if err != nil {
+			if gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
+				log.Printf("[DEBUG] Successfully deleted openstack_networking_secgroup_v2 %s", id)
+
+				return "", "DELETED", nil
+			}
+
+			return "", "ACTIVE", err
 		}
 
 		log.Printf("[DEBUG] openstack_networking_secgroup_v2 %s is still active", id)
 
-		return r, "ACTIVE", nil
+		return "", "ACTIVE", nil
 	}
 }

--- a/openstack/resource_openstack_blockstorage_volume_attach_v3.go
+++ b/openstack/resource_openstack_blockstorage_volume_attach_v3.go
@@ -229,7 +229,7 @@ func resourceBlockStorageVolumeAttachV3Create(ctx context.Context, d *schema.Res
 		Target:     []string{"in-use"},
 		Refresh:    blockStorageVolumeV3StateRefreshFunc(ctx, client, volumeID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      10 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -380,7 +380,7 @@ func resourceBlockStorageVolumeAttachV3Delete(ctx context.Context, d *schema.Res
 		Target:     []string{"available"},
 		Refresh:    blockStorageVolumeV3StateRefreshFunc(ctx, client, volumeID),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      10 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_blockstorage_volume_v3.go
+++ b/openstack/resource_openstack_blockstorage_volume_v3.go
@@ -240,7 +240,7 @@ func resourceBlockStorageVolumeV3Create(ctx context.Context, d *schema.ResourceD
 		Target:     []string{"available"},
 		Refresh:    blockStorageVolumeV3StateRefreshFunc(ctx, blockStorageClient, v.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      10 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -349,7 +349,7 @@ func resourceBlockStorageVolumeV3Update(ctx context.Context, d *schema.ResourceD
 			Target:     []string{"available", "in-use"},
 			Refresh:    blockStorageVolumeV3StateRefreshFunc(ctx, blockStorageClient, d.Id()),
 			Timeout:    d.Timeout(schema.TimeoutCreate),
-			Delay:      10 * time.Second,
+			Delay:      0,
 			MinTimeout: 3 * time.Second,
 		}
 
@@ -381,7 +381,7 @@ func resourceBlockStorageVolumeV3Update(ctx context.Context, d *schema.ResourceD
 			Target:     []string{"available", "in-use"},
 			Refresh:    blockStorageVolumeV3StateRefreshFunc(ctx, blockStorageClient, d.Id()),
 			Timeout:    d.Timeout(schema.TimeoutUpdate),
-			Delay:      10 * time.Second,
+			Delay:      0,
 			MinTimeout: 3 * time.Second,
 		}
 
@@ -450,7 +450,7 @@ func resourceBlockStorageVolumeV3Delete(ctx context.Context, d *schema.ResourceD
 			Target:     []string{"available", "deleted"},
 			Refresh:    blockStorageVolumeV3StateRefreshFunc(ctx, blockStorageClient, d.Id()),
 			Timeout:    10 * time.Minute,
-			Delay:      10 * time.Second,
+			Delay:      0,
 			MinTimeout: 3 * time.Second,
 		}
 
@@ -475,7 +475,7 @@ func resourceBlockStorageVolumeV3Delete(ctx context.Context, d *schema.ResourceD
 		Target:     []string{"deleted"},
 		Refresh:    blockStorageVolumeV3StateRefreshFunc(ctx, blockStorageClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      10 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -601,7 +601,7 @@ func resourceComputeInstanceV2Create(ctx context.Context, d *schema.ResourceData
 		Target:     []string{"ACTIVE"},
 		Refresh:    ServerV2StateRefreshFunc(ctx, computeClient, server.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      10 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -633,7 +633,7 @@ func resourceComputeInstanceV2Create(ctx context.Context, d *schema.ResourceData
 			Target:     []string{"SHUTOFF"},
 			Refresh:    ServerV2StateRefreshFunc(ctx, computeClient, d.Id()),
 			Timeout:    d.Timeout(schema.TimeoutCreate),
-			Delay:      10 * time.Second,
+			Delay:      0,
 			MinTimeout: 3 * time.Second,
 		}
 
@@ -817,7 +817,7 @@ func resourceComputeInstanceV2Update(ctx context.Context, d *schema.ResourceData
 				Target:     []string{"SHELVED_OFFLOADED"},
 				Refresh:    ServerV2StateRefreshFunc(ctx, computeClient, d.Id()),
 				Timeout:    d.Timeout(schema.TimeoutUpdate),
-				Delay:      10 * time.Second,
+				Delay:      0,
 				MinTimeout: 3 * time.Second,
 			}
 
@@ -840,7 +840,7 @@ func resourceComputeInstanceV2Update(ctx context.Context, d *schema.ResourceData
 				Target:     []string{"PAUSED"},
 				Refresh:    ServerV2StateRefreshFunc(ctx, computeClient, d.Id()),
 				Timeout:    d.Timeout(schema.TimeoutUpdate),
-				Delay:      10 * time.Second,
+				Delay:      0,
 				MinTimeout: 3 * time.Second,
 			}
 
@@ -863,7 +863,7 @@ func resourceComputeInstanceV2Update(ctx context.Context, d *schema.ResourceData
 				Target:     []string{"SHUTOFF"},
 				Refresh:    ServerV2StateRefreshFunc(ctx, computeClient, d.Id()),
 				Timeout:    d.Timeout(schema.TimeoutUpdate),
-				Delay:      10 * time.Second,
+				Delay:      0,
 				MinTimeout: 3 * time.Second,
 			}
 
@@ -902,7 +902,7 @@ func resourceComputeInstanceV2Update(ctx context.Context, d *schema.ResourceData
 				Target:     []string{"ACTIVE"},
 				Refresh:    ServerV2StateRefreshFunc(ctx, computeClient, d.Id()),
 				Timeout:    d.Timeout(schema.TimeoutUpdate),
-				Delay:      10 * time.Second,
+				Delay:      0,
 				MinTimeout: 3 * time.Second,
 			}
 
@@ -1044,7 +1044,7 @@ func resourceComputeInstanceV2Update(ctx context.Context, d *schema.ResourceData
 				Target:     []string{"ACTIVE", "SHUTOFF"},
 				Refresh:    ServerV2StateRefreshFunc(ctx, computeClient, d.Id()),
 				Timeout:    d.Timeout(schema.TimeoutUpdate),
-				Delay:      10 * time.Second,
+				Delay:      0,
 				MinTimeout: 3 * time.Second,
 			}
 
@@ -1058,7 +1058,7 @@ func resourceComputeInstanceV2Update(ctx context.Context, d *schema.ResourceData
 				Target:     []string{"VERIFY_RESIZE"},
 				Refresh:    ServerV2StateRefreshFunc(ctx, computeClient, d.Id()),
 				Timeout:    d.Timeout(schema.TimeoutUpdate),
-				Delay:      10 * time.Second,
+				Delay:      0,
 				MinTimeout: 3 * time.Second,
 			}
 
@@ -1080,7 +1080,7 @@ func resourceComputeInstanceV2Update(ctx context.Context, d *schema.ResourceData
 				Target:     []string{"ACTIVE", "SHUTOFF"},
 				Refresh:    ServerV2StateRefreshFunc(ctx, computeClient, d.Id()),
 				Timeout:    d.Timeout(schema.TimeoutUpdate),
-				Delay:      10 * time.Second,
+				Delay:      0,
 				MinTimeout: 3 * time.Second,
 			}
 
@@ -1132,7 +1132,7 @@ func resourceComputeInstanceV2Update(ctx context.Context, d *schema.ResourceData
 			Target:     []string{"ACTIVE", "SHUTOFF"},
 			Refresh:    ServerV2StateRefreshFunc(ctx, computeClient, d.Id()),
 			Timeout:    d.Timeout(schema.TimeoutUpdate),
-			Delay:      10 * time.Second,
+			Delay:      0,
 			MinTimeout: 3 * time.Second,
 		}
 
@@ -1177,7 +1177,7 @@ func resourceComputeInstanceV2Delete(ctx context.Context, d *schema.ResourceData
 				Target:     []string{"SHUTOFF"},
 				Refresh:    ServerV2StateRefreshFunc(ctx, computeClient, d.Id()),
 				Timeout:    d.Timeout(schema.TimeoutDelete),
-				Delay:      10 * time.Second,
+				Delay:      0,
 				MinTimeout: 3 * time.Second,
 			}
 
@@ -1211,7 +1211,7 @@ func resourceComputeInstanceV2Delete(ctx context.Context, d *schema.ResourceData
 						Target:     []string{"DETACHED"},
 						Refresh:    computeInterfaceAttachV2DetachFunc(ctx, computeClient, d.Id(), network.Port),
 						Timeout:    d.Timeout(schema.TimeoutDelete),
-						Delay:      5 * time.Second,
+						Delay:      0,
 						MinTimeout: 5 * time.Second,
 					}
 					if _, err = stateConf.WaitForStateContext(ctx); err != nil {
@@ -1246,7 +1246,7 @@ func resourceComputeInstanceV2Delete(ctx context.Context, d *schema.ResourceData
 		Target:     []string{"DELETED", "SOFT_DELETED"},
 		Refresh:    ServerV2StateRefreshFunc(ctx, computeClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      10 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_compute_interface_attach_v2.go
+++ b/openstack/resource_openstack_compute_interface_attach_v2.go
@@ -115,7 +115,7 @@ func resourceComputeInterfaceAttachV2Create(ctx context.Context, d *schema.Resou
 		Target:     []string{"ATTACHED"},
 		Refresh:    computeInterfaceAttachV2AttachFunc(ctx, computeClient, instanceID, attachment.PortID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 5 * time.Second,
 	}
 
@@ -183,7 +183,7 @@ func resourceComputeInterfaceAttachV2Delete(ctx context.Context, d *schema.Resou
 		Target:     []string{"DETACHED"},
 		Refresh:    computeInterfaceAttachV2DetachFunc(ctx, computeClient, instanceID, attachmentID),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 5 * time.Second,
 	}
 

--- a/openstack/resource_openstack_compute_volume_attach_v2.go
+++ b/openstack/resource_openstack_compute_volume_attach_v2.go
@@ -165,7 +165,7 @@ func resourceComputeVolumeAttachV2Create(ctx context.Context, d *schema.Resource
 		Target:     []string{"ATTACHED"},
 		Refresh:    computeVolumeAttachV2AttachFunc(ctx, computeClient, blockStorageClient, instanceID, attachment.ID, volumeID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -228,7 +228,7 @@ func resourceComputeVolumeAttachV2Delete(ctx context.Context, d *schema.Resource
 		Target:     []string{"DETACHED"},
 		Refresh:    computeVolumeAttachV2DetachFunc(ctx, computeClient, instanceID, attachmentID),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_containerinfra_cluster_v1.go
+++ b/openstack/resource_openstack_containerinfra_cluster_v1.go
@@ -302,7 +302,7 @@ func resourceContainerInfraClusterV1Create(ctx context.Context, d *schema.Resour
 		Target:       []string{"CREATE_COMPLETE"},
 		Refresh:      containerInfraClusterV1StateRefreshFunc(ctx, containerInfraClient, s),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
-		Delay:        1 * time.Minute,
+		Delay:        0,
 		PollInterval: 20 * time.Second,
 	}
 
@@ -445,7 +445,7 @@ func resourceContainerInfraClusterV1Update(ctx context.Context, d *schema.Resour
 			Target:       []string{"UPDATE_COMPLETE"},
 			Refresh:      containerInfraClusterV1StateRefreshFunc(ctx, containerInfraClient, d.Id()),
 			Timeout:      d.Timeout(schema.TimeoutUpdate),
-			Delay:        1 * time.Minute,
+			Delay:        0,
 			PollInterval: 20 * time.Second,
 		}
 
@@ -486,7 +486,7 @@ func resourceContainerInfraClusterV1Update(ctx context.Context, d *schema.Resour
 			Target:       []string{"UPDATE_COMPLETE"},
 			Refresh:      containerInfraClusterV1StateRefreshFunc(ctx, containerInfraClient, d.Id()),
 			Timeout:      d.Timeout(schema.TimeoutUpdate),
-			Delay:        1 * time.Minute,
+			Delay:        0,
 			PollInterval: 20 * time.Second,
 		}
 
@@ -517,7 +517,7 @@ func resourceContainerInfraClusterV1Delete(ctx context.Context, d *schema.Resour
 		Target:       []string{"DELETE_COMPLETE"},
 		Refresh:      containerInfraClusterV1StateRefreshFunc(ctx, containerInfraClient, d.Id()),
 		Timeout:      d.Timeout(schema.TimeoutDelete),
-		Delay:        30 * time.Second,
+		Delay:        0,
 		PollInterval: 10 * time.Second,
 	}
 

--- a/openstack/resource_openstack_containerinfra_nodegroup_v1.go
+++ b/openstack/resource_openstack_containerinfra_nodegroup_v1.go
@@ -200,7 +200,7 @@ func resourceContainerInfraNodeGroupV1Create(ctx context.Context, d *schema.Reso
 		Target:       []string{"CREATE_COMPLETE"},
 		Refresh:      containerInfraNodeGroupV1StateRefreshFunc(ctx, containerInfraClient, clusterID, nodeGroup.UUID),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
-		Delay:        1 * time.Minute,
+		Delay:        0,
 		PollInterval: 20 * time.Second,
 	}
 
@@ -336,7 +336,7 @@ func resourceContainerInfraNodeGroupV1Update(ctx context.Context, d *schema.Reso
 			Target:       []string{"UPDATE_COMPLETE"},
 			Refresh:      containerInfraNodeGroupV1StateRefreshFunc(ctx, containerInfraClient, clusterID, nodeGroupID),
 			Timeout:      d.Timeout(schema.TimeoutUpdate),
-			Delay:        1 * time.Minute,
+			Delay:        0,
 			PollInterval: 20 * time.Second,
 		}
 
@@ -374,7 +374,7 @@ func resourceContainerInfraNodeGroupV1Delete(ctx context.Context, d *schema.Reso
 		Target:       []string{"DELETE_COMPLETE"},
 		Refresh:      containerInfraNodeGroupV1StateRefreshFunc(ctx, containerInfraClient, clusterID, nodeGroupID),
 		Timeout:      d.Timeout(schema.TimeoutDelete),
-		Delay:        30 * time.Second,
+		Delay:        0,
 		PollInterval: 10 * time.Second,
 	}
 

--- a/openstack/resource_openstack_db_configuration_v1.go
+++ b/openstack/resource_openstack_db_configuration_v1.go
@@ -130,7 +130,7 @@ func resourceDatabaseConfigurationV1Create(ctx context.Context, d *schema.Resour
 		Target:     []string{"ACTIVE"},
 		Refresh:    databaseConfigurationV1StateRefreshFunc(ctx, databaseV1Client, cgroup.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      10 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -185,7 +185,7 @@ func resourceDatabaseConfigurationV1Delete(ctx context.Context, d *schema.Resour
 		Target:     []string{"DELETED"},
 		Refresh:    databaseConfigurationV1StateRefreshFunc(ctx, databaseV1Client, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      10 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_db_database_v1.go
+++ b/openstack/resource_openstack_db_database_v1.go
@@ -83,7 +83,7 @@ func resourceDatabaseDatabaseV1Create(ctx context.Context, d *schema.ResourceDat
 		Target:     []string{"ACTIVE"},
 		Refresh:    databaseDatabaseV1StateRefreshFunc(ctx, databaseV1Client, instanceID, dbName),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      10 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_db_instance_v1.go
+++ b/openstack/resource_openstack_db_instance_v1.go
@@ -253,7 +253,7 @@ func resourceDatabaseInstanceV1Create(ctx context.Context, d *schema.ResourceDat
 		Target:     []string{"ACTIVE", "HEALTHY"},
 		Refresh:    databaseInstanceV1StateRefreshFunc(ctx, databaseV1Client, instance.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      10 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -351,7 +351,7 @@ func resourceDatabaseInstanceV1Delete(ctx context.Context, d *schema.ResourceDat
 		Target:     []string{"DELETED"},
 		Refresh:    databaseInstanceV1StateRefreshFunc(ctx, databaseV1Client, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      10 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_db_user_v1.go
+++ b/openstack/resource_openstack_db_user_v1.go
@@ -96,7 +96,7 @@ func resourceDatabaseUserV1Create(ctx context.Context, d *schema.ResourceData, m
 		Target:     []string{"ACTIVE"},
 		Refresh:    databaseUserV1StateRefreshFunc(ctx, databaseV1Client, instanceID, userName),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      10 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_dns_recordset_v2.go
+++ b/openstack/resource_openstack_dns_recordset_v2.go
@@ -144,7 +144,7 @@ func resourceDNSRecordSetV2Create(ctx context.Context, d *schema.ResourceData, m
 			Pending:    []string{"PENDING"},
 			Refresh:    dnsRecordSetV2RefreshFunc(ctx, dnsClient, zoneID, n.ID),
 			Timeout:    d.Timeout(schema.TimeoutCreate),
-			Delay:      5 * time.Second,
+			Delay:      0,
 			MinTimeout: 3 * time.Second,
 		}
 
@@ -271,7 +271,7 @@ func resourceDNSRecordSetV2Update(ctx context.Context, d *schema.ResourceData, m
 			Pending:    []string{"PENDING"},
 			Refresh:    dnsRecordSetV2RefreshFunc(ctx, dnsClient, zoneID, recordsetID),
 			Timeout:    d.Timeout(schema.TimeoutUpdate),
-			Delay:      5 * time.Second,
+			Delay:      0,
 			MinTimeout: 3 * time.Second,
 		}
 
@@ -314,7 +314,7 @@ func resourceDNSRecordSetV2Delete(ctx context.Context, d *schema.ResourceData, m
 			Pending:    []string{"ACTIVE", "PENDING"},
 			Refresh:    dnsRecordSetV2RefreshFunc(ctx, dnsClient, zoneID, recordsetID),
 			Timeout:    d.Timeout(schema.TimeoutDelete),
-			Delay:      5 * time.Second,
+			Delay:      0,
 			MinTimeout: 3 * time.Second,
 		}
 

--- a/openstack/resource_openstack_dns_transfer_accept_v2.go
+++ b/openstack/resource_openstack_dns_transfer_accept_v2.go
@@ -103,7 +103,7 @@ func resourceDNSTransferAcceptV2Create(ctx context.Context, d *schema.ResourceDa
 		Pending:    []string{"PENDING"},
 		Refresh:    dnsTransferAcceptV2RefreshFunc(ctx, dnsClient, n.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -163,7 +163,7 @@ func resourceDNSTransferAcceptV2Delete(ctx context.Context, d *schema.ResourceDa
 		Pending:    []string{"ACTIVE"},
 		Refresh:    dnsTransferAcceptV2RefreshFunc(ctx, dnsClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_dns_transfer_request_v2.go
+++ b/openstack/resource_openstack_dns_transfer_request_v2.go
@@ -115,7 +115,7 @@ func resourceDNSTransferRequestV2Create(ctx context.Context, d *schema.ResourceD
 		Pending:    []string{"PENDING"},
 		Refresh:    dnsTransferRequestV2RefreshFunc(ctx, dnsClient, n.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -198,7 +198,7 @@ func resourceDNSTransferRequestV2Update(ctx context.Context, d *schema.ResourceD
 		Pending:    []string{"PENDING"},
 		Refresh:    dnsTransferRequestV2RefreshFunc(ctx, dnsClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutUpdate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -233,7 +233,7 @@ func resourceDNSTransferRequestV2Delete(ctx context.Context, d *schema.ResourceD
 		Pending:    []string{"ACTIVE", "PENDING"},
 		Refresh:    dnsTransferRequestV2RefreshFunc(ctx, dnsClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_dns_zone_v2.go
+++ b/openstack/resource_openstack_dns_zone_v2.go
@@ -154,7 +154,7 @@ func resourceDNSZoneV2Create(ctx context.Context, d *schema.ResourceData, meta a
 		Pending:    []string{"PENDING"},
 		Refresh:    dnsZoneV2RefreshFunc(ctx, dnsClient, n.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -270,7 +270,7 @@ func resourceDNSZoneV2Update(ctx context.Context, d *schema.ResourceData, meta a
 		Pending:    []string{"PENDING"},
 		Refresh:    dnsZoneV2RefreshFunc(ctx, dnsClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutUpdate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -309,7 +309,7 @@ func resourceDNSZoneV2Delete(ctx context.Context, d *schema.ResourceData, meta a
 		Pending:    []string{"ACTIVE", "PENDING"},
 		Refresh:    dnsZoneV2RefreshFunc(ctx, dnsClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_images_image_v2.go
+++ b/openstack/resource_openstack_images_image_v2.go
@@ -332,7 +332,7 @@ func resourceImagesImageV2Create(ctx context.Context, d *schema.ResourceData, me
 		Target:     []string{string(images.ImageStatusActive)},
 		Refresh:    resourceImagesImageV2RefreshFunc(ctx, imageClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      10 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_networking_addressscope_v2.go
+++ b/openstack/resource_openstack_networking_addressscope_v2.go
@@ -92,7 +92,7 @@ func resourceNetworkingAddressScopeV2Create(ctx context.Context, d *schema.Resou
 		Target:     []string{"ACTIVE"},
 		Refresh:    resourceNetworkingAddressScopeV2StateRefreshFunc(ctx, networkingClient, a.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -186,7 +186,7 @@ func resourceNetworkingAddressScopeV2Delete(ctx context.Context, d *schema.Resou
 		Target:     []string{"DELETED"},
 		Refresh:    resourceNetworkingAddressScopeV2StateRefreshFunc(ctx, networkingClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_networking_floatingip_associate_v2_test.go
+++ b/openstack/resource_openstack_networking_floatingip_associate_v2_test.go
@@ -139,7 +139,7 @@ resource "openstack_networking_port_v2" "port_1" {
   network_id = "${openstack_networking_subnet_v2.subnet_1.network_id}"
 
   fixed_ip {
-    subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+    subnet_id = openstack_networking_router_interface_v2.router_interface_1.subnet_id
     ip_address = "192.168.199.20"
   }
 }
@@ -151,6 +151,7 @@ resource "openstack_networking_floatingip_v2" "fip_1" {
 resource "openstack_networking_floatingip_associate_v2" "fip_1" {
   floating_ip = "${openstack_networking_floatingip_v2.fip_1.address}"
   port_id = "${openstack_networking_port_v2.port_1.id}"
+
 }
 `, osExtGwID, osPoolName)
 }
@@ -184,12 +185,12 @@ resource "openstack_networking_port_v2" "port_1" {
   network_id = "${openstack_networking_subnet_v2.subnet_1.network_id}"
 
   fixed_ip {
-    subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+    subnet_id = openstack_networking_router_interface_v2.router_interface_1.subnet_id
     ip_address = "192.168.199.20"
   }
 
   fixed_ip {
-    subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+    subnet_id = openstack_networking_router_interface_v2.router_interface_1.subnet_id
     ip_address = "192.168.199.21"
   }
 }
@@ -235,12 +236,12 @@ resource "openstack_networking_port_v2" "port_1" {
   network_id = "${openstack_networking_subnet_v2.subnet_1.network_id}"
 
   fixed_ip {
-    subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+    subnet_id = openstack_networking_router_interface_v2.router_interface_1.subnet_id
     ip_address = "192.168.199.20"
   }
 
   fixed_ip {
-    subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+    subnet_id = openstack_networking_router_interface_v2.router_interface_1.subnet_id
     ip_address = "192.168.199.21"
   }
 }

--- a/openstack/resource_openstack_networking_floatingip_v2.go
+++ b/openstack/resource_openstack_networking_floatingip_v2.go
@@ -224,7 +224,7 @@ func resourceNetworkFloatingIPV2Create(ctx context.Context, d *schema.ResourceDa
 		Target:     []string{"ACTIVE", "DOWN"},
 		Refresh:    networkingFloatingIPV2StateRefreshFunc(ctx, networkingClient, fip.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -367,7 +367,7 @@ func resourceNetworkFloatingIPV2Delete(ctx context.Context, d *schema.ResourceDa
 		Target:     []string{"DELETED"},
 		Refresh:    networkingFloatingIPV2StateRefreshFunc(ctx, networkingClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_networking_floatingip_v2_test.go
+++ b/openstack/resource_openstack_networking_floatingip_v2_test.go
@@ -206,12 +206,12 @@ resource "openstack_networking_port_v2" "port_1" {
   network_id = "${openstack_networking_subnet_v2.subnet_1.network_id}"
 
   fixed_ip {
-    subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+    subnet_id = openstack_networking_router_interface_v2.router_interface_1.subnet_id
     ip_address = "192.168.199.10"
   }
 
   fixed_ip {
-    subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+    subnet_id = openstack_networking_router_interface_v2.router_interface_1.subnet_id
     ip_address = "192.168.199.20"
   }
 }
@@ -254,12 +254,12 @@ resource "openstack_networking_port_v2" "port_1" {
   network_id = "${openstack_networking_subnet_v2.subnet_1.network_id}"
 
   fixed_ip {
-    subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+    subnet_id = openstack_networking_router_interface_v2.router_interface_1.subnet_id
     ip_address = "192.168.199.10"
   }
 
   fixed_ip {
-    subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+    subnet_id = openstack_networking_router_interface_v2.router_interface_1.subnet_id
     ip_address = "192.168.199.20"
   }
 }

--- a/openstack/resource_openstack_networking_network_v2.go
+++ b/openstack/resource_openstack_networking_network_v2.go
@@ -278,7 +278,7 @@ func resourceNetworkingNetworkV2Create(ctx context.Context, d *schema.ResourceDa
 		Target:     []string{"ACTIVE", "DOWN"},
 		Refresh:    resourceNetworkingNetworkV2StateRefreshFunc(ctx, networkingClient, n.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -474,7 +474,7 @@ func resourceNetworkingNetworkV2Delete(ctx context.Context, d *schema.ResourceDa
 		Target:     []string{"DELETED"},
 		Refresh:    resourceNetworkingNetworkV2StateRefreshFunc(ctx, networkingClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_networking_port_v2.go
+++ b/openstack/resource_openstack_networking_port_v2.go
@@ -404,7 +404,7 @@ func resourceNetworkingPortV2Create(ctx context.Context, d *schema.ResourceData,
 		Target:     []string{"ACTIVE", "DOWN"},
 		Refresh:    resourceNetworkingPortV2StateRefreshFunc(ctx, networkingClient, port.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -702,7 +702,7 @@ func resourceNetworkingPortV2Delete(ctx context.Context, d *schema.ResourceData,
 		Target:     []string{"DELETED"},
 		Refresh:    resourceNetworkingPortV2StateRefreshFunc(ctx, networkingClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_networking_portforwarding_v2.go
+++ b/openstack/resource_openstack_networking_portforwarding_v2.go
@@ -101,7 +101,7 @@ func resourceNetworkPortForwardingV2Create(ctx context.Context, d *schema.Resour
 		Target:     []string{"ACTIVE"},
 		Refresh:    networkingPortForwardingV2StateRefreshFunc(ctx, networkingClient, fipID, pf.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -220,7 +220,7 @@ func resourceNetworkPortForwardingV2Delete(ctx context.Context, d *schema.Resour
 		Target:     []string{"DELETED"},
 		Refresh:    networkingPortForwardingV2StateRefreshFunc(ctx, networkingClient, fipID, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_networking_qos_bandwidth_limit_rule_v2.go
+++ b/openstack/resource_openstack_networking_qos_bandwidth_limit_rule_v2.go
@@ -90,7 +90,7 @@ func resourceNetworkingQoSBandwidthLimitRuleV2Create(ctx context.Context, d *sch
 		Target:     []string{"ACTIVE"},
 		Refresh:    networkingQoSBandwidthLimitRuleV2StateRefreshFunc(ctx, networkingClient, qosPolicyID, r.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -204,7 +204,7 @@ func resourceNetworkingQoSBandwidthLimitRuleV2Delete(ctx context.Context, d *sch
 		Target:     []string{"DELETED"},
 		Refresh:    networkingQoSBandwidthLimitRuleV2StateRefreshFunc(ctx, networkingClient, qosPolicyID, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_networking_qos_dscp_marking_rule_v2.go
+++ b/openstack/resource_openstack_networking_qos_dscp_marking_rule_v2.go
@@ -75,7 +75,7 @@ func resourceNetworkingQoSDSCPMarkingRuleV2Create(ctx context.Context, d *schema
 		Target:     []string{"ACTIVE"},
 		Refresh:    networkingQoSDSCPMarkingRuleV2StateRefreshFunc(ctx, networkingClient, qosPolicyID, r.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -170,7 +170,7 @@ func resourceNetworkingQoSDSCPMarkingRuleV2Delete(ctx context.Context, d *schema
 		Target:     []string{"DELETED"},
 		Refresh:    networkingQoSDSCPMarkingRuleV2StateRefreshFunc(ctx, networkingClient, qosPolicyID, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_networking_qos_minimum_bandwidth_rule_v2.go
+++ b/openstack/resource_openstack_networking_qos_minimum_bandwidth_rule_v2.go
@@ -83,7 +83,7 @@ func resourceNetworkingQoSMinimumBandwidthRuleV2Create(ctx context.Context, d *s
 		Target:     []string{"ACTIVE"},
 		Refresh:    networkingQoSMinimumBandwidthRuleV2StateRefreshFunc(ctx, networkingClient, qosPolicyID, r.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -190,7 +190,7 @@ func resourceNetworkingQoSMinimumBandwidthRuleV2Delete(ctx context.Context, d *s
 		Target:     []string{"DELETED"},
 		Refresh:    networkingQoSMinimumBandwidthRuleV2StateRefreshFunc(ctx, networkingClient, qosPolicyID, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_networking_qos_policy_v2.go
+++ b/openstack/resource_openstack_networking_qos_policy_v2.go
@@ -137,7 +137,7 @@ func resourceNetworkingQoSPolicyV2Create(ctx context.Context, d *schema.Resource
 		Target:     []string{"ACTIVE"},
 		Refresh:    networkingQoSPolicyV2StateRefreshFunc(ctx, networkingClient, p.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -277,7 +277,7 @@ func resourceNetworkingQoSPolicyV2Delete(ctx context.Context, d *schema.Resource
 		Target:     []string{"DELETED"},
 		Refresh:    networkingQoSPolicyV2StateRefreshFunc(ctx, networkingClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_networking_router_interface_v2.go
+++ b/openstack/resource_openstack_networking_router_interface_v2.go
@@ -98,7 +98,7 @@ func resourceNetworkingRouterInterfaceV2Create(ctx context.Context, d *schema.Re
 		Target:     []string{"ACTIVE", "DOWN"},
 		Refresh:    resourceNetworkingRouterInterfaceV2StateRefreshFunc(ctx, networkingClient, r.PortID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -170,7 +170,7 @@ func resourceNetworkingRouterInterfaceV2Delete(ctx context.Context, d *schema.Re
 		Target:     []string{"DELETED"},
 		Refresh:    resourceNetworkingRouterInterfaceV2DeleteRefreshFunc(ctx, networkingClient, d),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_networking_router_v2.go
+++ b/openstack/resource_openstack_networking_router_v2.go
@@ -280,7 +280,7 @@ func resourceNetworkingRouterV2Create(ctx context.Context, d *schema.ResourceDat
 		Target:     []string{"ACTIVE"},
 		Refresh:    resourceNetworkingRouterV2StateRefreshFunc(ctx, networkingClient, r.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -485,7 +485,7 @@ func resourceNetworkingRouterV2Delete(ctx context.Context, d *schema.ResourceDat
 		Target:     []string{"DELETED"},
 		Refresh:    resourceNetworkingRouterV2StateRefreshFunc(ctx, networkingClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_networking_secgroup_rule_v2.go
+++ b/openstack/resource_openstack_networking_secgroup_rule_v2.go
@@ -215,7 +215,7 @@ func resourceNetworkingSecGroupRuleV2Delete(ctx context.Context, d *schema.Resou
 		Target:     []string{"DELETED"},
 		Refresh:    resourceNetworkingSecGroupRuleV2StateRefreshFunc(ctx, networkingClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_networking_secgroup_v2.go
+++ b/openstack/resource_openstack_networking_secgroup_v2.go
@@ -234,7 +234,7 @@ func resourceNetworkingSecGroupV2Delete(ctx context.Context, d *schema.ResourceD
 		Target:     []string{"DELETED"},
 		Refresh:    networkingSecgroupV2StateRefreshFuncDelete(ctx, networkingClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_networking_subnet_v2.go
+++ b/openstack/resource_openstack_networking_subnet_v2.go
@@ -296,7 +296,7 @@ func resourceNetworkingSubnetV2Create(ctx context.Context, d *schema.ResourceDat
 		Target:     []string{"ACTIVE"},
 		Refresh:    networkingSubnetV2StateRefreshFunc(ctx, networkingClient, s.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -496,7 +496,7 @@ func resourceNetworkingSubnetV2Delete(ctx context.Context, d *schema.ResourceDat
 		Target:     []string{"DELETED"},
 		Refresh:    networkingSubnetV2StateRefreshFuncDelete(ctx, networkingClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_networking_subnetpool_v2.go
+++ b/openstack/resource_openstack_networking_subnetpool_v2.go
@@ -198,7 +198,7 @@ func resourceNetworkingSubnetPoolV2Create(ctx context.Context, d *schema.Resourc
 		Target:     []string{"ACTIVE"},
 		Refresh:    networkingSubnetpoolV2StateRefreshFunc(ctx, networkingClient, s.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -379,7 +379,7 @@ func resourceNetworkingSubnetPoolV2Delete(ctx context.Context, d *schema.Resourc
 		Target:     []string{"DELETED"},
 		Refresh:    networkingSubnetpoolV2StateRefreshFunc(ctx, networkingClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_networking_trunk_v2.go
+++ b/openstack/resource_openstack_networking_trunk_v2.go
@@ -134,7 +134,7 @@ func resourceNetworkingTrunkV2Create(ctx context.Context, d *schema.ResourceData
 		Target:     []string{"ACTIVE", "DOWN"},
 		Refresh:    networkingTrunkV2StateRefreshFunc(ctx, client, trunk.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -305,7 +305,7 @@ func resourceNetworkingTrunkV2Delete(ctx context.Context, d *schema.ResourceData
 		Target:     []string{"DELETED"},
 		Refresh:    networkingTrunkV2StateRefreshFunc(ctx, client, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_orchestration_stack_v1.go
+++ b/openstack/resource_openstack_orchestration_stack_v1.go
@@ -227,7 +227,7 @@ func resourceOrchestrationStackV1Create(ctx context.Context, d *schema.ResourceD
 		Target:     []string{"CREATE_COMPLETE", "UPDATE_COMPLETE", "UPDATE_IN_PROGRESS"},
 		Refresh:    orchestrationStackV1StateRefreshFunc(ctx, orchestrationClient, stack.ID, false),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -387,7 +387,7 @@ func resourceOrchestrationStackV1Update(ctx context.Context, d *schema.ResourceD
 		Target:     []string{"UPDATE_COMPLETE"},
 		Refresh:    orchestrationStackV1StateRefreshFunc(ctx, orchestrationClient, d.Id(), true),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      10 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -429,7 +429,7 @@ func resourceOrchestrationStackV1Delete(ctx context.Context, d *schema.ResourceD
 		Target:     []string{"DELETE_COMPLETE"},
 		Refresh:    orchestrationStackV1StateRefreshFunc(ctx, orchestrationClient, d.Id(), true),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      10 * time.Second,
+		Delay:      0,
 		MinTimeout: 3 * time.Second,
 	}
 

--- a/openstack/resource_openstack_sharedfilesystem_share_access_v2.go
+++ b/openstack/resource_openstack_sharedfilesystem_share_access_v2.go
@@ -142,7 +142,7 @@ func resourceSharedFilesystemShareAccessV2Create(ctx context.Context, d *schema.
 		Pending:    []string{"new", "queued_to_apply", "applying"},
 		Refresh:    sharedFilesystemShareAccessV2StateRefreshFunc(ctx, sfsClient, shareID, access.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      1 * time.Second,
+		Delay:      0,
 		MinTimeout: 1 * time.Second,
 	}
 
@@ -250,7 +250,7 @@ func resourceSharedFilesystemShareAccessV2Delete(ctx context.Context, d *schema.
 		Pending:    []string{"active", "new", "queued_to_deny", "denying"},
 		Refresh:    sharedFilesystemShareAccessV2StateRefreshFunc(ctx, sfsClient, shareID, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      1 * time.Second,
+		Delay:      0,
 		MinTimeout: 1 * time.Second,
 	}
 

--- a/openstack/resource_openstack_sharedfilesystem_share_v2.go
+++ b/openstack/resource_openstack_sharedfilesystem_share_v2.go
@@ -525,7 +525,7 @@ func waitForSFV2Share(ctx context.Context, sfsClient *gophercloud.ServiceClient,
 		Pending:    pending,
 		Refresh:    resourceSFV2ShareRefreshFunc(ctx, sfsClient, id),
 		Timeout:    timeout,
-		Delay:      1 * time.Second,
+		Delay:      0,
 		MinTimeout: 1 * time.Second,
 	}
 


### PR DESCRIPTION
This PR removes useless delay before refresh state checks
https://github.com/hashicorp/terraform-plugin-sdk/blob/77f585e21b398feb244cbb1890cb3d1a29ffb083/helper/retry/state.go#L28

On resource deletion use "delete->check->REPEAT" loop, instead of "check->delete->REPEAT"

This should speed-up resource creation/deletion time, therefore functional tests time too.

Previously network tests took 1h20m. Now they take about 15m.