### PR TITLE
make subnet_id in openstack_networking_router_v2 optional

### DIFF
--- a/openstack/resource_openstack_networking_router_v2.go
+++ b/openstack/resource_openstack_networking_router_v2.go
@@ -97,6 +97,7 @@ func resourceNetworkingRouterV2() *schema.Resource {
 						"subnet_id": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"ip_address": {
 							Type:     schema.TypeString,


### PR DESCRIPTION
I want to fix the issue that it is impossible to set only the ip_address without specifying the subnet_id: #922 .

My solution just sets the `subnet_id` to be `computed`.
Inspired by https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/628.

Unfortunately, I do not know what "fixed_ip" I could use in the tests.
Also, I have no idea of how to test this locally with my terraform installation, because terraform strictly refuses to read my self-built binary with "Error: Required plugins are not installed" and some checksum warning.
