### PR TITLE
[compute] add `hostname` option to compute instance

### DIFF
--- a/docs/resources/compute_instance_v2.md
+++ b/docs/resources/compute_instance_v2.md
@@ -335,6 +335,10 @@ The following arguments are supported:
 
 * `name` - (Required) A unique name for the resource.
 
+* `hostname` - (Optional) The hostname used for the server. Note: This requires
+    compute microversion 2.90. With microversion 2.94 it allows the hostname to
+    be a FQDN with up to 255 characters.
+
 * `image_id` - (Optional; Required if `image_name` is empty and not booting
     from a volume. Do not specify if booting from a volume.) The image ID of
     the desired image for the server. Changing this rebuilds the existing

--- a/openstack/compute_instance_v2.go
+++ b/openstack/compute_instance_v2.go
@@ -26,6 +26,8 @@ const (
 	computeV2InstanceCreateServerWithNetworkModeMicroversion        = "2.37"
 	computeV2InstanceCreateServerWithTagsMicroversion               = "2.52"
 	computeV2InstanceCreateServerWithHypervisorHostnameMicroversion = "2.74"
+	computeV2InstanceCreateServerWithHostnameMicroversion           = "2.90"
+	computeV2InstanceCreateServerWithHostnameIsFqdnMicroversion     = "2.94"
 	computeV2TagsExtensionMicroversion                              = "2.26"
 	computeV2InstanceBlockDeviceVolumeTypeMicroversion              = "2.67"
 	computeV2InstanceBlockDeviceVolumeAttachTagsMicroversion        = "2.49"


### PR DESCRIPTION
This pull request adds the optional `hostname` option to the compute_instance resource. I've marked this as a draft as I'd like to get your input on a couple of things.

The `computeClient` used in `resourceComputeInstanceV2Read` does not set any microversion and thus the `OS-EXT-SRV-ATTR:hostname` is not returned by the OpenStack API. The `OS-EXT-SRV-ATTR:hostname` is available from microversion 2.3 but until version 2.90 it was only returned to administrator users. That shouldn't be an issue because until microversion 2.90 the hostname could not be specified anyway and was generated from the instance's name.

I'm not sure what the best solution to this problem is. Maybe an additional parameter to pass the microversion which would mean we have to change the calls in `resourceComputeInstanceV2Update` and `resourceComputeInstanceV2ImportState` as well.  
Another important detail is that with microversion 2.47 the response of the flavor changed from `flavor.id` and `flavor.ilnks` to an object with the individual fields of a flavor. However the flavor ID is _not_ available anymore.

I've tested these changes against a DevStack 2025.1 installation and against a real OpenStack environment running 2024.1. On DevStack I ran all acceptance tests beginning with `testAccCheckComputeV2Instance` without errors. The tests on the OpenStack environment were done manually.

* The added tests don't check the hostname (e.g. using `TestCheckResourceAttr`) as it isn't returned by the API.
* data source changes are not included due to the `dataSourceComputeInstanceV2Read` function also not setting any microversion.