### PR TITLE
Add fixed_ip block support in networking_port_v2 read/import

### DIFF
--- a/openstack/import_openstack_networking_port_v2_test.go
+++ b/openstack/import_openstack_networking_port_v2_test.go
@@ -25,9 +25,6 @@ func TestAccNetworkingV2Port_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"fixed_ip",
-				},
 			},
 		},
 	})
@@ -52,9 +49,6 @@ func TestAccNetworkingV2Port_importAllowedAddressPairs(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"fixed_ip",
-				},
 			},
 		},
 	})
@@ -79,9 +73,6 @@ func TestAccNetworkingV2Port_importAllowedAddressPairsNoMAC(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"fixed_ip",
-				},
 			},
 		},
 	})
@@ -106,9 +97,6 @@ func TestAccNetworkingV2Port_importDHCPOpts(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"fixed_ip",
-				},
 			},
 		},
 	})

--- a/openstack/networking_port_v2.go
+++ b/openstack/networking_port_v2.go
@@ -214,6 +214,19 @@ func expandNetworkingPortFixedIPToStringSlice(fixedIPs []ports.IP) []string {
 	return s
 }
 
+func flattenNetworkingPortFixedIPs(fixedIPs []ports.IP) []map[string]any {
+	f := make([]map[string]any, len(fixedIPs))
+
+	for i, fixedIP := range fixedIPs {
+		f[i] = map[string]any{
+			"subnet_id":  fixedIP.SubnetID,
+			"ip_address": fixedIP.IPAddress,
+		}
+	}
+
+	return f
+}
+
 func flattenNetworkingPortBindingV2(port portExtended) any {
 	var portBinding []map[string]any
 

--- a/openstack/resource_openstack_networking_port_v2.go
+++ b/openstack/resource_openstack_networking_port_v2.go
@@ -119,10 +119,12 @@ func resourceNetworkingPortV2() *schema.Resource {
 						"subnet_id": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"ip_address": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 					},
 				},
@@ -464,6 +466,8 @@ func resourceNetworkingPortV2Read(ctx context.Context, d *schema.ResourceData, m
 	// This will be in the order returned by the API,
 	// which is usually alpha-numeric.
 	d.Set("all_fixed_ips", expandNetworkingPortFixedIPToStringSlice(port.FixedIPs))
+
+	d.Set("fixed_ip", flattenNetworkingPortFixedIPs(port.FixedIPs))
 
 	// Set all security groups.
 	// This can be different from what the user specified since


### PR DESCRIPTION
Set fixed_ip in resourceNetworkingPortV2Read
Remove ImportStateVerifyIgnore for fixed_ip in import test
Mark subnet_id and ip_address fields as computed: true

Close #1959 