### PR TITLE
[DOCS] Lint provider Markdown documentation

### DIFF
--- a/.github/.markdownlint-cli2.jsonc
+++ b/.github/.markdownlint-cli2.jsonc
@@ -1,0 +1,13 @@
+{
+  "config": {
+    // error MD013/line-length Line length (maximum 80)
+    // https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md
+    "MD013": false
+  },
+  "globs": [
+    "**/*.md"
+  ],
+  "ignores": [
+    ".github/ISSUE_TEMPLATE/*.md"
+  ]
+}

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -2,4 +2,4 @@
 
 HashiCorp Community Guidelines apply to you when interacting with the community here on GitHub and contributing code.
 
-Please read the full text at https://www.hashicorp.com/community-guidelines
+Please read the full text at <https://www.hashicorp.com/community-guidelines>

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,19 +9,23 @@ assignees: ''
 
 Hi there,
 
-Thank you for opening an issue. Please note that we try to keep the Terraform issue tracker reserved for bug reports and feature requests. For general usage questions, please see https://www.terraform.io/community.html.
+Thank you for opening an issue. Please note that we try to keep the Terraform issue tracker reserved for bug reports and feature requests. For general usage questions, please see <https://developer.hashicorp.com/terraform>.
 
 ### Terraform Version
+
 Run `terraform -v` to show the version. If you are not running the latest version of Terraform, please upgrade because your issue may have already been fixed.
 
 ### Affected Resource(s)
+
 Please list the resources as a list, for example:
+
 - opc_instance
 - opc_storage_volume
 
 If this issue appears to affect multiple resources, it may be an issue with Terraform's core, so please mention this.
 
 ### Terraform Configuration Files
+
 ```hcl
 # Copy-paste your Terraform configurations here - for large Terraform configs,
 # please use a service like Dropbox and share a link to the ZIP file. For
@@ -29,28 +33,37 @@ If this issue appears to affect multiple resources, it may be an issue with Terr
 ```
 
 ### Debug Output
-Please provide a link to a GitHub Gist containing the complete debug output: https://www.terraform.io/docs/internals/debugging.html. 
+
+Please provide a link to a GitHub Gist containing the complete debug output: <https://developer.hashicorp.com/terraform/internals/debugging>.
 
 In addition, running Terraform with the `OS_DEBUG=1` environment variable set will print additional information specific to the OpenStack provider which will be helpful for troubleshooting.
 
 Please do NOT paste the debug output in the issue; just paste a link to the Gist.
 
 ### Panic Output
+
 If Terraform produced a panic, please provide a link to a GitHub Gist containing the output of the `crash.log`.
 
 ### Expected Behavior
+
 What should have happened?
 
 ### Actual Behavior
+
 What actually happened?
 
 ### Steps to Reproduce
+
 Please list the steps required to reproduce the issue, for example:
+
 1. `terraform apply`
 
 ### Important Factoids
+
 Is there anything atypical about your accounts that we should know? For example: Running in EC2 Classic? A custom version of OpenStack? Tight ACLs?
 
 ### References
+
 Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here? For example:
+
 - GH-1234

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -2,4 +2,4 @@
 
 Terraform is a mature project with a growing community. There are active, dedicated people willing to help you through various mediums.
 
-Take a look at those mediums listed at https://www.terraform.io/community.html
+Take a look at those mediums listed at <https://developer.hashicorp.com/terraform>

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# See GitHub's documentation for more information on this file:
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
 
 version: 2
 updates:

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,20 @@
+name: Markdown-lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  markdown-lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: DavidAnson/markdownlint-cli2-action@v22
+        with:
+          globs: '**/*.md'
+          config: '.github/.markdownlint-cli2.jsonc'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## 3.4.0 (11 November, 2025)
 
 NOTES
@@ -12,7 +14,6 @@ IMPROVEMENTS
 * Add new data source `data_source_openstack_lb_listener_v2` ([#1957](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1957))
 * Add new data source `data_source_openstack_lb_loadbalancer_v2` ([#1954](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1954))
 * Add new resource `resource_openstack_taas_tap_mirror_v2` ([#1948](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1948))
-
 
 BUG FIXES
 
@@ -256,25 +257,21 @@ BREAKING CHANGES
 * Remove `external_gateway` from `networking_router_v2` ([#1685](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1685))
 * Remove `floating_ip` from `compute_instance_v2` ([#1686](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1686))
 * Remove `volume` from `compute_instance_v2` ([#1687](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1687))
-* Remove `sort_key` and `sort_dir` from glance data sources (#1661)(https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1661))
-
+* Remove `sort_key` and `sort_dir` from glance data sources ([#1661](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1661))
 
 FEATURES
 
-* __New Data Source__: `openstack_lb_flavor_v2` ([#1679](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1679))
-
+* **New Data Source**: `openstack_lb_flavor_v2` ([#1679](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1679))
 
 IMPROVEMENTS
 
 * Added `tag` on `openstack_compute_volume_attach_v2` ([#1713](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1713))
-
 
 NOTES
 
 * Added Openstack Caracal jobs to CI ([#1705](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1705))
 * Removed Openstack Zed jobs from CI ([#1705](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1710))
 * Removed Openstack Yoga jobs from CI ([#1705](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1671))
-
 
 ## 1.54.1 (31 January, 2024)
 
@@ -290,7 +287,6 @@ NOTES
 * Added deprecation notice for `multiattach` on `openstack_blockstorage_volume_v3` ([#1629](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1629)). Support for it **will be removed on next major release**.
 * Added deprecation notice for various nova resources. Support for them will **not** be removed, but users are notified to use the new resources instead ([#1639](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1639)).
 
-
 IMPROVEMENTS
 
 * Updated Terraform SDK to `v2.30.0` ([#1631](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1631))
@@ -300,7 +296,6 @@ IMPROVEMENTS
 * Added extra validations on `openstack_lb_pool_v2` ([#1628](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1628))
 * Added attachment information on `data_source_blockstorage_volume_v3` ([#1624](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1624))
 * Added `backup_id` to `openstack_blockstorage_volume_v3` ([#1641](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1641))
-
 
 BUG FIXES
 
@@ -317,7 +312,6 @@ IMPROVEMENTS
 * Added `project_id` argument to the `openstack_fw_policy_v2` data source ([#1594](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1594))
 * Added `project_id` argument to the `openstack_fw_policy_v2` resource ([#1594](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1594))
 * Updated `openstack_compute_instance_v2` to use Glance client instead of deprecated Nova client for images ([#1615](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1615))
-
 
 BUG FIXES
 
@@ -444,9 +438,9 @@ BUG FIXES
 
 FEATURES
 
-* __New Resource__: `containerinfra_nodegroup_v1` ([#1364](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1364))
-* __New Data Source__: `containerinfra_nodegroup_v1` ([#1364](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1364))
-* __New Data Source__: `openstack_compute_limits_v2` ([#1418](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1418))
+* **New Resource**: `containerinfra_nodegroup_v1` ([#1364](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1364))
+* **New Data Source**: `containerinfra_nodegroup_v1` ([#1364](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1364))
+* **New Data Source**: `openstack_compute_limits_v2` ([#1418](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1418))
 
 IMPROVEMENTS
 
@@ -484,10 +478,10 @@ BUG FIXES
 
 FEATURES
 
-* __New Resource__: `blockstorage_qos_v3` ([#1325](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1325))
-* __New Resource__: `blockstorage_qos_association_v3` ([#1331](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1331))
-* __New Data Source__: `blockstorage_quotaset_v3` ([#1319](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1319))
-* __New Data Source__: `networking_quota_v2` ([#1318](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1318))
+* **New Resource**: `blockstorage_qos_v3` ([#1325](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1325))
+* **New Resource**: `blockstorage_qos_association_v3` ([#1331](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1331))
+* **New Data Source**: `blockstorage_quotaset_v3` ([#1319](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1319))
+* **New Data Source**: `networking_quota_v2` ([#1318](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1318))
 
 IMPROVEMENTS
 
@@ -503,7 +497,7 @@ IMPROVEMENTS
 
 FEATURES
 
-* __New Data Source__: `openstack_compute_quotaset_v2` ([#1302](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1302))
+* **New Data Source**: `openstack_compute_quotaset_v2` ([#1302](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1302))
 
 IMPROVEMENTS
 
@@ -536,8 +530,8 @@ BUG FIXES
 
 FEATURES
 
-* __New Resource__: `dns_transfer_request_v2` ([#1268](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1268))
-* __New Resource__: `dns_transfer_accept_v2` ([#1268](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1268))
+* **New Resource**: `dns_transfer_request_v2` ([#1268](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1268))
+* **New Resource**: `dns_transfer_accept_v2` ([#1268](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1268))
 
 IMPROVEMENTS
 
@@ -568,7 +562,7 @@ IMPROVEMENTS
 
 FEATURES
 
-* __New Resource__: `blockstorage_volume_type_access_v3` ([#1223](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1223))
+* **New Resource**: `blockstorage_volume_type_access_v3` ([#1223](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1223))
 
 IMPROVEMENTS
 
@@ -580,8 +574,8 @@ IMPROVEMENTS
 
 FEATURES
 
-* __New Resource__: `networking_portforwarding_v2` ([#940](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/940))
-* __New Resource__: `blockstorage_volume_type_v3` ([#1204](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1204))
+* **New Resource**: `networking_portforwarding_v2` ([#940](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/940))
+* **New Resource**: `blockstorage_volume_type_v3` ([#1204](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1204))
 
 IMPROVEMENTS
 
@@ -611,7 +605,7 @@ BUG FIXES
 
 FEATURES
 
-* __New Resource__: `openstack_lb_quota_v2` ([#1169](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1169))
+* **New Resource**: `openstack_lb_quota_v2` ([#1169](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1169))
 
 IMPROVEMENTS
 
@@ -643,8 +637,8 @@ NOTES
 
 FEATURES
 
-* __New Resource__: `openstack_identity_user_membership_v3` ([#1149](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1149))
-* __New Data Source__: `openstack_networking_subnet_ids_v2` ([#1153](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1153))
+* **New Resource**: `openstack_identity_user_membership_v3` ([#1149](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1149))
+* **New Data Source**: `openstack_networking_subnet_ids_v2` ([#1153](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1153))
 
 IMPROVEMENTS
 
@@ -665,9 +659,9 @@ BUG FIXES
 
 FEATURES
 
-* __New Resource__: `openstack_compute_aggregate_v2` ([#1121](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1121))
-* __New Data Source__: `openstack_compute_aggregate_v2` ([#1121](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1121))
-* __New Data Source__: `openstack_compute_hypervisor_v2` ([#1126](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1126))
+* **New Resource**: `openstack_compute_aggregate_v2` ([#1121](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1121))
+* **New Data Source**: `openstack_compute_aggregate_v2` ([#1121](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1121))
+* **New Data Source**: `openstack_compute_hypervisor_v2` ([#1126](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1126))
 
 IMPROVEMENTS
 
@@ -729,7 +723,7 @@ IMPROVEMENTS
 
 FEATURES
 
-* __New Resource__: `identity_ec2_credential_v3` ([#1033](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1033))
+* **New Resource**: `identity_ec2_credential_v3` ([#1033](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1033))
 
 IMPROVEMENTS
 
@@ -748,8 +742,8 @@ BUG FIXES
 
 FEATURES
 
-* __New Resource__: `openstack_identity_group_v3` ([#1028](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1028))
-* __New Data Source__: `openstack_images_image_ids_v2` ([#139](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/139))
+* **New Resource**: `openstack_identity_group_v3` ([#1028](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1028))
+* **New Data Source**: `openstack_images_image_ids_v2` ([#139](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/139))
 
 IMPROVEMENTS
 
@@ -760,7 +754,7 @@ IMPROVEMENTS
 
 FEATURES
 
-* __New Data Source__: `compute_instance_v2` ([#984](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/984))
+* **New Data Source**: `compute_instance_v2` ([#984](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/984))
 
 IMPROVEMENTS
 
@@ -802,8 +796,8 @@ BUG FIXES
 
 FEATURES
 
-* __New Resource__: `openstack_keymanager_order_v1` ([#992](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/992))
-* __New Resource__: `openstack_lb_members_v2` ([#898](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/898))
+* **New Resource**: `openstack_keymanager_order_v1` ([#992](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/992))
+* **New Resource**: `openstack_lb_members_v2` ([#898](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/898))
 
 IMPROVEMENTS
 
@@ -837,9 +831,9 @@ NOTES
 
 FEATURES
 
-* __New Resource__: `openstack_orchestration_stack_v1` ([#944](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/944))
-* __New Data Source__: `openstack_blockstorage_volume_v2` ([#928](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/928))
-* __New Data Source__: `openstack_blockstorage_volume_v3` ([#947](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/947))
+* **New Resource**: `openstack_orchestration_stack_v1` ([#944](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/944))
+* **New Data Source**: `openstack_blockstorage_volume_v2` ([#928](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/928))
+* **New Data Source**: `openstack_blockstorage_volume_v3` ([#947](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/947))
 
 IMPROVEMENTS
 
@@ -860,8 +854,8 @@ BUG FIXES
 
 FEATURES
 
-* __New Resource__: `openstack_networking_quota_v2` ([#915](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/915))
-* __New Resource__: `openstack_compute_quotaset_v2` ([#914](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/914))
+* **New Resource**: `openstack_networking_quota_v2` ([#915](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/915))
+* **New Resource**: `openstack_compute_quotaset_v2` ([#914](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/914))
 
 IMPROVEMENTS
 
@@ -885,8 +879,8 @@ BUG FIXES
 
 FEATURES
 
-* __New Resource__: `openstack_images_image_access_accept_v2` ([#872](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/872))
-* __New Resource__: `openstack_images_image_access_v2` ([#872](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/872))
+* **New Resource**: `openstack_images_image_access_accept_v2` ([#872](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/872))
+* **New Resource**: `openstack_images_image_access_v2` ([#872](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/872))
 
 IMPROVEMENTS
 
@@ -909,7 +903,7 @@ BUG FIXES
 
 FEATURES
 
-* __New Data Source__: `openstack_keymanager_container_v1` ([#846](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/846))
+* **New Data Source**: `openstack_keymanager_container_v1` ([#846](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/846))
 
 IMPROVEMENTS
 
@@ -933,15 +927,15 @@ BUG FIXES
 
 FEATURES
 
-* __New Resource__: `openstack_keymanager_secret_v1` ([#650](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/650)), ([#807](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/807))
-* __New Resource__: `openstack_keymanager_container_v1` ([#808](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/808))
-* __New Resource__: `openstack_identity_service_v3` ([#821](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/821))
-* __New Resource__: `openstack_identity_endpoint_v3` ([#823](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/823))
-* __New Resource__: `openstack_networking_rbac_policy_v2` ([#811](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/811))
-* __New Resource__: `openstack_blockstorage_quotaset_v2` ([#806](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/806))
-* __New Resource__: `openstack_blockstorage_quotaset_v3` ([#828](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/828))
-* __New Data Source__: `openstack_keymanager_secret_v1` ([#815](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/815))
-* __New Data Source__: `openstack_identity_service_v3` ([#819](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/819))
+* **New Resource**: `openstack_keymanager_secret_v1` ([#650](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/650)), ([#807](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/807))
+* **New Resource**: `openstack_keymanager_container_v1` ([#808](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/808))
+* **New Resource**: `openstack_identity_service_v3` ([#821](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/821))
+* **New Resource**: `openstack_identity_endpoint_v3` ([#823](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/823))
+* **New Resource**: `openstack_networking_rbac_policy_v2` ([#811](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/811))
+* **New Resource**: `openstack_blockstorage_quotaset_v2` ([#806](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/806))
+* **New Resource**: `openstack_blockstorage_quotaset_v3` ([#828](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/828))
+* **New Data Source**: `openstack_keymanager_secret_v1` ([#815](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/815))
+* **New Data Source**: `openstack_identity_service_v3` ([#819](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/819))
 
 IMPROVEMENTS
 
@@ -963,14 +957,14 @@ BUG FIXES
 
 FEATURES
 
-* __New Resource__: `openstack_networking_qos_policy_v2` ([#774](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/774))
-* __New Resource__: `openstack_networking_qos_bandwidth_limit_rule_v2` ([#783](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/783))
-* __New Resource__: `openstack_networking_qos_dscp_marking_rule_v2` ([#784](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/784))
-* __New Resource__: `openstack_networking_qos_minimum_bandwidth_rule_v2` ([#790](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/790))
-* __New Data Source__: `openstack_networking_qos_policy_v2`([#779](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/779))
-* __New Data Source__: `openstack_networking_qos_bandwidth_limit_rule_v2` ([#788](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/788))
-* __New Data Source__: `openstack_networking_qos_dscp_marking_rule_v2` ([#789](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/789))
-* __New Data Source__: `openstack_networking_qos_minimum_bandwidth_rule_v2` ([#793](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/793))
+* **New Resource**: `openstack_networking_qos_policy_v2` ([#774](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/774))
+* **New Resource**: `openstack_networking_qos_bandwidth_limit_rule_v2` ([#783](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/783))
+* **New Resource**: `openstack_networking_qos_dscp_marking_rule_v2` ([#784](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/784))
+* **New Resource**: `openstack_networking_qos_minimum_bandwidth_rule_v2` ([#790](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/790))
+* **New Data Source**: `openstack_networking_qos_policy_v2`([#779](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/779))
+* **New Data Source**: `openstack_networking_qos_bandwidth_limit_rule_v2` ([#788](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/788))
+* **New Data Source**: `openstack_networking_qos_dscp_marking_rule_v2` ([#789](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/789))
+* **New Data Source**: `openstack_networking_qos_minimum_bandwidth_rule_v2` ([#793](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/793))
 
 IMPROVEMENTS
 
@@ -1005,7 +999,7 @@ NOTES
 
 FEATURES
 
-* __New Data Source__: `openstack_networking_addressscope_v2` ([#741](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/741))
+* **New Data Source**: `openstack_networking_addressscope_v2` ([#741](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/741))
 
 BUG FIXES
 
@@ -1015,20 +1009,18 @@ BUG FIXES
 * Fixed a bug where `dns_nameservers` could not be cleared in `openstack_networking_subnet_v2` ([#728](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/728))
 * Fixed a bug where a port's `dns_name` was being unset by Terraform ([#748](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/748))
 
-
 ## 1.17.0 (April 01, 2019)
 
 NOTES
 
 * `extra_dhcp_option` in the `openstack_networking_port_v2` data source has been changed to a List. This is to resolve a bug where multiple DHCP options were not being rendered.
 
-
 FEATURES
 
-* __New Resource__: `openstack_identity_application_credential_v3` ([#660](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/660))
-* __New Data Source__: `openstack_blockstorage_availability_zones_v3` ([#652](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/652))
-* __New Data Source__: `openstack_sharedfilesystem_availability_zones_v2` ([#652](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/652))
-* __New Data Source__: `openstack_networking_trunk_v2` ([#626](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/626))
+* **New Resource**: `openstack_identity_application_credential_v3` ([#660](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/660))
+* **New Data Source**: `openstack_blockstorage_availability_zones_v3` ([#652](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/652))
+* **New Data Source**: `openstack_sharedfilesystem_availability_zones_v2` ([#652](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/652))
+* **New Data Source**: `openstack_networking_trunk_v2` ([#626](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/626))
 
 IMPROVEMENTS
 
@@ -1064,7 +1056,7 @@ NOTES
 
 FEATURES
 
-* __New Data Source__: `openstack_compute_availability_zones_v2` ([#655](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/655))
+* **New Data Source**: `openstack_compute_availability_zones_v2` ([#655](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/655))
 
 BUG FIXES
 
@@ -1086,8 +1078,8 @@ NOTES
 
 FEATURES
 
-* __New Resource__: `openstack_networking_addressscope_v2` ([#634](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/634))
-* __New Resource__: `openstack_networking_port_secgroup_associate_v2` ([#574](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/574))
+* **New Resource**: `openstack_networking_addressscope_v2` ([#634](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/634))
+* **New Resource**: `openstack_networking_port_secgroup_associate_v2` ([#574](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/574))
 
 IMPROVEMENTS
 
@@ -1129,15 +1121,15 @@ NOTES
 
 FEATURES
 
-* __New Resource__: `openstack_lb_l7policy_v2` ([#527](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/527))
-* __New Resource__: `openstack_lb_l7rule_v2` ([#522](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/522))
-* __New Resource__: `openstack_sharedfilesystem_share_v2` ([#525](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/525))
-* __New Resource__: `openstack_sharedfilesystem_share_access_v2` ([#526](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/526))
-* __New Data Source__: `openstack_sharedfilesystem_share_v2` ([#564](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/564))
-* __New Data Source__: `openstack_networking_port_v2` ([#567](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/567))
-* __New Data Source__: `openstack_sharedfilesystem_sharenetwork_v2` ([#576](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/576))
-* __New Data Source__: `openstack_networking_port_ids_v2` ([#569](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/569))
-* __New Data Source__: `openstack_sharedfilesystem_snapshot_v2` ([#577](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/577))
+* **New Resource**: `openstack_lb_l7policy_v2` ([#527](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/527))
+* **New Resource**: `openstack_lb_l7rule_v2` ([#522](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/522))
+* **New Resource**: `openstack_sharedfilesystem_share_v2` ([#525](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/525))
+* **New Resource**: `openstack_sharedfilesystem_share_access_v2` ([#526](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/526))
+* **New Data Source**: `openstack_sharedfilesystem_share_v2` ([#564](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/564))
+* **New Data Source**: `openstack_networking_port_v2` ([#567](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/567))
+* **New Data Source**: `openstack_sharedfilesystem_sharenetwork_v2` ([#576](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/576))
+* **New Data Source**: `openstack_networking_port_ids_v2` ([#569](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/569))
+* **New Data Source**: `openstack_sharedfilesystem_snapshot_v2` ([#577](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/577))
 
 IMPROVEMENTS
 
@@ -1167,11 +1159,11 @@ BUG FIXES
 
 FEATURES
 
-* __New Resource__: `openstack_sharedfilesystem_securityservice_v2` ([#515](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/515))
-* __New Resource__: `openstack_sharedfilesystem_sharenetwork_v2` ([#515](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/515))
-* __New Data Source__: `openstack_containerinfra_cluster_v1` ([#488](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/488))
-* __New Data Source__: `openstack_blockstorage_snapshot_v2` ([#448](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/448))
-* __New Data Source__: `openstack_blockstorage_snapshot_v3` ([#448](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/448))
+* **New Resource**: `openstack_sharedfilesystem_securityservice_v2` ([#515](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/515))
+* **New Resource**: `openstack_sharedfilesystem_sharenetwork_v2` ([#515](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/515))
+* **New Data Source**: `openstack_containerinfra_cluster_v1` ([#488](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/488))
+* **New Data Source**: `openstack_blockstorage_snapshot_v2` ([#448](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/448))
+* **New Data Source**: `openstack_blockstorage_snapshot_v3` ([#448](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/448))
 
 IMPROVEMENTS
 
@@ -1198,7 +1190,7 @@ BUG FIXES
 
 FEATURES
 
-* __New Resource__: `openstack_compute_interface_attach_v2` ([#470](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/470))
+* **New Resource**: `openstack_compute_interface_attach_v2` ([#470](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/470))
 
 IMPROVEMENTS
 
@@ -1217,13 +1209,12 @@ BUG FIXES
 
 * Fixed issue with nova-network based environments having the `tenantnetworks` API disabled ([#485](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/485))
 
-
 ## 1.11.0 (October 29, 2018)
 
 FEATURES
 
-* __New Resource__: `openstack_networking_trunk_v2` ([#446](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/446))
-* __New Resource__: `openstack_compute_flavor_access_v2` ([#447](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/447))
+* **New Resource**: `openstack_networking_trunk_v2` ([#446](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/446))
+* **New Resource**: `openstack_compute_flavor_access_v2` ([#447](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/447))
 
 IMPROVEMENTS
 
@@ -1241,8 +1232,8 @@ BUG FIXES
 
 FEATURES
 
-* __New Resource__: `openstack_containerinfra_cluster_v1` ([#421](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/421))
-* __New Data Source__: `openstack_containerinfra_clustertemplate_v1` ([#415](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/415))
+* **New Resource**: `openstack_containerinfra_cluster_v1` ([#421](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/421))
+* **New Data Source**: `openstack_containerinfra_clustertemplate_v1` ([#415](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/415))
 
 IMPROVEMENTS
 
@@ -1259,10 +1250,10 @@ BUG FIXES
 
 FEATURES
 
-* __New Resource__: `openstack_objectstorage_tempurl_v1` ([#379](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/379))
-* __New Resource__: `openstack_containerinfra_clustertemplate_v1` ([#403](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/403))
-* __New Data Source__: `openstack_fw_policy_v1` ([#398](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/398))
-* __New Data Source__: `openstack_networking_router_v2` ([#401](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/401))
+* **New Resource**: `openstack_objectstorage_tempurl_v1` ([#379](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/379))
+* **New Resource**: `openstack_containerinfra_clustertemplate_v1` ([#403](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/403))
+* **New Data Source**: `openstack_fw_policy_v1` ([#398](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/398))
+* **New Data Source**: `openstack_networking_router_v2` ([#401](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/401))
 
 IMPROVEMENTS
 
@@ -1277,8 +1268,8 @@ BACKWARDS INCOMPATIBILITIES / NOTES:
 
 FEATURES
 
-* __New Data Source__: `openstack_identity_group_v3` ([#385](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/385))
-* __New Data Source__: `openstack_networking_floatingip_v2` ([#387](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/387))
+* **New Data Source**: `openstack_identity_group_v3` ([#385](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/385))
+* **New Data Source**: `openstack_networking_floatingip_v2` ([#387](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/387))
 
 IMPROVEMENTS
 
@@ -1294,7 +1285,7 @@ BUG FIXES
 
 FEATURES
 
-* __New Data Source__: `openstack_identity_endpoint_v3` ([#377](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/377))
+* **New Data Source**: `openstack_identity_endpoint_v3` ([#377](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/377))
 
 IMPROVEMENTS
 
@@ -1315,7 +1306,7 @@ BUG FIXES
 
 FEATURES
 
-* __New Resource__: `openstack_vpnaas_site_connection_v2` ([#330](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/330))
+* **New Resource**: `openstack_vpnaas_site_connection_v2` ([#330](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/330))
 
 IMPROVEMENTS
 
@@ -1326,16 +1317,16 @@ IMPROVEMENTS
 
 FEATURES
 
-* __New Resource__: `openstack_blockstorage_volume_v3` ([#324](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/324))
-* __New Resource__: `openstack_blockstorage_volume_attach_v3` ([#324](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/324))
-* __New Resource__: `openstack_networking_subnet_route_v2` ([#314](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/314))
-* __New Resource__: `openstack_networking_floatingip_associate_v2` ([#313](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/313))
-* __New Resource__: `openstack_vpnaas_ipsec_policy_v2` ([#270](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/270))
-* __New Resource__: `openstack_vpnaas_service_v2` ([#300](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/300))
-* __New Resource__: `openstack_vpnaas_ike_policy_v2` ([#316](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/316))
-* __New Resource__: `openstack_vpnaas_endpoint_group_v2` ([#321](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/321))
-* __New Data Source__: `openstack_compute_keypair_v2` ([#307](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/307))
-* __New Data Source__: `openstack_identity_auth_scope_v3` ([#204](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/204))
+* **New Resource**: `openstack_blockstorage_volume_v3` ([#324](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/324))
+* **New Resource**: `openstack_blockstorage_volume_attach_v3` ([#324](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/324))
+* **New Resource**: `openstack_networking_subnet_route_v2` ([#314](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/314))
+* **New Resource**: `openstack_networking_floatingip_associate_v2` ([#313](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/313))
+* **New Resource**: `openstack_vpnaas_ipsec_policy_v2` ([#270](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/270))
+* **New Resource**: `openstack_vpnaas_service_v2` ([#300](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/300))
+* **New Resource**: `openstack_vpnaas_ike_policy_v2` ([#316](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/316))
+* **New Resource**: `openstack_vpnaas_endpoint_group_v2` ([#321](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/321))
+* **New Data Source**: `openstack_compute_keypair_v2` ([#307](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/307))
+* **New Data Source**: `openstack_identity_auth_scope_v3` ([#204](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/204))
 
 IMPROVEMENTS
 
@@ -1357,9 +1348,9 @@ BACKWARDS INCOMPATIBILITIES / NOTES:
 
 FEATURES
 
-* __New Resource__: `openstack_identity_role_assignment_v3` ([#265](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/265))
-* __New Data Source__: `openstack_identity_project_v3` ([#251](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/251))
-* __New Data Source__: `openstack_identity_user_v3` ([#252](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/252))
+* **New Resource**: `openstack_identity_role_assignment_v3` ([#265](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/265))
+* **New Data Source**: `openstack_identity_project_v3` ([#251](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/251))
+* **New Data Source**: `openstack_identity_user_v3` ([#252](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/252))
 
 IMPROVEMENTS
 
@@ -1383,10 +1374,10 @@ BACKWARDS INCOMPATIBILITIES / NOTES:
 
 FEATURES
 
-* __New Resource:__ `openstack_networking_subnetpool_v2` ([#243](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/243))
-* __New Resource:__ `openstack_identity_role_v3` ([#250](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/250))
-* __New Data Source:__ `openstack_networking_subnetpool_v2` ([#243](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/243))
-* __New Data Source:__ `openstack_identity_role_v3` ([#250](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/250))
+* **New Resource:** `openstack_networking_subnetpool_v2` ([#243](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/243))
+* **New Resource:** `openstack_identity_role_v3` ([#250](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/250))
+* **New Data Source:** `openstack_networking_subnetpool_v2` ([#243](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/243))
+* **New Data Source:** `openstack_identity_role_v3` ([#250](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/250))
 
 IMPROVEMENTS
 
@@ -1413,11 +1404,10 @@ BACKWARDS INCOMPATIBILITIES / NOTES:
 
 FEATURES
 
-* __New Resource:__ `openstack_db_database_v1` ([#179](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/179))
-* __New Resource:__ `openstack_db_user_v1` ([#180](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/180))
-* __New Resource:__ `openstack_db_configuration_v1` ([#185](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/185))
-* __New Data Source:__ `openstack_compute_flavor_v2` ([#190](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/190))
-
+* **New Resource:** `openstack_db_database_v1` ([#179](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/179))
+* **New Resource:** `openstack_db_user_v1` ([#180](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/180))
+* **New Resource:** `openstack_db_configuration_v1` ([#185](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/185))
+* **New Data Source:** `openstack_compute_flavor_v2` ([#190](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/190))
 
 IMPROVEMENTS
 
@@ -1442,8 +1432,8 @@ BUG FIXES
 
 FEATURES
 
-* __New Resource:__ `openstack_objectstorage_object_v1` ([#146](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/146))
-* __New Resource:__ `openstack_db_instance_v1` ([#155](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/155))
+* **New Resource:** `openstack_objectstorage_object_v1` ([#146](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/146))
+* **New Resource:** `openstack_db_instance_v1` ([#155](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/155))
 
 IMPROVEMENTS
 
@@ -1463,8 +1453,8 @@ BACKWARDS INCOMPATIBILITIES / NOTES:
 
 FEATURES
 
-* __New Data Source:__ `openstack_networking_subnet_v2` ([#135](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/135))
-* __New Data Source:__ `openstack_dns_zone_v2` ([#145](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/145))
+* **New Data Source:** `openstack_networking_subnet_v2` ([#135](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/135))
+* **New Data Source:** `openstack_dns_zone_v2` ([#145](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/145))
 
 IMPROVEMENTS
 
@@ -1479,13 +1469,13 @@ BACKWARDS INCOMPATIBILITIES / NOTES:
 
 IMPROVEMENTS
 
- * `openstack_networking_router_interface_v2` will now set `subnet_id` when importing ([#119](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/119))
- * `openstack_networking_router_route_v2` can now be imported ([#120](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/120))
- * `openstack_images_image_v2` resource and data source now supports reading and setting properties ([#113](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/113))
+* `openstack_networking_router_interface_v2` will now set `subnet_id` when importing ([#119](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/119))
+* `openstack_networking_router_route_v2` can now be imported ([#120](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/120))
+* `openstack_images_image_v2` resource and data source now supports reading and setting properties ([#113](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/113))
 
 BUG FIXES
 
-  * `openstack_networking_port_v2`: Fixed issues with how security groups and allowed address pairs are applied and updated [[#114](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/114)].
+* `openstack_networking_port_v2`: Fixed issues with how security groups and allowed address pairs are applied and updated [[#114](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/114)].
 
 ## 0.2.2 (September 15, 2017)
 
@@ -1495,13 +1485,14 @@ BACKWARDS INCOMPATIBILITIES / NOTES:
 
 FEATURES:
 
-* __New Data Source:__ `openstack_networking_secgroup_v2` ([#86](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/86))
-* __New Resource:__: `openstack_compute_flavor_v2` ([#83](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/83))
+* **New Data Source:** `openstack_networking_secgroup_v2` ([#86](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/86))
+* **New Resource:**: `openstack_compute_flavor_v2` ([#83](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/83))
 
 IMPROVEMENTS
- * Added `status` field to `openstack_networking_network_v2` data source ([#105](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/105))
- * `openstack_networking_router_v2` can now be imported ([#111](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/111))
- * `openstack_networking_router_interface_v2` can now be imported ([#112](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/112))
+
+* Added `status` field to `openstack_networking_network_v2` data source ([#105](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/105))
+* `openstack_networking_router_v2` can now be imported ([#111](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/111))
+* `openstack_networking_router_interface_v2` can now be imported ([#112](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/112))
 
 BUG FIXES
 
@@ -1533,8 +1524,8 @@ BACKWARDS INCOMPATIBILITIES / NOTES:
 
 FEATURES:
 
-* __New Resource:__ `openstack_identity_project_v3` ([#50](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/50))
-* __New Resource:__ `openstack_identity_user_v3` ([#52](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/52))
+* **New Resource:** `openstack_identity_project_v3` ([#50](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/50))
+* **New Resource:** `openstack_identity_user_v3` ([#52](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/52))
 
 IMPROVEMENTS:
 
@@ -1545,6 +1536,7 @@ IMPROVEMENTS:
 * `openstack_lb_loadbalancer_v2.provider` has been removed. See notes above. ([#65](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/65))
 
 BUG FIXES:
+
 * `openstack_lb_pool_v2` handling of `persistence` updated, `cookie_name` is now optional. ([#57](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/57))
 * `openstack_fw_firewall_v1.associated_routers` is now computed. ([#53](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/53))
 * All `openstack_fw_rule_v1` attributes are now passed during an update phase. ([#53](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/53))
@@ -1559,7 +1551,6 @@ BACKWARDS INCOMPATIBILITIES / NOTES:
 * `floating_ip` has been removed from `openstack_compute_instance_v2`. You must now use `openstack_compute_floatingip_associate_v2` to associate a Floating IP with an Instance.
 * `volume` has been removed from `openstack_compute_instance_v2`. You must now use `openstack_compute_volume_attach_v2` to attach a Volume with an Instance.
 * `member` has been removed from `openstack_lb_pool_v1`. You must now use `openstack_lb_member_v1` to add a LBaaS v1 Member to a Pool.
-
 
 IMPROVEMENTS:
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -34,6 +34,9 @@ fmtcheck:
 errcheck:
 	@sh -c "'$(CURDIR)/scripts/errcheck.sh'"
 
+lint-markdown:
+	markdownlint-cli2 --config .github/.markdownlint-cli2.jsonc
+
 test-compile:
 	@if [ "$(TEST)" = "./..." ]; then \
 		echo "ERROR: Set TEST to a specific package. For example,"; \

--- a/README.md
+++ b/README.md
@@ -1,66 +1,61 @@
-Terraform OpenStack Provider
-============================
+# Terraform OpenStack Provider
 
-Documentation:
-- [registry.terraform.io](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs)
-- [search.opentofu.org](https://search.opentofu.org/provider/terraform-provider-openstack/openstack/latest)
+The **Terraform OpenStack Provider** allows you to manage OpenStack resources using Terraform or OpenTofu.
 
-Requirements
-------------
+## Requirements
 
-- [Terraform](https://www.terraform.io/downloads.html) 1.x
-- [OpenTofu](https://opentofu.org/docs/intro/install) 1.x
-- [Go](https://golang.org/doc/install) 1.24 (to build the provider plugin)
+- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.x
+- [OpenTofu](https://opentofu.org/docs/intro/install) >= 1.x
+- [Go](https://go.dev/doc/install) >= 1.24 (to build the provider plugin)
 
-Building The Provider
----------------------
+## Building the Provider
 
-Clone the repository
+Clone the repository:
 
-```sh
-$ git clone git@github.com:terraform-provider-openstack/terraform-provider-openstack.git
+```shell
+git clone git@github.com:terraform-provider-openstack/terraform-provider-openstack.git
 ```
 
-Enter the provider directory and build the provider
+Enter the provider directory and build the provider:
 
-```sh
-$ cd terraform-provider-openstack
-$ make build
+```shell
+cd terraform-provider-openstack
+make build
 ```
 
-Using the provider
-----------------------
-Please see the documentation at [registry.terraform.io](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs) or [search.opentofu.org](https://search.opentofu.org/provider/terraform-provider-openstack/openstack/latest).
+## Using the provider
 
-Or you can browse the documentation within this repo [here](https://github.com/terraform-provider-openstack/terraform-provider-openstack/tree/main/website/docs).
+For usage instructions and examples, refer to the documentation:
 
-Developing the Provider
----------------------------
+- [Terraform Registry](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs)
+- [OpenTofu Registry](https://search.opentofu.org/provider/terraform-provider-openstack/openstack/latest)
+- Or browse the [documentation in this repository](https://github.com/terraform-provider-openstack/terraform-provider-openstack/tree/main/docs)
 
-If you wish to work on the provider, you'll first need [Go](https://golang.org) installed on your machine (version 1.24+ is *required*).
+## Developing the Provider
+
+If you wish to work on the provider, you'll first need [Go](https://go.dev) installed on your machine (see [Requirements](#requirements) above).
 
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the current directory.
 
-```sh
-$ make build
+```shell
+make build
 ```
 
 For further details on how to work on this provider, please see the [Testing and Development](https://github.com/terraform-provider-openstack/terraform-provider-openstack/blob/main/docs/index.md#testing-and-development) documentation.
 
-Releasing the Provider
-----------------------
+## Releasing the Provider
 
 This repository contains a GitHub Action configured to automatically build and
 publish assets for release when a tag is pushed that matches the pattern `v*`
 (ie. `v0.1.0`).
 
-A [Gorelaser](https://goreleaser.com/) configuration is provided that produce
-build artifacts matching the [layout required](https://www.terraform.io/docs/registry/providers/publishing.html#manually-preparing-a-release)
+A [Goreleaser](https://goreleaser.com/) configuration is provided that produce
+build artifacts matching the [layout required](https://developer.hashicorp.com/terraform/registry/providers/publishing)
 to publish the provider in the Terraform Registry.
 
 Releases will as drafts. Once marked as published on the GitHub Releases page,
 they will become available via the Terraform Registry.
 
-Before releasing, a PR updating the changelog should be made to trigger the CI 
+Before releasing, a PR updating the changelog should be made to trigger the CI
 for all services and ensure that everything is OK. Moreover, update the example
-on `website/docs/index.html.markdown` to point to the new version.
+on `docs/index.md` to point to the new version.

--- a/docs/data-sources/blockstorage_quotaset_v3.md
+++ b/docs/data-sources/blockstorage_quotaset_v3.md
@@ -26,7 +26,6 @@ data "openstack_blockstorage_quotaset_v3" "quota" {
 
 * `project_id` - (Required) The id of the project to retrieve the quotaset.
 
-
 ## Attributes Reference
 
 The following attributes are exported:

--- a/docs/data-sources/blockstorage_snapshot_v3.md
+++ b/docs/data-sources/blockstorage_snapshot_v3.md
@@ -34,7 +34,6 @@ data "openstack_blockstorage_snapshot_v3" "snapshot_1" {
 * `most_recent` - (Optional) Pick the most recently created snapshot if there
     are multiple results.
 
-
 ## Attributes Reference
 
 The following attributes are exported:

--- a/docs/data-sources/compute_availability_zones_v2.md
+++ b/docs/data-sources/compute_availability_zones_v2.md
@@ -22,7 +22,6 @@ data "openstack_compute_availability_zones_v2" "zones" {}
 * `region` - (Optional) The `region` to fetch availability zones from, defaults to the provider's `region`
 * `state` - (Optional) The `state` of the availability zones to match, default ("available").
 
-
 ## Attributes Reference
 
 `id` is set to hash of the returned zone list. In addition, the following attributes

--- a/docs/data-sources/compute_flavor_v2.md
+++ b/docs/data-sources/compute_flavor_v2.md
@@ -50,7 +50,6 @@ data "openstack_compute_flavor_v2" "small" {
 
 * `is_public` - (Optional) The flavor visibility.
 
-
 ## Attributes Reference
 
 `id` is set to the ID of the found flavor. In addition, the following attributes

--- a/docs/data-sources/compute_instance_v2.md
+++ b/docs/data-sources/compute_instance_v2.md
@@ -65,7 +65,6 @@ In addition to the above, the following attributes are exported:
 
 * `updated` - The time when the instance was last updated.
 
-
 The `network` block is defined as:
 
 * `uuid` - The UUID of the network
@@ -79,4 +78,3 @@ The `network` block is defined as:
 * `port` - The port UUID for this network
 
 * `mac` - The MAC address assigned to this network interface.
-

--- a/docs/data-sources/compute_keypair_v2.md
+++ b/docs/data-sources/compute_keypair_v2.md
@@ -27,9 +27,8 @@ data "openstack_compute_keypair_v2" "kp" {
 * `name` - (Required) The unique name of the keypair.
 
 * `user_id` - (Optional) The user id of the owner of the key pair.
-    This parameter can be specified only if the provider is configured to use 
+    This parameter can be specified only if the provider is configured to use
     the credentials of an OpenStack administrator.
-
 
 ## Attributes Reference
 

--- a/docs/data-sources/compute_limits_v2.md
+++ b/docs/data-sources/compute_limits_v2.md
@@ -26,7 +26,6 @@ data "openstack_compute_limits_v2" "limits" {
 
 * `project_id` - (Required) The id of the project to retrieve the limits.
 
-
 ## Attributes Reference
 
 The following attributes are exported:

--- a/docs/data-sources/compute_quotaset_v2.md
+++ b/docs/data-sources/compute_quotaset_v2.md
@@ -26,7 +26,6 @@ data "openstack_compute_quotaset_v2" "quota" {
 
 * `project_id` - (Required) The id of the project to retrieve the quotaset.
 
-
 ## Attributes Reference
 
 The following attributes are exported:

--- a/docs/data-sources/dns_zone_share_v2.md
+++ b/docs/data-sources/dns_zone_share_v2.md
@@ -15,11 +15,13 @@ Use this data source to get information about a DNS zone share.
 
 ```hcl
 data "openstack_dns_zone_share_v2" "example" {
-  zone_id           = "00000000-0000-0000-0000-000000000000"
+  zone_id = "00000000-0000-0000-0000-000000000000"
+
   # Optionally, filter by target project ID.
   target_project_id = "11111111-1111-1111-1111-111111111111"
+
   # Optionally, specify the owner project ID. Required if the zone is not in your default project.
-  project_id        = "22222222-2222-2222-2222-222222222222"
+  project_id = "22222222-2222-2222-2222-222222222222"
 }
 ```
 

--- a/docs/data-sources/identity_auth_scope_v3.md
+++ b/docs/data-sources/identity_auth_scope_v3.md
@@ -17,7 +17,7 @@ the username or project name currently in use as well as the service catalog.
 source will store an *unencrypted* session token in your Terraform state file.
 **Use of this data source with `set_token_id = true` in production deployments
 is *not* recommended**.
-[Read more about sensitive data in state](https://www.terraform.io/docs/language/state/sensitive-data.html).
+[Read more about sensitive data in state](https://developer.hashicorp.com/terraform/language/manage-sensitive-data).
 
 ## Example Usage
 
@@ -34,10 +34,18 @@ service catalog:
 
 ```hcl
 locals {
-  object_store_service    = [for entry in data.openstack_identity_auth_scope_v3.scope.service_catalog:
-                                 entry if entry.type=="object-store"][0]
-  object_store_endpoint   = [for endpoint in local.object_store_service.endpoints:
-                                 endpoint if (endpoint.interface=="public" && endpoint.region=="region1")][0]
+  object_store_service = [
+    for entry in data.openstack_identity_auth_scope_v3.scope.service_catalog :
+    entry
+    if entry.type == "object-store"
+  ][0]
+
+  object_store_endpoint = [
+    for endpoint in local.object_store_service.endpoints :
+    endpoint
+    if endpoint.interface == "public" && endpoint.region == "region1"
+  ][0]
+
   object_store_public_url = local.object_store_endpoint.url
 }
 ```
@@ -54,10 +62,18 @@ data "openstack_identity_auth_scope_v3" "scope" {
 
 ```hcl
 locals {
-  object_store_service    = [for entry in data.openstack_identity_auth_scope_v3.scope.service_catalog:
-                                 entry if entry.type=="object-store"][0]
-  object_store_endpoint   = [for endpoint in local.object_store_service.endpoints:
-                                 endpoint if (endpoint.interface=="public" && endpoint.region=="region1")][0]
+  object_store_service = [
+    for entry in data.openstack_identity_auth_scope_v3.scope.service_catalog :
+    entry
+    if entry.type == "object-store"
+  ][0]
+
+  object_store_endpoint = [
+    for endpoint in local.object_store_service.endpoints :
+    endpoint
+    if endpoint.interface == "public" && endpoint.region == "region1"
+  ][0]
+
   object_store_public_url = local.object_store_endpoint.url
 }
 

--- a/docs/data-sources/identity_group_v3.md
+++ b/docs/data-sources/identity_group_v3.md
@@ -31,7 +31,6 @@ data "openstack_identity_group_v3" "admins" {
 * `region` - (Optional) The region in which to obtain the V3 Keystone client.
     If omitted, the `region` argument of the provider is used.
 
-
 ## Attributes Reference
 
 `id` is set to the ID of the found group. In addition, the following attributes

--- a/docs/data-sources/images_image_v2.md
+++ b/docs/data-sources/images_image_v2.md
@@ -89,7 +89,7 @@ are exported:
   location of the image or the path to retrieve it.
 * `metadata` - The metadata associated with the image. Image metadata allow for
   meaningfully define the image properties and tags. See
-  https://docs.openstack.org/glance/latest/user/metadefs-concepts.html.
+  <https://docs.openstack.org/glance/latest/user/metadefs-concepts.html>.
 * `min_disk_gb` - The minimum amount of disk space required to use the image.
 * `min_ram_mb` - The minimum amount of ram required to use the image.
 * `properties` - Freeform information about the image.

--- a/docs/data-sources/keymanager_container_v1.md
+++ b/docs/data-sources/keymanager_container_v1.md
@@ -50,9 +50,9 @@ The following attributes are exported:
 
 The `secret_refs` block supports:
 
-* `name` - The name of the secret reference. The reference names must correspond
-  the container type, more details are available
-  [here](https://docs.openstack.org/barbican/stein/api/reference/containers.html).
+* `name` - The name of the secret reference.
+  The reference name must correspond the container type. See the
+  [Barbican container reference documentation][barbican-containers].
 
 * `secret_ref` - The secret reference / where to find the secret, URL.
 
@@ -72,3 +72,5 @@ The `acl` `read` attribute supports:
 * `created_at` - The date the container ACL was created.
 
 * `updated_at` - The date the container ACL was last updated.
+
+[barbican-containers]: https://docs.openstack.org/barbican/latest/api/reference/containers.html

--- a/docs/data-sources/keymanager_secret_v1.md
+++ b/docs/data-sources/keymanager_secret_v1.md
@@ -15,7 +15,7 @@ secret
 ~> **Important Security Notice** The payload of this data source will be stored
 *unencrypted* in your Terraform state file. **Use of this resource for
 production deployments is *not* recommended**. [Read more about sensitive data
-in state](https://www.terraform.io/docs/language/state/sensitive-data.html).
+in state](https://developer.hashicorp.com/terraform/language/manage-sensitive-data).
 
 ## Example Usage
 

--- a/docs/data-sources/lb_flavor_v2.md
+++ b/docs/data-sources/lb_flavor_v2.md
@@ -35,12 +35,12 @@ The following arguments are supported:
 `id` is set to the ID of the found flavor. In addition, the following attributes
 are exported:
 
- * `name` - The name of the flavor.
+* `name` - The name of the flavor.
 
- * `description` - The description of the flavor.
+* `description` - The description of the flavor.
 
- * `flavor_id` - The ID of the flavor.
+* `flavor_id` - The ID of the flavor.
 
- * `flavor_profile_id` - The ID of the flavor profile.
+* `flavor_profile_id` - The ID of the flavor profile.
 
- * `enabled` - Is the flavor enabled.
+* `enabled` - Is the flavor enabled.

--- a/docs/data-sources/loadbalancer_flavor_v2.md
+++ b/docs/data-sources/loadbalancer_flavor_v2.md
@@ -37,12 +37,12 @@ The following arguments are supported:
 `id` is set to the ID of the found flavor. In addition, the following attributes
 are exported:
 
- * `name` - The name of the flavor.
+* `name` - The name of the flavor.
 
- * `description` - The description of the flavor.
+* `description` - The description of the flavor.
 
- * `flavor_id` - The ID of the flavor.
+* `flavor_id` - The ID of the flavor.
 
- * `flavor_profile_id` - The ID of the flavor profile.
+* `flavor_profile_id` - The ID of the flavor profile.
 
- * `enabled` - Is the flavor enabled.
+* `enabled` - Is the flavor enabled.

--- a/docs/data-sources/networking_qos_bandwidth_limit_rule_v2.md
+++ b/docs/data-sources/networking_qos_bandwidth_limit_rule_v2.md
@@ -24,15 +24,14 @@ data "openstack_networking_qos_bandwidth_limit_rule_v2" "qos_bandwidth_limit_rul
 * `region` - (Optional) The region in which to obtain the V2 Networking client.
     A Networking client is needed to create a Neutron QoS bandwidth limit rule. If omitted, the
     `region` argument of the provider is used.
-    
+
 * `qos_policy_id` - (Required) The QoS policy reference.
-   
+
 * `max_kbps` - (Optional) The maximum kilobits per second of a QoS bandwidth limit rule.
 
 * `max_burst_kbps` - (Optional) The maximum burst size in kilobits of a QoS bandwidth limit rule.
-   
-* `direction` - (Optional) The direction of traffic.
 
+* `direction` - (Optional) The direction of traffic.
 
 ## Attributes Reference
 

--- a/docs/data-sources/networking_qos_dscp_marking_rule_v2.md
+++ b/docs/data-sources/networking_qos_dscp_marking_rule_v2.md
@@ -29,7 +29,6 @@ data "openstack_networking_qos_dscp_marking_rule_v2" "qos_dscp_marking_rule_1" {
 
 * `dscp_mark` - (Optional) The value of a DSCP mark.
 
-
 ## Attributes Reference
 
 `id` is set to the `qos_policy_id/dscp_marking_rule_id` format of the found QoS DSCP marking rule.

--- a/docs/data-sources/networking_qos_minimum_bandwidth_rule_v2.md
+++ b/docs/data-sources/networking_qos_minimum_bandwidth_rule_v2.md
@@ -29,7 +29,6 @@ data "openstack_networking_qos_minimum_bandwidth_rule_v2" "qos_min_bw_rule_1" {
 
 * `min_kbps` - (Optional) The value of a minimum kbps bandwidth.
 
-
 ## Attributes Reference
 
 `id` is set to the `qos_policy_id/minimum_bandwidth_rule_id` format of the found QoS minimum bandwidth rule.

--- a/docs/data-sources/networking_quota_v2.md
+++ b/docs/data-sources/networking_quota_v2.md
@@ -26,7 +26,6 @@ data "openstack_networking_quota_v2" "quota" {
 
 * `project_id` - (Required) The id of the project to retrieve the quota.
 
-
 ## Attributes Reference
 
 The following attributes are exported:

--- a/docs/guides/upgrade-guide-version-2.md
+++ b/docs/guides/upgrade-guide-version-2.md
@@ -6,6 +6,8 @@ description: |-
   Terraform Openstack Provider Version 2 Upgrade Guide
 ---
 
+# Terraform Openstack Provider Version 2 Upgrade Guide
+
 ~> **Note:** The provider go module version has been updated to `v2` in the `2.1.0` release. Downstream users should check the changelog of the `2.1.0` release as well before changing to the `v2` module.
 
 Version 2.0.0 of the Openstack provider for Terraform is a major release and includes some changes that you will need to consider when upgrading. We intend this guide to help with that process.
@@ -13,29 +15,30 @@ Version 2.0.0 of the Openstack provider for Terraform is a major release and inc
 We previously marked most of the changes we outline in this guide as deprecated in the Terraform plan/apply output throughout previous provider releases. You can find these changes, including deprecation notices, in the [Terraform Openstack Provider CHANGELOG](https://github.com/terraform-provider-openstack/terraform-provider-openstack/blob/main/CHANGELOG.md).
 
 Upgrade topics:
+
 - [Provider Version Configuration](#provider-version-configuration)
 - [Neutron LBaaS Deprecation](#neutron-lbaas-deprecation)
   - [Provider configuration option](#provider-configuration-option)
   - [Changes for users of Octavia](#changes-for-users-of-octavia)
   - [Changes for users of Neutron-LBaaS](#changes-for-users-of-neutron-lbaas)
-- [Other Removals](#other-removals)
-  - [Remove multiattach from volume_v2](#remove-multiattach-from-blockstoragevolumev3)
-  - [Remove dhcp_disabled from subnet_v2 data source](#remove-dhcpdisabled-from-networkingsubnetv2-data-source)
-  - [Remove update_at from image_v2](#remove-updateat-from-imagesimagev2)
-  - [Remove instance_id from blockstorage_volume_attach_v2](#remove-instanceid-from-blockstoragevolumeattachv2)
-  - [Remove member from lb_pool_v1](#remove-member-from-lbpoolv1)
-  - [Remove allocation_pools from subnet_v2](#remove-allocationpools-from-networkingsubnetv2)
-  - [Remove external_gateway from router_v2](#remove-externalgateway-from-networkingrouterv2)
-  - [Remove floating_ip from instance_v2](#remove-floatingip-from-computeinstancev2)
-  - [Remove volume from instance_v2](#remove-volume-from-computeinstancev2)
-  - [Remove sort_key and sort_dir from glance data sources](#remove-sortkey-and-sortdir-from-glance-data-sources)
-
+- [Other removals](#other-removals)
+  - [Remove multiattach from blockstorage\_volume\_v3](#remove-multiattach-from-blockstorage_volume_v3)
+  - [Remove dhcp\_disabled from networking\_subnet\_v2 data source](#remove-dhcp_disabled-from-networking_subnet_v2-data-source)
+  - [Remove update\_at from images\_image\_v2](#remove-update_at-from-images_image_v2)
+  - [Remove instance\_id from blockstorage\_volume\_attach\_v2](#remove-instance_id-from-blockstorage_volume_attach_v2)
+  - [Remove member from lb\_pool\_v1](#remove-member-from-lb_pool_v1)
+  - [Remove allocation\_pools from networking\_subnet\_v2](#remove-allocation_pools-from-networking_subnet_v2)
+  - [Remove external\_gateway from networking\_router\_v2](#remove-external_gateway-from-networking_router_v2)
+  - [Remove floating\_ip from compute\_instance\_v2](#remove-floating_ip-from-compute_instance_v2)
+  - [Remove volume from compute\_instance\_v2](#remove-volume-from-compute_instance_v2)
+  - [Remove sort\_key and sort\_dir from glance data sources](#remove-sort_key-and-sort_dir-from-glance-data-sources)
+  - [Remove host\_route from networking\_subnet\_v2](#remove-host_route-from-networking_subnet_v2)
 
 ## Provider Version Configuration
 
--> Before upgrading to version 2.0.0, upgrade to the most recent 1.X.Y version of the provider and ensure that your environment successfully runs [`terraform plan`](https://www.terraform.io/docs/commands/plan.html). You should not see changes you don't expect.
+-> Before upgrading to version 2.0.0, upgrade to the most recent 1.X.Y version of the provider and ensure that your environment successfully runs [`terraform plan`](https://developer.hashicorp.com/terraform/cli/commands/plan). You should not see changes you don't expect.
 
-Use [version constraints when configuring Terraform providers](https://www.terraform.io/docs/configuration/providers.html#provider-versions). If you are following that recommendation, update the version constraints in your Terraform configuration and run [`terraform init -upgrade`](https://www.terraform.io/docs/commands/init.html) to download the new version.
+Use [version constraints when configuring Terraform providers](https://developer.hashicorp.com/terraform/language/block/provider#provider-versions). If you are following that recommendation, update the version constraints in your Terraform configuration and run [`terraform init -upgrade`](https://developer.hashicorp.com/terraform/cli/commands/init) to download the new version.
 
 For example, given this previous configuration:
 
@@ -81,7 +84,7 @@ The provider configuration option `use_octavia` has been removed, since the prov
 
 ```terraform
 provider "openstack" {
-  ...
+  # ...
   use_octavia = false/true
 }
 ```
@@ -90,7 +93,7 @@ Should be updated into:
 
 ```terraform
 provider "openstack" {
-  ...
+  # ...
 }
 ```
 
@@ -101,7 +104,6 @@ The upgrade should be transparent for all loadbalancer resources that are alread
 ### Changes for users of Neutron-LBaaS
 
 Neutron-LBaaS will not be supported, therefore any loadbalancer resources **cannot be managed** through terraform-provider-openstack in 2.0.0 and beyond. Cloud-administrator should consider upgrading from Neutron-LBaaS to Octavia.
-
 
 ## Other removals
 
@@ -137,7 +139,7 @@ More details on [multiattach volumes types](https://docs.openstack.org/cinder/la
 
 ### Remove member from lb_pool_v1
 
-`member` block has been removed from `openstack_lb_pool_v1` resource. `openstack_lb_member_v1` resource should be used instead. 
+`member` block has been removed from `openstack_lb_pool_v1` resource. `openstack_lb_member_v1` resource should be used instead.
 
 ### Remove allocation_pools from networking_subnet_v2
 
@@ -160,6 +162,7 @@ More details on [multiattach volumes types](https://docs.openstack.org/cinder/la
 `sort_key` and `sort_dir` has been removed from `openstack_images_image_v2` and `openstack_images_image_ids_v2` data sources. `sort` should be used instead.
 
 For example:
+
 ```terraform
 data "openstack_images_image_ids_v2" "images" {
   name_regex = "^Ubuntu 16\\.04.*-amd64"
@@ -169,6 +172,7 @@ data "openstack_images_image_ids_v2" "images" {
 ```
 
 Should be changed into:
+
 ```terraform
 data "openstack_images_image_ids_v2" "images" {
   name_regex = "^Ubuntu 16\\.04.*-amd64"
@@ -195,6 +199,7 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
 ```
 
 should be changed into:
+
 ```terraform
 resource "openstack_networking_subnet_v2" "subnet_1" {
   name       = "subnet_1"

--- a/docs/guides/upgrade-guide-version-3.md
+++ b/docs/guides/upgrade-guide-version-3.md
@@ -6,12 +6,15 @@ description: |-
   Terraform Openstack Provider Version 3.0 Upgrade Guide
 ---
 
+# Terraform Openstack Provider Version 3.0 Upgrade Guide
+
 Version 3.0.0 of the OpenStack provider for Terraform is a major release that includes several important changes. This guide is intended to assist you in managing the upgrade process.
 
 Most of the changes described in this guide were previously marked as deprecated in the `terraform plan/apply` output in earlier provider releases. You can review these changes, including deprecation notices, in the [Terraform OpenStack Provider CHANGELOG](https://github.com/terraform-provider-openstack/terraform-provider-openstack/blob/main/CHANGELOG.md).
 
-### Table of Contents:
+## Table of Contents
 
+- [Table of Contents](#table-of-contents)
 - [Provider Version Configuration](#provider-version-configuration)
 - [Compute Floating IPs API Removal](#compute-floating-ips-api-removal)
 - [Compute Security Groups API Removal](#compute-security-groups-api-removal)
@@ -20,7 +23,7 @@ Most of the changes described in this guide were previously marked as deprecated
 
 ## Provider Version Configuration
 
-When configuring Terraform providers, always use [version constraints](https://www.terraform.io/docs/configuration/providers.html#provider-versions). If you have implemented version constraints, update them accordingly in your configuration and run [`terraform init -upgrade`](https://www.terraform.io/docs/commands/init.html) to download the latest version.
+When configuring Terraform providers, always use [version constraints](https://developer.hashicorp.com/terraform/language/block/provider#provider-versions). If you have implemented version constraints, update them accordingly in your configuration and run [`terraform init -upgrade`](https://developer.hashicorp.com/terraform/cli/commands/init) to download the latest version.
 
 For example, if your previous configuration looked like this:
 
@@ -140,24 +143,24 @@ This API was used in the `openstack_compute_instance_v2` resource when the `OS_N
 
 Several data sources have been removed in this version:
 
-| Data Source | Replacement |
-|-------------|-------------|
+| Data Source                          | Replacement                          |
+| ------------------------------------ | ------------------------------------ |
 | `openstack_blockstorage_snapshot_v2` | `openstack_blockstorage_snapshot_v3` |
 | `openstack_blockstorage_volume_v2`   | `openstack_blockstorage_volume_v3`   |
 | `openstack_fw_policy_v1`             | `openstack_fw_policy_v2`             |
 
 In addition, the following resources have been removed:
 
-| Resource | Replacement |
-|----------|-------------|
-| `openstack_blockstorage_quotaset_v2`           | `openstack_blockstorage_quotaset_v3`           |
-| `openstack_blockstorage_volume_v1`             | `openstack_blockstorage_volume_v3`             |
-| `openstack_blockstorage_volume_v2`             | `openstack_blockstorage_volume_v3`             |
-| `openstack_blockstorage_volume_attach_v2`      | `openstack_blockstorage_volume_attach_v3`      |
-| `openstack_fw_firewall_v1`                     | `openstack_fw_group_v2`                        |
-| `openstack_fw_policy_v1`                       | `openstack_fw_policy_v2`                       |
-| `openstack_fw_rule_v1`                         | `openstack_fw_rule_v2`                         |
-| `openstack_lb_member_v1`                       | `openstack_lb_member_v2`                       |
-| `openstack_lb_monitor_v1`                      | `openstack_lb_monitor_v2`                      |
-| `openstack_lb_pool_v1`                         | `openstack_lb_pool_v2`                         |
-| `openstack_lb_vip_v1`                          | `openstack_lb_loadbalancer_v2`, `openstack_lb_listener_v2`, `openstack_networking_floatingip_associate_v2` |
+| Resource                                  | Replacement                                                                                                |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `openstack_blockstorage_quotaset_v2`      | `openstack_blockstorage_quotaset_v3`                                                                       |
+| `openstack_blockstorage_volume_v1`        | `openstack_blockstorage_volume_v3`                                                                         |
+| `openstack_blockstorage_volume_v2`        | `openstack_blockstorage_volume_v3`                                                                         |
+| `openstack_blockstorage_volume_attach_v2` | `openstack_blockstorage_volume_attach_v3`                                                                  |
+| `openstack_fw_firewall_v1`                | `openstack_fw_group_v2`                                                                                    |
+| `openstack_fw_policy_v1`                  | `openstack_fw_policy_v2`                                                                                   |
+| `openstack_fw_rule_v1`                    | `openstack_fw_rule_v2`                                                                                     |
+| `openstack_lb_member_v1`                  | `openstack_lb_member_v2`                                                                                   |
+| `openstack_lb_monitor_v1`                 | `openstack_lb_monitor_v2`                                                                                  |
+| `openstack_lb_pool_v1`                    | `openstack_lb_pool_v2`                                                                                     |
+| `openstack_lb_vip_v1`                     | `openstack_lb_loadbalancer_v2`, `openstack_lb_listener_v2`, `openstack_networking_floatingip_associate_v2` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ Use the navigation to the left to read about the available resources.
 ```hcl
 # Define required providers
 terraform {
-required_version = ">= 0.14.0"
+  required_version = ">= 0.14.0"
   required_providers {
     openstack = {
       source  = "terraform-provider-openstack/openstack"
@@ -250,7 +250,7 @@ To enable these logs, set the `OS_DEBUG` environment variable to `1` along
 with the usual `TF_LOG=DEBUG` environment variable:
 
 ```shell
-$ OS_DEBUG=1 TF_LOG=DEBUG terraform apply
+OS_DEBUG=1 TF_LOG=DEBUG terraform apply
 ```
 
 If you submit these logs with a bug report, please ensure any sensitive
@@ -294,7 +294,7 @@ with all other resources is either untested or known to not work.
 
 * To use networks, override the endpoint in your provider configuration
 
-```
+```hcl
 provider "openstack" {
   user_name = "your-username"
   password  = "your-password"
@@ -310,7 +310,7 @@ provider "openstack" {
 * Explicitly define the public and private networks in your
 instances as shown below:
 
-```
+```hcl
 resource "openstack_compute_instance_v2" "my_instance" {
   name      = "my_instance"
   region    = "DFW"
@@ -410,24 +410,28 @@ this provider uses [Go Modules](https://github.com/golang/go/wiki/Modules).
 
 If there is access to an existing cloud, developers can test changes on resources
 against that cloud. In order to do so:
-- Build the provider with your changes
+
+* Build the provider with your changes
 
 Build locally the provider including your changes with:
-```
+
+```shell
 go build .
 ```
+
 this should generate a `terraform-provider-openstack` binary.
 
-- Remove the Terraform Lock File
+* Remove the Terraform Lock File
 
 If there is already a terraform lock file, remove it with:
-```
+
+```shell
 rm .terraform.lock.hcl
 ```
 
-- Create or edit `.terraform.rc` as shown below:
+* Create or edit `.terraform.rc` as shown below:
 
-```
+```hcl
 provider_installation {
   dev_overrides {
     "registry.terraform.io/terraform-provider-openstack/openstack" = "/path/to/directory/where/the/provider/binary/is"
@@ -435,21 +439,22 @@ provider_installation {
   direct {}
 }
 ```
+
 This configuration tells Terraform to use the provider binary at the specified path
 instead of the one from the Terraform Registry. The direct {} block tells Terraform
 to use the provider from the Terraform Registry if it’s not available locally.
 Any other providers not specified in dev_overrides will still be downloaded from the
 Terraform Registry.
 
-- Set Environment Variable for Terraform Configuration
+* Set Environment Variable for Terraform Configuration
 
-```
+```shell
 export TF_CLI_CONFIG_FILE=~/.terraform.rc
 ```
 
-- Run terraform
+* Run terraform
 
-```
+```shell
 ❯ terraform plan
 
 │ Warning: Provider development overrides are in effect
@@ -458,13 +463,12 @@ export TF_CLI_CONFIG_FILE=~/.terraform.rc
 │  - terraform-provider-openstack/openstack in /path/to/directory/where/the/provider/binary/is
 │
 | The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
-
 ```
 
 ### Acceptance Tests
 
 Acceptance Tests are a crucial part of adding features or fixing a bug. Please
-make sure to read the core [testing](https://www.terraform.io/docs/extend/testing/index.html)
+make sure to read the core [testing](https://developer.hashicorp.com/terraform/plugin/sdkv2/testing)
 documentation for more information about how Acceptance Tests work.
 
 In order to run the Acceptance Tests, you'll need to set the following
@@ -530,26 +534,26 @@ We recommend only running the acceptance tests related to the feature or bug
 you're working on. To do this, run:
 
 ```shell
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack
-$ make testacc TEST=./openstack TESTARGS="-run=<keyword> -count=1"
+cd $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack
+make testacc TEST=./openstack TESTARGS="-run=<keyword> -count=1"
 ```
 
 Where `<keyword>` is the full name or partial name of a test. For example:
 
 ```shell
-$ make testacc TEST=./openstack TESTARGS="-run=TestAccComputeV2Keypair_basic -count=1"
+make testacc TEST=./openstack TESTARGS="-run=TestAccComputeV2Keypair_basic -count=1"
 ```
 
 We recommend running tests with logging set to `DEBUG`:
 
 ```shell
-$ TF_LOG=DEBUG make testacc TEST=./openstack TESTARGS="-run=TestAccComputeV2Keypair_basic -count=1"
+TF_LOG=DEBUG make testacc TEST=./openstack TESTARGS="-run=TestAccComputeV2Keypair_basic -count=1"
 ```
 
 And you can even enable OpenStack debugging to see the actual HTTP API requests:
 
 ```shell
-$ TF_LOG=DEBUG OS_DEBUG=1 make testacc TEST=./openstack TESTARGS="-run=TestAccComputeV2Keypair_basic -count=1"
+TF_LOG=DEBUG OS_DEBUG=1 make testacc TEST=./openstack TESTARGS="-run=TestAccComputeV2Keypair_basic -count=1"
 ```
 
 ### Creating a Pull Request
@@ -558,14 +562,14 @@ When you're ready to submit a Pull Request, create a branch, commit your code,
 and push to your forked version of `terraform-provider-openstack`:
 
 ```shell
-$ git remote add my-github-username https://github.com/my-github-username/terraform-provider-openstack
-$ git checkout -b my-feature
-$ git add .
-$ git commit
-$ git push -u my-github-username my-feature
+git remote add my-github-username https://github.com/my-github-username/terraform-provider-openstack
+git checkout -b my-feature
+git add .
+git commit
+git push -u my-github-username my-feature
 ```
 
-Then navigate to https://github.com/terraform-provider-openstack/terraform-provider-openstack
+Then navigate to <https://github.com/terraform-provider-openstack/terraform-provider-openstack>
 and create a Pull Request.
 
 ### Testing with GitHub Actions

--- a/docs/index.md
+++ b/docs/index.md
@@ -354,6 +354,18 @@ OpenStack Provider contributors aren't!) and we're happy to provide
 guidance. Don't be afraid if this is your first contribution to the OpenStack
 provider or even your first contribution to an open source project!
 
+#### Markdown Documentation Style
+
+We use [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) to ensure all Markdown documentation follows a consistent style.
+All Markdown files are checked for linting issues by GitHub Actions for every pull request.
+
+You can also run the linting locally before submitting a PR:
+
+```shell
+npm install -g markdownlint-cli2
+make lint-markdown
+```
+
 ### Testing Environment
 
 In order to start fixing bugs or adding features, you need access to an

--- a/docs/resources/bgpvpn_network_associate_v2.md
+++ b/docs/resources/bgpvpn_network_associate_v2.md
@@ -55,6 +55,6 @@ The following attributes are exported:
 BGP VPN network associations can be imported using the BGP VPN ID and BGP VPN
 network association ID separated by a slash, e.g.:
 
-```hcl
-$ terraform import openstack_bgpvpn_network_associate_v2.association_1 2145aaa9-edaa-44fb-9815-e47a96677a72/67bb952a-f9d1-4fc8-ae84-082253a879d4
+```shell
+terraform import openstack_bgpvpn_network_associate_v2.association_1 2145aaa9-edaa-44fb-9815-e47a96677a72/67bb952a-f9d1-4fc8-ae84-082253a879d4
 ```

--- a/docs/resources/bgpvpn_port_associate_v2.md
+++ b/docs/resources/bgpvpn_port_associate_v2.md
@@ -80,6 +80,6 @@ The following attributes are exported:
 BGP VPN port associations can be imported using the BGP VPN ID and BGP VPN port
 association ID separated by a slash, e.g.:
 
-```hcl
-$ terraform import openstack_bgpvpn_port_associate_v2.association_1 5bb44ecf-f8fe-4d75-8fc5-313f96ee2696/8f8fc660-3f28-414e-896a-0c7c51162fcf
+```shell
+terraform import openstack_bgpvpn_port_associate_v2.association_1 5bb44ecf-f8fe-4d75-8fc5-313f96ee2696/8f8fc660-3f28-414e-896a-0c7c51162fcf
 ```

--- a/docs/resources/bgpvpn_router_associate_v2.md
+++ b/docs/resources/bgpvpn_router_associate_v2.md
@@ -15,8 +15,8 @@ Manages a V2 BGP VPN router association resource within OpenStack.
 
 ```hcl
 resource "openstack_bgpvpn_router_associate_v2" "association_1" {
-  bgpvpn_id  = "d57d39e1-dc63-44fd-8cbd-a4e1488100c5"
-  router_id  = "423fa80f-e0d7-4d02-a9a5-8b8c05812bf6"
+  bgpvpn_id = "d57d39e1-dc63-44fd-8cbd-a4e1488100c5"
+  router_id = "423fa80f-e0d7-4d02-a9a5-8b8c05812bf6"
 }
 ```
 
@@ -59,6 +59,6 @@ The following attributes are exported:
 BGP VPN router associations can be imported using the BGP VPN ID and BGP VPN
 router association ID separated by a slash, e.g.:
 
-```hcl
-$ terraform import openstack_bgpvpn_router_associate_v2.association_1 e26d509e-fc2d-4fb5-8562-619911a9a6bc/3cc9df2d-80db-4536-8ba6-295d1d0f723f
+```shell
+terraform import openstack_bgpvpn_router_associate_v2.association_1 e26d509e-fc2d-4fb5-8562-619911a9a6bc/3cc9df2d-80db-4536-8ba6-295d1d0f723f
 ```

--- a/docs/resources/bgpvpn_v2.md
+++ b/docs/resources/bgpvpn_v2.md
@@ -84,6 +84,6 @@ The following attributes are exported:
 
 BGP VPNs can be imported using the `id`, e.g.
 
-```hcl
-$ terraform import openstack_bgpvpn_v2.bgpvpn_1 1eec2c66-6be2-4305-af3f-354c9b81f18c
+```shell
+terraform import openstack_bgpvpn_v2.bgpvpn_1 1eec2c66-6be2-4305-af3f-354c9b81f18c
 ```

--- a/docs/resources/blockstorage_qos_association_v3.md
+++ b/docs/resources/blockstorage_qos_association_v3.md
@@ -13,15 +13,14 @@ Manages a V3 block storage Qos Association resource within OpenStack.
 
 ~> **Note:** This usually requires admin privileges.
 
-
 ## Example Usage
 
 ```hcl
 resource "openstack_blockstorage_qos_v3" "qos" {
-  name = "%s"
+  name     = "%s"
   consumer = "front-end"
   specs = {
-	  read_iops_sec = "20000"
+    read_iops_sec = "20000"
   }
 }
 
@@ -33,7 +32,6 @@ resource "openstack_blockstorage_qos_association_v3" "qos_association" {
   qos_id         = openstack_blockstorage_qos_v3.qos.id
   volume_type_id = openstack_blockstorage_volume_type_v3.volume_type.id
 }
-
 ```
 
 ## Argument Reference
@@ -62,6 +60,6 @@ The following attributes are exported:
 
 Qos association can be imported using the `qos_id/volume_type_id`, e.g.
 
-```
-$ terraform import openstack_blockstorage_qos_association_v3.qos_association 941793f0-0a34-4bc4-b72e-a6326ae58283/ea257959-eeb1-4c10-8d33-26f0409a755d
+```shell
+terraform import openstack_blockstorage_qos_association_v3.qos_association 941793f0-0a34-4bc4-b72e-a6326ae58283/ea257959-eeb1-4c10-8d33-26f0409a755d
 ```

--- a/docs/resources/blockstorage_qos_v3.md
+++ b/docs/resources/blockstorage_qos_v3.md
@@ -13,19 +13,17 @@ Manages a V3 block storage Quality-Of-Servirce (qos) resource within OpenStack.
 
 ~> **Note:** This usually requires admin privileges.
 
-
 ## Example Usage
 
 ```hcl
 resource "openstack_blockstorage_qos_v3" "qos" {
-  name = "foo"
+  name     = "foo"
   consumer = "back-end"
   specs = {
-		read_iops_sec  = "40000"
-		write_iops_sec = "40000"
-	}
+    read_iops_sec  = "40000"
+    write_iops_sec = "40000"
+  }
 }
-
 ```
 
 ## Argument Reference
@@ -57,6 +55,6 @@ The following attributes are exported:
 
 Qos can be imported using the `qos_id`, e.g.
 
-```
-$ terraform import openstack_blockstorage_qos_v3.qos 941793f0-0a34-4bc4-b72e-a6326ae58283
+```shell
+terraform import openstack_blockstorage_qos_v3.qos 941793f0-0a34-4bc4-b72e-a6326ae58283
 ```

--- a/docs/resources/blockstorage_quotaset_v3.md
+++ b/docs/resources/blockstorage_quotaset_v3.md
@@ -24,16 +24,16 @@ resource "openstack_identity_project_v3" "project_1" {
 }
 
 resource "openstack_blockstorage_quotaset_v3" "quotaset_1" {
-  project_id = openstack_identity_project_v3.project_1.id
-  volumes   = 10
-  snapshots = 4
-  gigabytes = 100
+  project_id           = openstack_identity_project_v3.project_1.id
+  volumes              = 10
+  snapshots            = 4
+  gigabytes            = 100
   per_volume_gigabytes = 10
-  backups = 4
-  backup_gigabytes = 10
-  groups = 100
+  backups              = 4
+  backup_gigabytes     = 10
+  groups               = 100
   volume_type_quota = {
-    volumes_ssd = 30
+    volumes_ssd   = 30
     gigabytes_ssd = 500
     snapshots_ssd = 10
   }
@@ -95,6 +95,6 @@ The following attributes are exported:
 
 Quotasets can be imported using the `project_id/region`, e.g.
 
-```
-$ terraform import openstack_blockstorage_quotaset_v3.quotaset_1 2a0f2240-c5e6-41de-896d-e80d97428d6b/region_1
+```shell
+terraform import openstack_blockstorage_quotaset_v3.quotaset_1 2a0f2240-c5e6-41de-896d-e80d97428d6b/region_1
 ```

--- a/docs/resources/blockstorage_volume_attach_v3.md
+++ b/docs/resources/blockstorage_volume_attach_v3.md
@@ -16,7 +16,7 @@ Please use the `openstack_compute_volume_attach_v2` resource for that.
 
 ~> **Note:** All arguments including the `data` computed attribute will be
 stored in the raw state as plain-text. [Read more about sensitive data in
-state](https://www.terraform.io/docs/language/state/sensitive-data.html).
+state](https://developer.hashicorp.com/terraform/language/manage-sensitive-data).
 
 Creates a general purpose attachment connection to a Block
 Storage volume using the OpenStack Block Storage (Cinder) v3 API.
@@ -101,7 +101,7 @@ required to complete the block storage connection.
 
 As an example, creating an iSCSI-based volume will return the following:
 
-```
+```text
 data.access_mode = rw
 data.auth_method = CHAP
 data.auth_password = xUhbGKQ8QCwKmHQ2
@@ -114,7 +114,7 @@ data.volume_id = 2d87ed25-c312-4f42-be1d-3b36b014561d
 This information can then be fed into a provisioner or a template shell script,
 where the final result would look something like:
 
-```
+```shell
 iscsiadm -m node -T ${self.data.target_iqn} -p ${self.data.target_portal} --interface default --op new
 iscsiadm -m node -T ${self.data.target_iqn} -p ${self.data.target_portal} --op update -n node.session.auth.authmethod -v ${self.data.auth_method}
 iscsiadm -m node -T ${self.data.target_iqn} -p ${self.data.target_portal} --op update -n node.session.auth.username -v ${self.data.auth_username}

--- a/docs/resources/blockstorage_volume_type_access_v3.md
+++ b/docs/resources/blockstorage_volume_type_access_v3.md
@@ -13,7 +13,6 @@ Manages a V3 block storage volume type access resource within OpenStack.
 
 ~> **Note:** This usually requires admin privileges.
 
-
 ## Example Usage
 
 ```hcl
@@ -30,7 +29,6 @@ resource "openstack_blockstorage_volume_type_access_v3" "volume_type_access" {
   project_id     = openstack_identity_project_v3.project_1.id
   volume_type_id = openstack_blockstorage_volume_type_v3.volume_type_1.id
 }
-
 ```
 
 ## Argument Reference
@@ -47,7 +45,6 @@ The following arguments are supported:
 * `volume_type_id` - (Required) ID of the volume type to give access to. Changing
     this creates a new resource.
 
-
 ## Attributes Reference
 
 The following attributes are exported:
@@ -60,6 +57,6 @@ The following attributes are exported:
 
 Volume types access can be imported using the `volume_type_id/project_id`, e.g.
 
-```
-$ terraform import openstack_blockstorage_volume_type_access_v3.volume_type_access 941793f0-0a34-4bc4-b72e-a6326ae58283/ed498e81f0cc448bae0ad4f8f21bf67f
+```shell
+terraform import openstack_blockstorage_volume_type_access_v3.volume_type_access 941793f0-0a34-4bc4-b72e-a6326ae58283/ed498e81f0cc448bae0ad4f8f21bf67f
 ```

--- a/docs/resources/blockstorage_volume_type_v3.md
+++ b/docs/resources/blockstorage_volume_type_v3.md
@@ -13,7 +13,6 @@ Manages a V3 block storage volume type resource within OpenStack.
 
 ~> **Note:** This usually requires admin privileges.
 
-
 ## Example Usage
 
 ### Basic Volume Type
@@ -23,11 +22,10 @@ resource "openstack_blockstorage_volume_type_v3" "volume_type_1" {
   name        = "volume_type_1"
   description = "Volume type 1"
   extra_specs = {
-      capabilities        = "gpu"
-      volume_backend_name = "ssd"
+    capabilities        = "gpu"
+    volume_backend_name = "ssd"
   }
 }
-
 ```
 
 ### Volume Type with multiattach enabled
@@ -37,11 +35,11 @@ resource "openstack_blockstorage_volume_type_v3" "multiattach" {
   name        = "multiattach"
   description = "Multiattach-enabled volume type"
   extra_specs = {
-      multiattach = "<is> True"
+    multiattach = "<is> True"
   }
 }
-
 ```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -75,6 +73,6 @@ The following attributes are exported:
 
 Volume types can be imported using the `volume_type_id`, e.g.
 
-```
-$ terraform import openstack_blockstorage_volume_type_v3.volume_type_1 941793f0-0a34-4bc4-b72e-a6326ae58283
+```shell
+terraform import openstack_blockstorage_volume_type_v3.volume_type_1 941793f0-0a34-4bc4-b72e-a6326ae58283
 ```

--- a/docs/resources/blockstorage_volume_v3.md
+++ b/docs/resources/blockstorage_volume_v3.md
@@ -70,7 +70,7 @@ The following arguments are supported:
     creates a new volume. Requires microversion >= 3.47.
 
 * `volume_type` - (Optional) The type of volume to create or update.
-    Changing this will attempt an in-place retype operation; migration depends on `volume_retype_policy`.  
+    Changing this will attempt an in-place retype operation; migration depends on `volume_retype_policy`.
 
 * `volume_retype_policy` - (Optional) Migration policy when changing `volume_type`.
     `"never"` *(default)* prevents migration to another storage backend, while `"on-demand"`
@@ -78,27 +78,26 @@ The following arguments are supported:
 
 * `scheduler_hints` - (Optional) Provide the Cinder scheduler with hints on where
     to instantiate a volume in the OpenStack cloud. The available hints are described below.
-    
+
 The `scheduler_hints` block supports:
 
-* `different_host` - (Optional) The volume should be scheduled on a 
+* `different_host` - (Optional) The volume should be scheduled on a
     different host from the set of volumes specified in the list provided.
 
 * `same_host` - (Optional) A list of volume UUIDs. The volume should be
     scheduled on the same host as another volume specified in the list provided.
 
-* `local_to_instance` - (Optional) An instance UUID. The volume should be 
+* `local_to_instance` - (Optional) An instance UUID. The volume should be
     scheduled on the same host as the instance.
 
-* `query` - (Optional) A conditional query that a back-end must pass in
-    order to host a volume. The query must use the `JsonFilter` syntax
-    which is described
-    [here](https://docs.openstack.org/cinder/latest/configuration/block-storage/scheduler-filters.html#jsonfilter).
+* `query` – (Optional) A conditional query that a back-end must satisfy in order
+    to host a volume. The query must use the `JsonFilter` syntax which is described in the
+    [Cinder scheduler JsonFilter documentation][cinder-jsonfilter].
     At this time, only simple queries are supported. Compound queries using
     `and`, `or`, or `not` are not supported. An example of a simple query is:
 
-    ```
-    [“=”, “$backend_id”, “rbd:vol@ceph#cloud”]
+    ```json
+    ["=", "$backend_id", "rbd:vol@ceph#cloud"]
     ```
 
 * `additional_properties` - (Optional) Arbitrary key/value pairs of additional
@@ -127,6 +126,8 @@ The following attributes are exported:
 
 Volumes can be imported using the `id`, e.g.
 
+```shell
+terraform import openstack_blockstorage_volume_v3.volume_1 ea257959-eeb1-4c10-8d33-26f0409a755d
 ```
-$ terraform import openstack_blockstorage_volume_v3.volume_1 ea257959-eeb1-4c10-8d33-26f0409a755d
-```
+
+[cinder-jsonfilter]: https://docs.openstack.org/cinder/latest/configuration/block-storage/scheduler-filters.html#jsonfilter

--- a/docs/resources/compute_aggregate_v2.md
+++ b/docs/resources/compute_aggregate_v2.md
@@ -57,12 +57,14 @@ The following arguments are supported:
 ## Import
 
 You can import an existing Host Aggregate by their ID.
-```
-$ terraform import openstack_compute_aggregate_v2.myaggregate 24
+
+```shell
+terraform import openstack_compute_aggregate_v2.myaggregate 24
 ```
 
 The ID can be obtained with an openstack command:
-```
+
+```shell
 $ openstack aggregate list
 +----+------+-------------------+
 | ID | Name | Availability Zone |

--- a/docs/resources/compute_flavor_access_v2.md
+++ b/docs/resources/compute_flavor_access_v2.md
@@ -63,6 +63,6 @@ The following attributes are exported:
 This resource can be imported by specifying all two arguments, separated
 by a forward slash:
 
-```
-$ terraform import openstack_compute_flavor_access_v2.access_1 flavor_id/tenant_id
+```shell
+terraform import openstack_compute_flavor_access_v2.access_1 flavor_id/tenant_id
 ```

--- a/docs/resources/compute_flavor_v2.md
+++ b/docs/resources/compute_flavor_v2.md
@@ -88,6 +88,6 @@ The following attributes are exported:
 
 Flavors can be imported using the `ID`, e.g.
 
-```
-$ terraform import openstack_compute_flavor_v2.my-flavor 4142e64b-1b35-44a0-9b1e-5affc7af1106
+```shell
+terraform import openstack_compute_flavor_v2.my-flavor 4142e64b-1b35-44a0-9b1e-5affc7af1106
 ```

--- a/docs/resources/compute_interface_attach_v2.md
+++ b/docs/resources/compute_interface_attach_v2.md
@@ -31,7 +31,6 @@ resource "openstack_compute_interface_attach_v2" "ai_1" {
   instance_id = openstack_compute_instance_v2.instance_1.id
   network_id  = openstack_networking_network_v2.network_1.id
 }
-
 ```
 
 ### Attachment Specifying a Fixed IP
@@ -52,9 +51,7 @@ resource "openstack_compute_interface_attach_v2" "ai_1" {
   network_id  = openstack_networking_port_v2.network_1.id
   fixed_ip    = "10.0.10.10"
 }
-
 ```
-
 
 ### Attachment Using an Existing Port
 
@@ -80,7 +77,6 @@ resource "openstack_compute_interface_attach_v2" "ai_1" {
   instance_id = openstack_compute_instance_v2.instance_1.id
   port_id     = openstack_networking_port_v2.port_1.id
 }
-
 ```
 
 ### Attaching Multiple Interfaces
@@ -173,13 +169,13 @@ The following attributes are exported:
 * `instance_id` - See Argument Reference above.
 * `port_id` - See Argument Reference above.
 * `network_id` - See Argument Reference above.
-* `fixed_ip`  - See Argument Reference above.
+* `fixed_ip` - See Argument Reference above.
 
 ## Import
 
 Interface Attachments can be imported using the Instance ID and Port ID
 separated by a slash, e.g.
 
-```
-$ terraform import openstack_compute_interface_attach_v2.ai_1 89c60255-9bd6-460c-822a-e2b959ede9d2/45670584-225f-46c3-b33e-6707b589b666
+```shell
+terraform import openstack_compute_interface_attach_v2.ai_1 89c60255-9bd6-460c-822a-e2b959ede9d2/45670584-225f-46c3-b33e-6707b589b666
 ```

--- a/docs/resources/compute_keypair_v2.md
+++ b/docs/resources/compute_keypair_v2.md
@@ -74,6 +74,6 @@ The following attributes are exported:
 
 Keypairs can be imported using the `name`, e.g.
 
-```
-$ terraform import openstack_compute_keypair_v2.my-keypair test-keypair
+```shell
+terraform import openstack_compute_keypair_v2.my-keypair test-keypair
 ```

--- a/docs/resources/compute_quotaset_v2.md
+++ b/docs/resources/compute_quotaset_v2.md
@@ -112,6 +112,6 @@ The following attributes are exported:
 
 Quotasets can be imported using the `project_id/region_name`, e.g.
 
-```
-$ terraform import openstack_compute_quotaset_v2.quotaset_1 2a0f2240-c5e6-41de-896d-e80d97428d6b/region_1
+```shell
+terraform import openstack_compute_quotaset_v2.quotaset_1 2a0f2240-c5e6-41de-896d-e80d97428d6b/region_1
 ```

--- a/docs/resources/compute_servergroup_v2.md
+++ b/docs/resources/compute_servergroup_v2.md
@@ -13,7 +13,7 @@ Manages a V2 Server Group resource within OpenStack.
 
 ## Example Usage
 
-### Compute service API version 2.63 or below:
+### Compute service API version 2.63 or below
 
 ```hcl
 resource "openstack_compute_servergroup_v2" "test-sg" {
@@ -36,14 +36,14 @@ resource "openstack_compute_instance_v2" "test-instance" {
 }
 ```
 
-### Compute service API version 2.64 or above:
+### Compute service API version 2.64 or above
 
 ```hcl
 resource "openstack_compute_servergroup_v2" "test-sg" {
   name     = "my-sg"
   policies = ["anti-affinity"]
   rules {
-      max_server_per_host = 3
+    max_server_per_host = 3
   }
 }
 
@@ -114,6 +114,6 @@ The following attributes are exported:
 
 Server Groups can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_compute_servergroup_v2.test-sg 1bc30ee9-9d5b-4c30-bdd5-7f1e663f5edf
+```shell
+terraform import openstack_compute_servergroup_v2.test-sg 1bc30ee9-9d5b-4c30-bdd5-7f1e663f5edf
 ```

--- a/docs/resources/compute_volume_attach_v2.md
+++ b/docs/resources/compute_volume_attach_v2.md
@@ -103,7 +103,7 @@ clouds support multiattach. Multiattach volumes require a volume_type that has [
 resource "openstack_blockstorage_volume_v3" "volume_1" {
   name        = "volume_1"
   size        = 1
-  volume_type = "multiattach" 
+  volume_type = "multiattach"
 }
 
 resource "openstack_compute_instance_v2" "instance_1" {
@@ -186,6 +186,6 @@ The following attributes are exported:
 Volume Attachments can be imported using the Instance ID and Volume ID
 separated by a slash, e.g.
 
-```
-$ terraform import openstack_compute_volume_attach_v2.va_1 89c60255-9bd6-460c-822a-e2b959ede9d2/45670584-225f-46c3-b33e-6707b589b666
+```shell
+terraform import openstack_compute_volume_attach_v2.va_1 89c60255-9bd6-460c-822a-e2b959ede9d2/45670584-225f-46c3-b33e-6707b589b666
 ```

--- a/docs/resources/containerinfra_cluster_v1.md
+++ b/docs/resources/containerinfra_cluster_v1.md
@@ -13,7 +13,7 @@ Manages a V1 Magnum cluster resource within OpenStack.
 
 ~> **Note:** All arguments including the `kubeconfig` computed attribute will be
 stored in the raw state as plain-text. [Read more about sensitive data in
-state](https://www.terraform.io/docs/language/state/sensitive-data.html).
+state](https://developer.hashicorp.com/terraform/language/manage-sensitive-data).
 
 ## Example Usage
 
@@ -85,7 +85,7 @@ The following arguments are supported:
   for the master nodes. Changing this creates a new cluster.
 
 * `node_count` - (Optional) The number of nodes for the cluster.
-    
+
 * `fixed_network` - (Optional) The fixed network that will be attached to the
     cluster. Changing this creates a new cluster.
 
@@ -135,6 +135,6 @@ The following attributes are exported:
 
 Clusters can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_containerinfra_cluster_v1.cluster_1 ce0f9463-dd25-474b-9fe8-94de63e5e42b
+```shell
+terraform import openstack_containerinfra_cluster_v1.cluster_1 ce0f9463-dd25-474b-9fe8-94de63e5e42b
 ```

--- a/docs/resources/containerinfra_clustertemplate_v1.md
+++ b/docs/resources/containerinfra_clustertemplate_v1.md
@@ -206,6 +206,6 @@ The following attributes are exported:
 
 Cluster templates can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_containerinfra_clustertemplate_v1.clustertemplate_1 b9a45c5c-cd03-4958-82aa-b80bf93cb922
+```shell
+terraform import openstack_containerinfra_clustertemplate_v1.clustertemplate_1 b9a45c5c-cd03-4958-82aa-b80bf93cb922
 ```

--- a/docs/resources/containerinfra_nodegroup_v1.md
+++ b/docs/resources/containerinfra_nodegroup_v1.md
@@ -17,9 +17,9 @@ Manages a V1 Magnum node group resource within OpenStack.
 
 ```hcl
 resource "openstack_containerinfra_nodegroup_v1" "nodegroup_1" {
-  name                = "nodegroup_1"
-  cluster_id          = "b9a45c5c-cd03-4958-82aa-b80bf93cb922"
-  node_count          = 5
+  name       = "nodegroup_1"
+  cluster_id = "b9a45c5c-cd03-4958-82aa-b80bf93cb922"
+  node_count = 5
 }
 ```
 
@@ -71,7 +71,6 @@ The following arguments are supported:
 * `role` - (Optional) The role of nodes in the node group. Changing this
     creates a new node group.
 
-
 ## Attributes reference
 
 The following attributes are exported:
@@ -95,6 +94,6 @@ The following attributes are exported:
 
 Node groups can be imported using the `id` (cluster_id/nodegroup_id), e.g.
 
-```
-$ terraform import openstack_containerinfra_nodegroup_v1.nodegroup_1 b9a45c5c-cd03-4958-82aa-b80bf93cb922/ce0f9463-dd25-474b-9fe8-94de63e5e42b
+```shell
+terraform import openstack_containerinfra_nodegroup_v1.nodegroup_1 b9a45c5c-cd03-4958-82aa-b80bf93cb922/ce0f9463-dd25-474b-9fe8-94de63e5e42b
 ```

--- a/docs/resources/db_configuration_v1.md
+++ b/docs/resources/db_configuration_v1.md
@@ -59,7 +59,6 @@ The `configuration` block supports:
 * `value` - (Optional) Configuration parameter value. Changing this creates a new resource.
 * `string_type` - (Optional) Whether or not to store configuration parameter value as string. Changing this creates a new resource. See the below note for more information.
 
-
 ## Attributes Reference
 
 The following attributes are exported:
@@ -76,7 +75,9 @@ The following attributes are exported:
 ## Types of configuration parameter values
 
 Openstack API requires to store some database configuration parameter's values as strings, even if they contain numbers.
-To force store their values as strings set `string_type` to `true`. Otherwise Terraform will try to store them as number what can cause error from Openstack API like below:
-```
+To force store their values as strings set `string_type` to `true`. Otherwise Terraform will try to store them as number what can cause error from Openstack
+API like below:
+
+```json
 "The value provided for the configuration parameter log_min_duration_statement is not of type string."
 ```

--- a/docs/resources/db_database_v1.md
+++ b/docs/resources/db_database_v1.md
@@ -45,6 +45,6 @@ The following attributes are exported:
 
 Databases can be imported by using `instance-id/db-name`, e.g.
 
-```
-$ terraform import openstack_db_database_v1.mydb 7b9e3cd3-00d9-449c-b074-8439f8e274fa/mydb
+```shell
+terraform import openstack_db_database_v1.mydb 7b9e3cd3-00d9-449c-b074-8439f8e274fa/mydb
 ```

--- a/docs/resources/db_instance_v1.md
+++ b/docs/resources/db_instance_v1.md
@@ -13,7 +13,7 @@ Manages a V1 DB instance resource within OpenStack.
 
 ~> **Note:** All arguments including the instance user password will be stored
 in the raw state as plain-text. [Read more about sensitive data in
-state](https://www.terraform.io/docs/language/state/sensitive-data.html).
+state](https://developer.hashicorp.com/terraform/language/manage-sensitive-data).
 
 ## Example Usage
 

--- a/docs/resources/db_user_v1.md
+++ b/docs/resources/db_user_v1.md
@@ -13,7 +13,7 @@ Manages a V1 DB user resource within OpenStack.
 
 ~> **Note:** All arguments including the database password will be stored in the
 raw state as plain-text. [Read more about sensitive data in
-state](https://www.terraform.io/docs/language/state/sensitive-data.html).
+state](https://developer.hashicorp.com/terraform/language/manage-sensitive-data).
 
 ## Example Usage
 
@@ -21,10 +21,10 @@ state](https://www.terraform.io/docs/language/state/sensitive-data.html).
 
 ```hcl
 resource "openstack_db_user_v1" "basic" {
-  name         = "basic"
-  instance_id  = openstack_db_instance_v1.basic.id
-  password     = "password"
-  databases    = ["testdb"]
+  name        = "basic"
+  instance_id = openstack_db_instance_v1.basic.id
+  password    = "password"
+  databases   = ["testdb"]
 }
 ```
 

--- a/docs/resources/dns_quota_v2.md
+++ b/docs/resources/dns_quota_v2.md
@@ -37,7 +37,6 @@ resource "openstack_dns_quota_v2" "quota_1" {
 
 The following arguments are supported:
 
-
 * `region` - (Optional) The region in which to obtain the V2 DNS client. If
   omitted, the `region` argument of the provider is used. Changing this creates
   a new DNS quota.
@@ -73,6 +72,6 @@ The following attributes are exported:
 
 Quotas can be imported using the `project_id/region_name`, e.g.
 
-```
-$ terraform import openstack_dns_quota_v2.quota_1 2a0f2240-c5e6-41de-896d-e80d97428d6b/region_1
+```shell
+terraform import openstack_dns_quota_v2.quota_1 2a0f2240-c5e6-41de-896d-e80d97428d6b/region_1
 ```

--- a/docs/resources/dns_recordset_v2.md
+++ b/docs/resources/dns_recordset_v2.md
@@ -85,7 +85,7 @@ The following attributes are exported:
 
 This resource can be imported by specifying the zone ID and recordset ID with an optional project ID as a prefix:
 
-```
-$ terraform import openstack_dns_recordset_v2.recordset_1 project_id/zone_id/recordset_id
-$ terraform import openstack_dns_recordset_v2.recordset_1 zone_id/recordset_id
+```shell
+terraform import openstack_dns_recordset_v2.recordset_1 project_id/zone_id/recordset_id
+terraform import openstack_dns_recordset_v2.recordset_1 zone_id/recordset_id
 ```

--- a/docs/resources/dns_transfer_accept_v2.md
+++ b/docs/resources/dns_transfer_accept_v2.md
@@ -25,15 +25,14 @@ resource "openstack_dns_zone_v2" "example_zone" {
 }
 
 resource "openstack_dns_transfer_request_v2" "request_1" {
-  zone_id           = openstack_dns_zone_v2.example_zone.id
-  description       = "a transfer accept"
+  zone_id     = openstack_dns_zone_v2.example_zone.id
+  description = "a transfer accept"
 }
 
 resource "openstack_dns_transfer_accept_v2" "accept_1" {
   zone_transfer_request_id = openstack_dns_transfer_request_v2.request_1.id
   key                      = openstack_dns_transfer_request_v2.request_1.key
 }
-
 ```
 
 ## Argument Reference
@@ -68,6 +67,6 @@ The following attributes are exported:
 
 This resource can be imported by specifying the transferAccept ID:
 
-```
-$ terraform import openstack_dns_transfer_accept_v2.accept_1 accept_id
+```shell
+terraform import openstack_dns_transfer_accept_v2.accept_1 accept_id
 ```

--- a/docs/resources/dns_transfer_request_v2.md
+++ b/docs/resources/dns_transfer_request_v2.md
@@ -25,8 +25,8 @@ resource "openstack_dns_zone_v2" "example_zone" {
 }
 
 resource "openstack_dns_transfer_request_v2" "request_1" {
-  zone_id           = openstack_dns_zone_v2.example_zone.id
-  description       = "a transfer request"
+  zone_id     = openstack_dns_zone_v2.example_zone.id
+  description = "a transfer request"
 }
 ```
 
@@ -66,6 +66,6 @@ The following attributes are exported:
 
 This resource can be imported by specifying the transferRequest ID:
 
-```
-$ terraform import openstack_dns_transfer_request_v2.request_1 request_id
+```shell
+terraform import openstack_dns_transfer_request_v2.request_1 request_id
 ```

--- a/docs/resources/dns_zone_share_v2.md
+++ b/docs/resources/dns_zone_share_v2.md
@@ -18,7 +18,7 @@ resource "openstack_dns_zone_share_v2" "example" {
   zone_id           = "00000000-0000-0000-0000-000000000000"
   target_project_id = "11111111-1111-1111-1111-111111111111"
   # project_id is optional; if omitted, the provider derives it from the zone details.
-  project_id        = "22222222-2222-2222-2222-222222222222"
+  project_id = "22222222-2222-2222-2222-222222222222"
 }
 ```
 
@@ -52,7 +52,7 @@ The following attributes are exported:
 
 DNS zone share can be imported by specifying the zone ID with share ID and optional project ID:
 
-```bash
-$ terraform import openstack_dns_zone_share_v2.share_1 60cbdc69-64f9-49ee-b294-352e71e22827/0e1dae51-aee2-4b44-962f-885bb69f3a5c
-$ terraform import openstack_dns_zone_share_v2.share_1 60cbdc69-64f9-49ee-b294-352e71e22827/0e1dae51-aee2-4b44-962f-885bb69f3a5c/eb92139f6c054a878852ac9e8cbe612a
+```shell
+terraform import openstack_dns_zone_share_v2.share_1 60cbdc69-64f9-49ee-b294-352e71e22827/0e1dae51-aee2-4b44-962f-885bb69f3a5c
+terraform import openstack_dns_zone_share_v2.share_1 60cbdc69-64f9-49ee-b294-352e71e22827/0e1dae51-aee2-4b44-962f-885bb69f3a5c/eb92139f6c054a878852ac9e8cbe612a
 ```

--- a/docs/resources/dns_zone_v2.md
+++ b/docs/resources/dns_zone_v2.md
@@ -37,7 +37,7 @@ The following arguments are supported:
   Changing this creates a new DNS zone.
 
 * `project_id` - (Optional) The ID of the project DNS zone is created
-  for, sets `X-Auth-Sudo-Tenant-ID` header (requires an assigned 
+  for, sets `X-Auth-Sudo-Tenant-ID` header (requires an assigned
   user role in target project).
 
 * `email` - (Optional) The email contact for the zone record.
@@ -81,7 +81,7 @@ The following attributes are exported:
 
 This resource can be imported by specifying the zone ID with optional project ID:
 
-```
-$ terraform import openstack_dns_zone_v2.zone_1 zone_id
-$ terraform import openstack_dns_zone_v2.zone_1 zone_id/project_id
+```shell
+terraform import openstack_dns_zone_v2.zone_1 zone_id
+terraform import openstack_dns_zone_v2.zone_1 zone_id/project_id
 ```

--- a/docs/resources/fw_group_v2.md
+++ b/docs/resources/fw_group_v2.md
@@ -51,9 +51,9 @@ resource "openstack_fw_policy_v2" "policy_2" {
 }
 
 resource "openstack_fw_group_v2" "group_1" {
-  name      = "firewall_group"
+  name                       = "firewall_group"
   ingress_firewall_policy_id = openstack_fw_policy_v2.policy_1.id
-  egress_firewall_policy_id = openstack_fw_policy_v2.policy_2.id
+  egress_firewall_policy_id  = openstack_fw_policy_v2.policy_2.id
 }
 ```
 
@@ -124,6 +124,6 @@ The following attributes are exported:
 
 Firewall groups can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_fw_group_v2.group_1 c9e39fb2-ce20-46c8-a964-25f3898c7a97
+```shell
+terraform import openstack_fw_group_v2.group_1 c9e39fb2-ce20-46c8-a964-25f3898c7a97
 ```

--- a/docs/resources/fw_policy_v2.md
+++ b/docs/resources/fw_policy_v2.md
@@ -102,6 +102,6 @@ The following attributes are exported:
 
 Firewall Policies can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_fw_policy_v2.policy_1 07f422e6-c596-474b-8b94-fe2c12506ce0
+```shell
+terraform import openstack_fw_policy_v2.policy_1 07f422e6-c596-474b-8b94-fe2c12506ce0
 ```

--- a/docs/resources/fw_rule_v2.md
+++ b/docs/resources/fw_rule_v2.md
@@ -111,6 +111,6 @@ The following attributes are exported:
 
 Firewall Rules can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_fw_rule_v2.rule_1 8dbc0c28-e49c-463f-b712-5c5d1bbac327
+```shell
+terraform import openstack_fw_rule_v2.rule_1 8dbc0c28-e49c-463f-b712-5c5d1bbac327
 ```

--- a/docs/resources/identity_application_credential_v3.md
+++ b/docs/resources/identity_application_credential_v3.md
@@ -13,12 +13,12 @@ Manages a V3 Application Credential resource within OpenStack Keystone.
 
 ~> **Note:** All arguments including the application credential name and secret
 will be stored in the raw state as plain-text. [Read more about sensitive data
-in state](https://www.terraform.io/docs/language/state/sensitive-data.html).
+in state](https://developer.hashicorp.com/terraform/language/manage-sensitive-data).
 
 ~> **Note:** An Application Credential is created within the authenticated user
 project scope and is not visible by an admin or other accounts.
 The Application Credential visibility is similar to
-[`openstack_compute_keypair_v2`](compute_keypair_v2.html).
+[`openstack_compute_keypair_v2`](./compute_keypair_v2.md).
 
 ## Example Usage
 
@@ -63,8 +63,8 @@ starting from [Train](https://releases.openstack.org/train/highlights.html#keyst
 
 ```hcl
 resource "openstack_identity_application_credential_v3" "monitoring" {
-  name        = "monitoring"
-  expires_at  = "2019-02-13T12:12:12Z"
+  name       = "monitoring"
+  expires_at = "2019-02-13T12:12:12Z"
 
   access_rules {
     path    = "/v2.0/metrics"
@@ -157,6 +157,6 @@ The following attributes are exported:
 
 Application Credentials can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_identity_application_credential_v3.application_credential_1 c17304b7-0953-4738-abb0-67005882b0a0
+```shell
+terraform import openstack_identity_application_credential_v3.application_credential_1 c17304b7-0953-4738-abb0-67005882b0a0
 ```

--- a/docs/resources/identity_ec2_credential_v3.md
+++ b/docs/resources/identity_ec2_credential_v3.md
@@ -15,7 +15,7 @@ endpoints or to authenticate against Keystone.
 
 ~> **Note:** All arguments including the EC2 credential access key and secret
 will be stored in the raw state as plain-text. [Read more about sensitive data
-in state](https://www.terraform.io/docs/language/state/sensitive-data.html).
+in state](https://developer.hashicorp.com/terraform/language/manage-sensitive-data).
 
 ## Example Usage
 
@@ -32,7 +32,7 @@ from the current auth scope.
 
 ```hcl
 resource "openstack_identity_ec2_credential_v3" "ec2_key1" {
-    project_id = "f7ac731cc11f40efbc03a9f9e1d1d21f"
+  project_id = "f7ac731cc11f40efbc03a9f9e1d1d21f"
 }
 ```
 
@@ -66,6 +66,6 @@ The following attributes are exported:
 
 EC2 Credentials can be imported using the `access`, e.g.
 
-```
-$ terraform import openstack_identity_ec2_credential_v3.ec2_cred_1 2d0ac4a2f81b4b0f9513ee49e780647d
+```shell
+terraform import openstack_identity_ec2_credential_v3.ec2_cred_1 2d0ac4a2f81b4b0f9513ee49e780647d
 ```

--- a/docs/resources/identity_endpoint_v3.md
+++ b/docs/resources/identity_endpoint_v3.md
@@ -66,6 +66,6 @@ exported:
 
 Endpoints can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_identity_endpoint_v3.endpoint_1 5392472b-106a-4845-90c6-7c8445f18770
+```shell
+terraform import openstack_identity_endpoint_v3.endpoint_1 5392472b-106a-4845-90c6-7c8445f18770
 ```

--- a/docs/resources/identity_group_v3.md
+++ b/docs/resources/identity_group_v3.md
@@ -50,6 +50,6 @@ The following attributes are exported:
 
 groups can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_identity_group_v3.group_1 89c60255-9bd6-460c-822a-e2b959ede9d2
+```shell
+terraform import openstack_identity_group_v3.group_1 89c60255-9bd6-460c-822a-e2b959ede9d2
 ```

--- a/docs/resources/identity_inherit_role_assignment_v3.md
+++ b/docs/resources/identity_inherit_role_assignment_v3.md
@@ -20,19 +20,19 @@ this resource.
 
 ```hcl
 resource "openstack_identity_user_v3" "user_1" {
-  name = "user_1"
+  name      = "user_1"
   domain_id = "default"
 }
 
 resource "openstack_identity_role_v3" "role_1" {
-  name = "role_1"
+  name      = "role_1"
   domain_id = "default"
 }
 
 resource "openstack_identity_inherit_role_assignment_v3" "role_assignment_1" {
-  user_id = openstack_identity_user_v3.user_1.id
+  user_id   = openstack_identity_user_v3.user_1.id
   domain_id = "default"
-  role_id = openstack_identity_role_v3.role_1.id
+  role_id   = openstack_identity_role_v3.role_1.id
 }
 ```
 
@@ -68,16 +68,16 @@ The following attributes are exported:
 
 ## Import
 
-Inherit role assignments can be imported using a constructed id. The id should 
+Inherit role assignments can be imported using a constructed id. The id should
 have the form of `domainID/projectID/groupID/userID/roleID`. When something is
 not used then leave blank.
 
-For example this will import the inherit role assignment for: 
+For example this will import the inherit role assignment for:
 projectID: 014395cd-89fc-4c9b-96b7-13d1ee79dad2,
 userID: 4142e64b-1b35-44a0-9b1e-5affc7af1106,
 roleID: ea257959-eeb1-4c10-8d33-26f0409a755d
 ( domainID and groupID are left blank)
 
-```
-$ terraform import openstack_identity_inherit_role_assignment_v3.role_assignment_1 /014395cd-89fc-4c9b-96b7-13d1ee79dad2//4142e64b-1b35-44a0-9b1e-5affc7af1106/ea257959-eeb1-4c10-8d33-26f0409a755d
+```shell
+terraform import openstack_identity_inherit_role_assignment_v3.role_assignment_1 /014395cd-89fc-4c9b-96b7-13d1ee79dad2//4142e64b-1b35-44a0-9b1e-5affc7af1106/ea257959-eeb1-4c10-8d33-26f0409a755d
 ```

--- a/docs/resources/identity_limit_v3.md
+++ b/docs/resources/identity_limit_v3.md
@@ -75,6 +75,6 @@ The following attributes are exported:
 
 Limits can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_identity_limit_v3.limit_1 89c60255-9bd6-460c-822a-e2b959ede9d2
+```shell
+terraform import openstack_identity_limit_v3.limit_1 89c60255-9bd6-460c-822a-e2b959ede9d2
 ```

--- a/docs/resources/identity_project_v3.md
+++ b/docs/resources/identity_project_v3.md
@@ -67,6 +67,6 @@ The following attributes are exported:
 
 Projects can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_identity_project_v3.project_1 89c60255-9bd6-460c-822a-e2b959ede9d2
+```shell
+terraform import openstack_identity_project_v3.project_1 89c60255-9bd6-460c-822a-e2b959ede9d2
 ```

--- a/docs/resources/identity_registered_limit_v3.md
+++ b/docs/resources/identity_registered_limit_v3.md
@@ -64,6 +64,6 @@ The following attributes are exported:
 
 Registered Limits can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_identity_registered_limit_v3.limit_1 89c60255-9bd6-460c-822a-e2b959ede9d2
+```shell
+terraform import openstack_identity_registered_limit_v3.limit_1 89c60255-9bd6-460c-822a-e2b959ede9d2
 ```

--- a/docs/resources/identity_role_assignment_v3.md
+++ b/docs/resources/identity_role_assignment_v3.md
@@ -71,12 +71,12 @@ The following attributes are exported:
 Role assignments can be imported using a constructed id. The id should have the form of
 `domainID/projectID/groupID/userID/roleID`. When something is not used then leave blank.
 
-For example this will import the role assignment for: 
+For example this will import the role assignment for:
 projectID: 014395cd-89fc-4c9b-96b7-13d1ee79dad2,
 userID: 4142e64b-1b35-44a0-9b1e-5affc7af1106,
 roleID: ea257959-eeb1-4c10-8d33-26f0409a755d
 ( domainID and groupID are left blank)
 
-```
-$ terraform import openstack_identity_role_assignment_v3.role_assignment_1 /014395cd-89fc-4c9b-96b7-13d1ee79dad2//4142e64b-1b35-44a0-9b1e-5affc7af1106/ea257959-eeb1-4c10-8d33-26f0409a755d
+```shell
+terraform import openstack_identity_role_assignment_v3.role_assignment_1 /014395cd-89fc-4c9b-96b7-13d1ee79dad2//4142e64b-1b35-44a0-9b1e-5affc7af1106/ea257959-eeb1-4c10-8d33-26f0409a755d
 ```

--- a/docs/resources/identity_role_v3.md
+++ b/docs/resources/identity_role_v3.md
@@ -46,6 +46,6 @@ The following attributes are exported:
 
 Roles can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_identity_role_v3.role_1 89c60255-9bd6-460c-822a-e2b959ede9d2
+```shell
+terraform import openstack_identity_role_v3.role_1 89c60255-9bd6-460c-822a-e2b959ede9d2
 ```

--- a/docs/resources/identity_service_v3.md
+++ b/docs/resources/identity_service_v3.md
@@ -52,6 +52,6 @@ are exported:
 
 Services can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_identity_service_v3.service_1 6688e967-158a-496f-a224-cae3414e6b61
+```shell
+terraform import openstack_identity_service_v3.service_1 6688e967-158a-496f-a224-cae3414e6b61
 ```

--- a/docs/resources/identity_user_membership_v3.md
+++ b/docs/resources/identity_user_membership_v3.md
@@ -75,6 +75,6 @@ The following attributes are exported:
 This resource can be imported by specifying all two arguments, separated
 by a forward slash:
 
-```
-$ terraform import openstack_identity_user_membership_v3.user_membership_1 user_id/group_id
+```shell
+terraform import openstack_identity_user_membership_v3.user_membership_1 user_id/group_id
 ```

--- a/docs/resources/identity_user_v3.md
+++ b/docs/resources/identity_user_v3.md
@@ -13,7 +13,7 @@ Manages a V3 User resource within OpenStack Keystone.
 
 ~> **Note:** All arguments including the user password will be stored in the
 raw state as plain-text. [Read more about sensitive data in
-state](https://www.terraform.io/docs/language/state/sensitive-data.html).
+state](https://developer.hashicorp.com/terraform/language/manage-sensitive-data).
 
 ~> **Note:** You _must_ have admin privileges in your OpenStack cloud to use
 this resource.
@@ -105,6 +105,6 @@ The following attributes are exported:
 
 Users can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_identity_user_v3.user_1 89c60255-9bd6-460c-822a-e2b959ede9d2
+```shell
+terraform import openstack_identity_user_v3.user_1 89c60255-9bd6-460c-822a-e2b959ede9d2
 ```

--- a/docs/resources/images_image_access_accept_v2.md
+++ b/docs/resources/images_image_access_accept_v2.md
@@ -58,6 +58,6 @@ The following attributes are exported:
 
 Image access acceptance status can be imported using the `image_id`, e.g.
 
-```
-$ terraform import openstack_images_image_access_accept_v2 89c60255-9bd6-460c-822a-e2b959ede9d2
+```shell
+terraform import openstack_images_image_access_accept_v2 89c60255-9bd6-460c-822a-e2b959ede9d2
 ```

--- a/docs/resources/images_image_access_v2.md
+++ b/docs/resources/images_image_access_v2.md
@@ -92,6 +92,6 @@ The following attributes are exported:
 Image access can be imported using the `image_id` and the `member_id`,
 separated by a slash, e.g.
 
-```
-$ terraform import openstack_images_image_access_v2 89c60255-9bd6-460c-822a-e2b959ede9d2/bed6b6cbb86a4e2d8dc2735c2f1000e4
+```shell
+terraform import openstack_images_image_access_v2 89c60255-9bd6-460c-822a-e2b959ede9d2/bed6b6cbb86a4e2d8dc2735c2f1000e4
 ```

--- a/docs/resources/images_image_v2.md
+++ b/docs/resources/images_image_v2.md
@@ -13,7 +13,7 @@ Manages a V2 Image resource within OpenStack Glance.
 
 ~> **Note:** All arguments including the source image URL password will be
 stored in the raw state as plain-text. [Read more about sensitive data in
-state](https://www.terraform.io/docs/language/state/sensitive-data.html).
+state](https://developer.hashicorp.com/terraform/language/manage-sensitive-data).
 
 ## Example Usage
 
@@ -120,7 +120,7 @@ The following attributes are exported:
 * `id` - A unique ID assigned by Glance.
 * `metadata` - The metadata associated with the image.
    Image metadata allow for meaningfully define the image properties
-   and tags. See https://docs.openstack.org/glance/latest/user/metadefs-concepts.html.
+   and tags. See <https://docs.openstack.org/glance/latest/user/metadefs-concepts.html>.
 * `min_disk_gb` - See Argument Reference above.
 * `min_ram_mb` - See Argument Reference above.
 * `name` - See Argument Reference above.
@@ -158,6 +158,6 @@ Image Service set it.
 
 Images can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_images_image_v2.rancheros 89c60255-9bd6-460c-822a-e2b959ede9d2
+```shell
+terraform import openstack_images_image_v2.rancheros 89c60255-9bd6-460c-822a-e2b959ede9d2
 ```

--- a/docs/resources/keymanager_container_v1.md
+++ b/docs/resources/keymanager_container_v1.md
@@ -119,7 +119,9 @@ The following arguments are supported:
 
 The `secret_refs` block supports:
 
-* `name` - (Optional) The name of the secret reference. The reference names must correspond the container type, more details are available [here](https://docs.openstack.org/barbican/stein/api/reference/containers.html).
+* `name` - The name of the secret reference.
+  The reference name must correspond the container type. See the
+  [Barbican container reference documentation][barbican-containers].
 
 * `secret_ref` - (Required) The secret reference / where to find the secret, URL.
 
@@ -161,6 +163,8 @@ The `consumers` block supports:
 
 Containers can be imported using the container id (the last part of the container reference), e.g.:
 
+```shell
+terraform import openstack_keymanager_container_v1.container_1 0c6cd26a-c012-4d7b-8034-057c0f1c2953
 ```
-$ terraform import openstack_keymanager_container_v1.container_1 0c6cd26a-c012-4d7b-8034-057c0f1c2953
-```
+
+[barbican-containers]: https://docs.openstack.org/barbican/latest/api/reference/containers.html

--- a/docs/resources/keymanager_order_v1.md
+++ b/docs/resources/keymanager_order_v1.md
@@ -88,6 +88,6 @@ The following attributes are exported:
 
 Orders can be imported using the order id (the last part of the order reference), e.g.:
 
-```
-$ terraform import openstack_keymanager_order_v1.order_1 0c6cd26a-c012-4d7b-8034-057c0f1c2953
+```shell
+terraform import openstack_keymanager_order_v1.order_1 0c6cd26a-c012-4d7b-8034-057c0f1c2953
 ```

--- a/docs/resources/keymanager_secret_v1.md
+++ b/docs/resources/keymanager_secret_v1.md
@@ -14,7 +14,7 @@ Manages a V1 Barbican secret resource within OpenStack.
 ~> **Important Security Notice** The payload of this resource will be stored
 *unencrypted* in your Terraform state file. **Use of this resource for production
 deployments is *not* recommended**. [Read more about sensitive data in
-state](https://www.terraform.io/docs/language/state/sensitive-data.html).
+state](https://developer.hashicorp.com/terraform/language/manage-sensitive-data).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ resource "openstack_keymanager_secret_v1" "secret_1" {
 it's recommended to store it in a base64 encoding. Plain text payload can also
 work, but further addind or removing of the leading or trailing whitespaces
 won't be detected as a state change, e.g. changing plain text payload from
-`password ` to `password` won't recreate the secret.
+`password` to `password` won't recreate the secret.
 
 ```hcl
 resource "openstack_keymanager_secret_v1" "secret_1" {
@@ -106,7 +106,7 @@ The following arguments are supported:
 
 * `name` - (Optional) Human-readable name for the Secret. Does not have
     to be unique.
-    
+
 * `bit_length` - (Optional) Metadata provided by a user or system for informational purposes.
 
 * `algorithm` - (Optional) Metadata provided by a user or system for informational purposes.
@@ -114,7 +114,7 @@ The following arguments are supported:
 * `mode` - (Optional) Metadata provided by a user or system for informational purposes.
 
 * `secret_type` - (Optional) Used to indicate the type of secret being stored. For more information see [Secret types](https://docs.openstack.org/barbican/latest/api/reference/secret_types.html).
- 
+
 * `payload` - (Optional) The secret's data to be stored. **payload\_content\_type** must also be supplied if **payload** is included.
 
 * `payload_content_type` - (Optional) (required if **payload** is included) The media type for the content of the payload. Must be one of `text/plain`, `text/plain;charset=utf-8`, `text/plain; charset=utf-8`, `application/octet-stream`, `application/pkcs8`.
@@ -169,6 +169,6 @@ The following attributes are exported:
 
 Secrets can be imported using the secret id (the last part of the secret reference), e.g.:
 
-```
-$ terraform import openstack_keymanager_secret_v1.secret_1 8a7a79c2-cf17-4e65-b2ae-ddc8bfcf6c74
+```shell
+terraform import openstack_keymanager_secret_v1.secret_1 8a7a79c2-cf17-4e65-b2ae-ddc8bfcf6c74
 ```

--- a/docs/resources/lb_flavor_v2.md
+++ b/docs/resources/lb_flavor_v2.md
@@ -17,17 +17,17 @@ Manages a V2 load balancer flavor resource within OpenStack.
 
 ```hcl
 resource "openstack_lb_flavorprofile_v2" "fp_1" {
-	name          = "test"
-	provider_name = "amphora"
-	flavor_data   = jsonencode({
-	  "loadbalancer_topology": "ACTIVE_STANDBY",
-	})
+  name          = "test"
+  provider_name = "amphora"
+  flavor_data   = jsonencode({
+    "loadbalancer_topology" : "ACTIVE_STANDBY",
+  })
 }
 
 resource "openstack_lb_flavor_v2" "flavor_1" {
-	name              = "test"
-	description       = "This is a test flavor"
-	flavor_profile_id = openstack_lb_flavorprofile_v2.fp_1.id
+  name              = "test"
+  description       = "This is a test flavor"
+  flavor_profile_id = openstack_lb_flavorprofile_v2.fp_1.id
 }
 ```
 
@@ -61,12 +61,12 @@ The following attributes are exported:
 * `name` - See Argument Reference above.
 * `flavor_profile_id` - See Argument Reference above.
 * `description` - See Argument Reference above.
-* `enabled` -  See Argument Reference above.
+* `enabled` - See Argument Reference above.
 
 ## Import
 
 flavors can be imported using their `id`. Example:
 
-```
-$ terraform import openstack_lb_flavor_v2.flavor_1 2a0f2240-c5e6-41de-896d-e80d97428d6b
+```shell
+terraform import openstack_lb_flavor_v2.flavor_1 2a0f2240-c5e6-41de-896d-e80d97428d6b
 ```

--- a/docs/resources/lb_flavorprofile_v2.md
+++ b/docs/resources/lb_flavorprofile_v2.md
@@ -13,7 +13,7 @@ Manages a V2 load balancer flavorprofile resource within OpenStack.
 
 ~> **Note:** This usually requires admin privileges.
 
-## Example Usage 
+## Example Usage
 
 ### Using jsonencode
 
@@ -22,7 +22,7 @@ resource "openstack_lb_flavorprofile_v2" "flavorprofile_1" {
   name          = "amphora-single-profile"
   provider_name = "amphora"
   flavor_data   = jsonencode({
-    "loadbalancer_topology": "SINGLE",
+    "loadbalancer_topology" : "SINGLE",
   })
 }
 ```
@@ -69,6 +69,7 @@ The following attributes are exported:
 ## Import
 
 flavorprofiles can be imported using their `id`. Example:
-```
-$ terraform import openstack_lb_flavorprofile_v2.flavorprofile_1 2a0f2240-c5e6-41de-896d-e80d97428d6b
+
+```shell
+terraform import openstack_lb_flavorprofile_v2.flavorprofile_1 2a0f2240-c5e6-41de-896d-e80d97428d6b
 ```

--- a/docs/resources/lb_l7policy_v2.md
+++ b/docs/resources/lb_l7policy_v2.md
@@ -87,12 +87,12 @@ The following arguments are supported:
 * `redirect_url` - (Optional) Requests matching this policy will be redirected to this URL.
     Only valid if action is REDIRECT\_TO\_URL.
 
-* `redirect_prefix` - (Optional) Requests matching this policy will be redirected to 
+* `redirect_prefix` - (Optional) Requests matching this policy will be redirected to
     this Prefix URL. Only valid if action is REDIRECT\_PREFIX.
 
-* `redirect_http_code` - (Optional) Integer. Requests matching this policy will be  
-    redirected to the specified URL or Prefix URL with the HTTP response code.  
-    Valid if action is REDIRECT\_TO\_URL or REDIRECT\_PREFIX. Valid options are: 
+* `redirect_http_code` - (Optional) Integer. Requests matching this policy will be
+    redirected to the specified URL or Prefix URL with the HTTP response code.
+    Valid if action is REDIRECT\_TO\_URL or REDIRECT\_PREFIX. Valid options are:
     301, 302, 303, 307, or 308. Default is 302. New in octavia version 2.9
 
 * `admin_state_up` - (Optional) The administrative state of the L7 Policy.
@@ -120,6 +120,6 @@ The following attributes are exported:
 
 Load Balancer L7 Policy can be imported using the L7 Policy ID, e.g.:
 
-```
-$ terraform import openstack_lb_l7policy_v2.l7policy_1 8a7a79c2-cf17-4e65-b2ae-ddc8bfcf6c74
+```shell
+terraform import openstack_lb_l7policy_v2.l7policy_1 8a7a79c2-cf17-4e65-b2ae-ddc8bfcf6c74
 ```

--- a/docs/resources/lb_l7rule_v2.md
+++ b/docs/resources/lb_l7rule_v2.md
@@ -119,6 +119,6 @@ The following attributes are exported:
 Load Balancer L7 Rule can be imported using the L7 Policy ID and L7 Rule ID
 separated by a slash, e.g.:
 
-```
-$ terraform import openstack_lb_l7rule_v2.l7rule_1 e0bd694a-abbe-450e-b329-0931fd1cc5eb/4086b0c9-b18c-4d1c-b6b8-4c56c3ad2a9e
+```shell
+terraform import openstack_lb_l7rule_v2.l7rule_1 e0bd694a-abbe-450e-b329-0931fd1cc5eb/4086b0c9-b18c-4d1c-b6b8-4c56c3ad2a9e
 ```

--- a/docs/resources/lb_listener_v2.md
+++ b/docs/resources/lb_listener_v2.md
@@ -113,16 +113,14 @@ argument of the provider is used. Changing this creates a new Listener.
 * `timeout_tcp_inspect` - (Optional) The time in milliseconds, to wait for
   additional TCP packets for content inspection.
 
-* `default_tls_container_ref` - (Optional) A reference to a Barbican Secrets
-  container which stores TLS information. This is required if the protocol is
-  `TERMINATED_HTTPS`. See
-  [here](https://docs.openstack.org/octavia/latest/user/guides/basic-cookbook.html#deploy-a-tls-terminated-https-load-balancer)
-  for more information.
+* `default_tls_container_ref` – (Optional) A reference to a Barbican Secrets
+  container that stores TLS information. This is required when the protocol is
+  `TERMINATED_HTTPS`. For more information, see the
+  [Octavia TLS-terminated HTTPS load balancer guide][octavia-tls-guide].
 
-* `sni_container_refs` - (Optional) A list of references to Barbican Secrets
-  containers which store SNI information. See
-  [here](https://docs.openstack.org/octavia/latest/user/guides/basic-cookbook.html#deploy-a-tls-terminated-https-load-balancer)
-  for more information.
+* `sni_container_refs` – (Optional) A list of references to Barbican Secrets
+  containers that store SNI information. For more information, see the
+  [Octavia TLS-terminated HTTPS load balancer guide][octavia-tls-guide].
 
 * `admin_state_up` - (Optional) The administrative state of the Listener. A
   valid value is true (UP) or false (DOWN).
@@ -175,7 +173,7 @@ argument of the provider is used. Changing this creates a new Listener.
 
 * `tls_ciphers` - (Optional) List of ciphers in OpenSSL format
   (colon-separated). See
-  https://www.openssl.org/docs/man1.1.1/man1/ciphers.html for more information.
+  <https://docs.openssl.org/1.1.1/man1/ciphers/> for more information.
   Supported only in **Octavia minor version >= 2.15**.
 
 * `tls_versions` - (Optional) A list of TLS protocol versions. Available
@@ -222,6 +220,8 @@ The following attributes are exported:
 
 Load Balancer Listener can be imported using the Listener ID, e.g.:
 
+```shell
+terraform import openstack_lb_listener_v2.listener_1 b67ce64e-8b26-405d-afeb-4a078901f15a
 ```
-$ terraform import openstack_lb_listener_v2.listener_1 b67ce64e-8b26-405d-afeb-4a078901f15a
-```
+
+[octavia-tls-guide]: https://docs.openstack.org/octavia/latest/user/guides/basic-cookbook.html#deploy-a-tls-terminated-https-load-balancer

--- a/docs/resources/lb_loadbalancer_v2.md
+++ b/docs/resources/lb_loadbalancer_v2.md
@@ -34,17 +34,17 @@ The following arguments are supported:
 * `vip_subnet_id` - (Optional) The subnet on which to allocate the
     Loadbalancer's address. A tenant can only create Loadbalancers on networks
     authorized by policy (e.g. networks that belong to them or networks that
-    are shared).  Changing this creates a new loadbalancer. Exactly one of 
+    are shared).  Changing this creates a new loadbalancer. Exactly one of
     `vip_subnet_id`, `vip_network_id` or `vip_port_id` has to be defined.
 
 * `vip_network_id` - (Optional) The network on which to allocate the
     Loadbalancer's address. A tenant can only create Loadbalancers on networks
     authorized by policy (e.g. networks that belong to them or networks that
-    are shared).  Changing this creates a new loadbalancer. Exactly one of 
+    are shared).  Changing this creates a new loadbalancer. Exactly one of
     `vip_subnet_id`, `vip_network_id` or `vip_port_id` has to be defined.
 
 * `vip_port_id` - (Optional) The port UUID that the loadbalancer will use.
-    Changing this creates a new loadbalancer. Exactly one of 
+    Changing this creates a new loadbalancer. Exactly one of
     `vip_subnet_id`, `vip_network_id` or `vip_port_id` has to be defined.
 
 * `name` - (Optional) Human-readable name for the Loadbalancer. Does not have
@@ -59,7 +59,7 @@ The following arguments are supported:
 * `vip_address` - (Optional) The ip address of the load balancer.
     Changing this creates a new loadbalancer.
 
-* `vip_qos_policy_id` - (Optional) The ID of the QoS Policy which will 
+* `vip_qos_policy_id` - (Optional) The ID of the QoS Policy which will
     be applied to the Virtual IP (VIP).
 
 * `admin_state_up` - (Optional) The administrative state of the Loadbalancer.
@@ -106,6 +106,6 @@ The following attributes are exported:
 
 Load Balancer can be imported using the Load Balancer ID, e.g.:
 
-```
-$ terraform import openstack_lb_loadbalancer_v2.loadbalancer_1 19bcfdc7-c521-4a7e-9459-6750bd16df76
+```shell
+terraform import openstack_lb_loadbalancer_v2.loadbalancer_1 19bcfdc7-c521-4a7e-9459-6750bd16df76
 ```

--- a/docs/resources/lb_member_v2.md
+++ b/docs/resources/lb_member_v2.md
@@ -61,7 +61,7 @@ The following arguments are supported:
 * `monitor_port` - (Optional) An alternate protocol port used for health monitoring a backend member.
   Available only for Octavia
 
-* `backup` - (Optional) Boolean that indicates whether that member works as a backup or not. Available 
+* `backup` - (Optional) Boolean that indicates whether that member works as a backup or not. Available
   only for Octavia >= 2.1.
 
 * `tags` - (Optional) A list of simple strings assigned to the member.
@@ -90,6 +90,6 @@ The following attributes are exported:
 Load Balancer Pool Member can be imported using the Pool ID and Member ID
 separated by a slash, e.g.:
 
-```
-$ terraform import openstack_lb_member_v2.member_1 c22974d2-4c95-4bcb-9819-0afc5ed303d5/9563b79c-8460-47da-8a95-2711b746510f
+```shell
+terraform import openstack_lb_member_v2.member_1 c22974d2-4c95-4bcb-9819-0afc5ed303d5/9563b79c-8460-47da-8a95-2711b746510f
 ```

--- a/docs/resources/lb_members_v2.md
+++ b/docs/resources/lb_members_v2.md
@@ -14,7 +14,6 @@ Manages a V2 members resource within OpenStack (batch members update).
 ~> **Note:** This resource has attributes that depend on octavia minor versions.
 Please ensure your Openstack cloud supports the required [minor version](../#octavia-api-versioning).
 
-
 ## Example Usage
 
 ```hcl
@@ -64,10 +63,10 @@ The `member` block supports:
   example, a member with a weight of 10 receives five times as much traffic
   as a member with a weight of 2. Defaults to 1.
 
-* `monitor_port` - (Optional) An alternate protocol port used for health 
+* `monitor_port` - (Optional) An alternate protocol port used for health
   monitoring a backend member.
 
-* `monitor_address` - (Optional) An alternate IP address used for health 
+* `monitor_address` - (Optional) An alternate IP address used for health
 monitoring a backend member.
 
 * `admin_state_up` - (Optional) The administrative state of the member.
@@ -88,6 +87,6 @@ The following attributes are exported:
 
 Load Balancer Pool Members can be imported using the Pool ID, e.g.:
 
-```
-$ terraform import openstack_lb_members_v2.members_1 c22974d2-4c95-4bcb-9819-0afc5ed303d5
+```shell
+terraform import openstack_lb_members_v2.members_1 c22974d2-4c95-4bcb-9819-0afc5ed303d5
 ```

--- a/docs/resources/lb_monitor_v2.md
+++ b/docs/resources/lb_monitor_v2.md
@@ -44,7 +44,7 @@ The following arguments are supported:
   other than their own. Changing this creates a new monitor.
 
 * `type` - (Required) The type of probe, which is PING, TCP, HTTP, HTTPS,
-  TLS-HELLO, SCTP or UDP-CONNECT, that is sent by the loadbalancer to 
+  TLS-HELLO, SCTP or UDP-CONNECT, that is sent by the loadbalancer to
   verify the member state. Changing this creates a new monitor.
 
 * `delay` - (Required) The time, in seconds, between sending probes to members.
@@ -56,17 +56,17 @@ The following arguments are supported:
 * `max_retries` - (Required) Number of permissible ping failures before
   changing the member's status to INACTIVE. Must be a number between 1
   and 10.
-    
-* `max_retries_down` - (Optional) Number of permissible ping failures before 
-  changing the member's status to ERROR. Must be a number between 1 and 10. 
-  The default is 3. Changing this updates the max_retries_down of the 
+
+* `max_retries_down` - (Optional) Number of permissible ping failures before
+  changing the member's status to ERROR. Must be a number between 1 and 10.
+  The default is 3. Changing this updates the max_retries_down of the
   existing monitor.
 
 * `url_path` - (Optional) Required for HTTP(S) types. URI path that will be
   accessed if monitor type is HTTP or HTTPS. Default is `/`.
 
-* `http_method` - (Optional) Required for HTTP(S) types. The HTTP method that 
-  the health monitor uses for requests. One of CONNECT, DELETE, GET, HEAD, 
+* `http_method` - (Optional) Required for HTTP(S) types. The HTTP method that
+  the health monitor uses for requests. One of CONNECT, DELETE, GET, HEAD,
   OPTIONS, PATCH, POST, PUT, or TRACE. The default is GET.
 
 * `http_version` - (Optional) Required for HTTP(S) types. The HTTP version that
@@ -104,12 +104,12 @@ The following attributes are exported:
 
 Load Balancer Pool Monitor can be imported using the Monitor ID, e.g.:
 
-```
-$ terraform import openstack_lb_monitor_v2.monitor_1 47c26fc3-2403-427a-8c79-1589bd0533c2
+```shell
+terraform import openstack_lb_monitor_v2.monitor_1 47c26fc3-2403-427a-8c79-1589bd0533c2
 ```
 
 In case of using OpenContrail, the import may not work properly. If you face an issue, try to import the monitor providing its parent pool ID:
 
-```
-$ terraform import openstack_lb_monitor_v2.monitor_1 47c26fc3-2403-427a-8c79-1589bd0533c2/708bc224-0f8c-4981-ac82-97095fe051b6
+```shell
+terraform import openstack_lb_monitor_v2.monitor_1 47c26fc3-2403-427a-8c79-1589bd0533c2/708bc224-0f8c-4981-ac82-97095fe051b6
 ```

--- a/docs/resources/lb_pool_v2.md
+++ b/docs/resources/lb_pool_v2.md
@@ -88,7 +88,7 @@ The following arguments are supported:
 
 * `tls_ciphers` - (Optional) List of ciphers in OpenSSL format
   (colon-separated). See
-  https://www.openssl.org/docs/man1.1.1/man1/ciphers.html for more information.
+  <https://docs.openssl.org/1.1.1/man1/ciphers/> for more information.
   Supported only in **Octavia minor version >= 2.15**.
 
 * `tls_versions` - (Optional) A list of TLS protocol versions. Available
@@ -132,6 +132,6 @@ The following attributes are exported:
 
 Load Balancer Pool can be imported using the Pool ID, e.g.:
 
-```
-$ terraform import openstack_lb_pool_v2.pool_1 60ad9ee4-249a-4d60-a45b-aa60e046c513
+```shell
+terraform import openstack_lb_pool_v2.pool_1 60ad9ee4-249a-4d60-a45b-aa60e046c513
 ```

--- a/docs/resources/lb_quota_v2.md
+++ b/docs/resources/lb_quota_v2.md
@@ -71,7 +71,6 @@ The following arguments are supported:
   updates the existing quota. Omitting it sets it to 0. Available in
   **Octavia minor version 2.19**.
 
-
 ## Attributes Reference
 
 The following attributes are exported:
@@ -90,6 +89,6 @@ The following attributes are exported:
 Quotas can be imported using the `project_id/region_name`, where region_name is the
 one defined is the Openstack credentials that are in use. E.g.
 
-```
-$ terraform import openstack_lb_quota_v2.quota_1 2a0f2240-c5e6-41de-896d-e80d97428d6b/region_1
+```shell
+terraform import openstack_lb_quota_v2.quota_1 2a0f2240-c5e6-41de-896d-e80d97428d6b/region_1
 ```

--- a/docs/resources/networking_address_group_v2.md
+++ b/docs/resources/networking_address_group_v2.md
@@ -57,6 +57,6 @@ The following attributes are exported:
 
 Address Groups can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_networking_address_group_v2.group_1 782fef9c-d03c-400a-9735-2f9af5681cb3
+```shell
+terraform import openstack_networking_address_group_v2.group_1 782fef9c-d03c-400a-9735-2f9af5681cb3
 ```

--- a/docs/resources/networking_addressscope_v2.md
+++ b/docs/resources/networking_addressscope_v2.md
@@ -74,6 +74,6 @@ The following attributes are exported:
 
 Address-scopes can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_networking_addressscope_v2.addressscope_1 9cc35860-522a-4d35-974d-51d4b011801e
+```shell
+terraform import openstack_networking_addressscope_v2.addressscope_1 9cc35860-522a-4d35-974d-51d4b011801e
 ```

--- a/docs/resources/networking_bgp_peer_v2.md
+++ b/docs/resources/networking_bgp_peer_v2.md
@@ -18,11 +18,11 @@ BGP speaker to exchange routing information.
 
 ```hcl
 resource "openstack_networking_bgp_peer_v2" "peer_1" {
-  name       = "bgp_peer_1"
-  peer_ip    = "192.0.2.10"
-  remote_as  = 65001
-  auth_type  = "md5"
-  password   = "supersecret"
+  name      = "bgp_peer_1"
+  peer_ip   = "192.0.2.10"
+  remote_as = 65001
+  auth_type = "md5"
+  password  = "supersecret"
 }
 ```
 
@@ -70,5 +70,5 @@ The following attributes are exported:
 BGP peers can be imported using their ID:
 
 ```shell
-$ terraform import openstack_networking_bgp_peer_v2.peer1 a1b2c3d4-e5f6-7890-abcd-1234567890ef
+terraform import openstack_networking_bgp_peer_v2.peer1 a1b2c3d4-e5f6-7890-abcd-1234567890ef
 ```

--- a/docs/resources/networking_bgp_speaker_v2.md
+++ b/docs/resources/networking_bgp_speaker_v2.md
@@ -22,11 +22,11 @@ resource "openstack_networking_network_v2" "network1" {
 }
 
 resource "openstack_networking_bgp_peer_v2" "peer_1" {
-  name       = "bgp_peer_1"
-  peer_ip    = "192.0.2.10"
-  remote_as  = 65001
-  auth_type  = "md5"
-  password   = "supersecret"
+  name      = "bgp_peer_1"
+  peer_ip   = "192.0.2.10"
+  remote_as = 65001
+  auth_type = "md5"
+  password  = "supersecret"
 }
 
 resource "openstack_networking_bgp_speaker_v2" "speaker_1" {
@@ -98,5 +98,5 @@ The following attributes are exported:
 BGP speakers can be imported using their ID:
 
 ```shell
-$ terraform import openstack_networking_bgp_speaker_v2.speaker_1 8a2ad402-b805-46bf-a60b-008573ca2844
+terraform import openstack_networking_bgp_speaker_v2.speaker_1 8a2ad402-b805-46bf-a60b-008573ca2844
 ```

--- a/docs/resources/networking_floatingip_associate_v2.md
+++ b/docs/resources/networking_floatingip_associate_v2.md
@@ -53,6 +53,6 @@ The following attributes are exported:
 
 Floating IP associations can be imported using the `id` of the floating IP, e.g.
 
-```
-$ terraform import openstack_networking_floatingip_associate_v2.fip 2c7f39f3-702b-48d1-940c-b50384177ee1
+```shell
+terraform import openstack_networking_floatingip_associate_v2.fip 2c7f39f3-702b-48d1-940c-b50384177ee1
 ```

--- a/docs/resources/networking_floatingip_v2.md
+++ b/docs/resources/networking_floatingip_v2.md
@@ -118,6 +118,6 @@ The following attributes are exported:
 
 Floating IPs can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_networking_floatingip_v2.floatip_1 2c7f39f3-702b-48d1-940c-b50384177ee1
+```shell
+terraform import openstack_networking_floatingip_v2.floatip_1 2c7f39f3-702b-48d1-940c-b50384177ee1
 ```

--- a/docs/resources/networking_network_v2.md
+++ b/docs/resources/networking_network_v2.md
@@ -126,7 +126,7 @@ The following arguments are supported:
     extension is enabled. The `dns_domain` of a network in conjunction with the
     `dns_name` attribute of its ports will be published in an external DNS
     service when Neutron is configured to integrate with such a service.
-    
+
 * `qos_policy_id` - (Optional) Reference to the associated QoS policy.
 
 The `segments` block supports:
@@ -161,6 +161,6 @@ The following attributes are exported:
 
 Networks can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_networking_network_v2.network_1 d90ce693-5ccf-4136-a0ed-152ce412b6b9
+```shell
+terraform import openstack_networking_network_v2.network_1 d90ce693-5ccf-4136-a0ed-152ce412b6b9
 ```

--- a/docs/resources/networking_port_secgroup_associate_v2.md
+++ b/docs/resources/networking_port_secgroup_associate_v2.md
@@ -10,7 +10,7 @@ description: |-
 # openstack\_networking\_port\_secgroup\_associate\_v2
 
 Manages a V2 port's security groups within OpenStack. Useful, when the port was
-not created by Terraform (e.g. Manila or LBaaS). 
+not created by Terraform (e.g. Manila or LBaaS).
 
 When the resource is deleted, Terraform doesn't delete the port, but unsets the
 list of user defined security group IDs.  However, if `enforce` is set to `true`
@@ -18,7 +18,7 @@ and the resource is deleted, Terraform will remove all assigned security group
 IDs.
 
 ~> **Warning:** This resource should **not** be used when the
-port was created directly within Terraform. If it is, it can lead  
+port was created directly within Terraform. If it is, it can lead
 to **security problems** with incorrect security groups on ports
 
 ## Example Usage
@@ -108,6 +108,6 @@ The following attributes are exported:
 
 Port security group association can be imported using the `id` of the port, e.g.
 
-```
-$ terraform import openstack_networking_port_secgroup_associate_v2.port_1 eae26a3e-1c33-4cc1-9c31-0cd729c438a1
+```shell
+terraform import openstack_networking_port_secgroup_associate_v2.port_1 eae26a3e-1c33-4cc1-9c31-0cd729c438a1
 ```

--- a/docs/resources/networking_port_v2.md
+++ b/docs/resources/networking_port_v2.md
@@ -13,9 +13,9 @@ Manages a V2 port resource within OpenStack.
 
 ~> **Note:** Ports do not get an IP if the network they are attached
 to does not have a subnet. If you create the subnet resource in the
-same run as the port, make sure to use `fixed_ip.subnet_id` or 
+same run as the port, make sure to use `fixed_ip.subnet_id` or
 `depends_on` to enforce the subnet resource creation before the port
-creation is triggered. More info [here](https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1606#issuecomment-1790945191)
+creation is triggered. For more information, see [issue #1606][issue-1606].
 
 ## Example Usage
 
@@ -174,7 +174,7 @@ The following arguments are supported:
 
 * `dns_name` - (Optional) The port DNS name. Available, when Neutron DNS extension
     is enabled.
-    
+
 * `qos_policy_id` - (Optional) Reference to the associated QoS policy.
 
 The `fixed_ip` block supports:
@@ -248,8 +248,8 @@ The following attributes are exported:
 
 Ports can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_networking_port_v2.port_1 eae26a3e-1c33-4cc1-9c31-0cd729c438a1
+```shell
+terraform import openstack_networking_port_v2.port_1 eae26a3e-1c33-4cc1-9c31-0cd729c438a1
 ```
 
 ## Notes
@@ -259,3 +259,5 @@ $ terraform import openstack_networking_port_v2.port_1 eae26a3e-1c33-4cc1-9c31-0
 There are some notes to consider when connecting Instances to networks using
 Ports. Please see the `openstack_compute_instance_v2` documentation for further
 documentation.
+
+[issue-1606]: https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1606#issuecomment-1790945191

--- a/docs/resources/networking_qos_bandwidth_limit_rule_v2.md
+++ b/docs/resources/networking_qos_bandwidth_limit_rule_v2.md
@@ -36,18 +36,18 @@ The following arguments are supported:
 * `region` - (Optional) The region in which to obtain the V2 Networking client.
     A Networking client is needed to create a Neutron QoS bandwidth limit rule. If omitted, the
     `region` argument of the provider is used. Changing this creates a new QoS bandwidth limit rule.
-    
+
 * `qos_policy_id` - (Required) The QoS policy reference. Changing this creates a new QoS bandwidth limit rule.
-   
+
 * `max_kbps` - (Required) The maximum kilobits per second of a QoS bandwidth limit rule. Changing this updates the
     maximum kilobits per second of the existing QoS bandwidth limit rule.
 
 * `max_burst_kbps` - (Optional) The maximum burst size in kilobits of a QoS bandwidth limit rule. Changing this updates the
     maximum burst size in kilobits of the existing QoS bandwidth limit rule.
-   
+
 * `direction` - (Optional) The direction of traffic. Defaults to "egress". Changing this updates the direction of the
     existing QoS bandwidth limit rule.
-    
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -62,6 +62,6 @@ The following attributes are exported:
 
 QoS bandwidth limit rules can be imported using the `qos_policy_id/bandwidth_limit_rule` format, e.g.
 
-```
-$ terraform import openstack_networking_qos_bandwidth_limit_rule_v2.bw_limit_rule_1 d6ae28ce-fcb5-4180-aa62-d260a27e09ae/46dfb556-b92f-48ce-94c5-9a9e2140de94
+```shell
+terraform import openstack_networking_qos_bandwidth_limit_rule_v2.bw_limit_rule_1 d6ae28ce-fcb5-4180-aa62-d260a27e09ae/46dfb556-b92f-48ce-94c5-9a9e2140de94
 ```

--- a/docs/resources/networking_qos_dscp_marking_rule_v2.md
+++ b/docs/resources/networking_qos_dscp_marking_rule_v2.md
@@ -34,12 +34,12 @@ The following arguments are supported:
 * `region` - (Optional) The region in which to obtain the V2 Networking client.
     A Networking client is needed to create a Neutron QoS DSCP marking rule. If omitted, the
     `region` argument of the provider is used. Changing this creates a new QoS DSCP marking rule.
-    
+
 * `qos_policy_id` - (Required) The QoS policy reference. Changing this creates a new QoS DSCP marking rule.
-   
+
 * `dscp_mark` - (Required) The value of DSCP mark. Changing this updates the DSCP mark value existing
     QoS DSCP marking rule.
-    
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -52,6 +52,6 @@ The following attributes are exported:
 
 QoS DSCP marking rules can be imported using the `qos_policy_id/dscp_marking_rule_id` format, e.g.
 
-```
-$ terraform import openstack_networking_qos_dscp_marking_rule_v2.dscp_marking_rule_1 d6ae28ce-fcb5-4180-aa62-d260a27e09ae/46dfb556-b92f-48ce-94c5-9a9e2140de94
+```shell
+terraform import openstack_networking_qos_dscp_marking_rule_v2.dscp_marking_rule_1 d6ae28ce-fcb5-4180-aa62-d260a27e09ae/46dfb556-b92f-48ce-94c5-9a9e2140de94
 ```

--- a/docs/resources/networking_qos_minimum_bandwidth_rule_v2.md
+++ b/docs/resources/networking_qos_minimum_bandwidth_rule_v2.md
@@ -34,15 +34,15 @@ The following arguments are supported:
 * `region` - (Optional) The region in which to obtain the V2 Networking client.
     A Networking client is needed to create a Neutron QoS minimum bandwidth rule. If omitted, the
     `region` argument of the provider is used. Changing this creates a new QoS minimum bandwidth rule.
-    
+
 * `qos_policy_id` - (Required) The QoS policy reference. Changing this creates a new QoS minimum bandwidth rule.
-   
+
 * `min_kbps` - (Required) The minimum kilobits per second. Changing this updates the min kbps value of the existing
     QoS minimum bandwidth rule.
 
 * `direction` - (Optional) The direction of traffic. Defaults to "egress". Changing this updates the direction of the
     existing QoS minimum bandwidth rule.
-    
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -56,6 +56,6 @@ The following attributes are exported:
 
 QoS minimum bandwidth rules can be imported using the `qos_policy_id/minimum_bandwidth_rule_id` format, e.g.
 
-```
-$ terraform import openstack_networking_qos_minimum_bandwidth_rule_v2.minimum_bandwidth_rule_1 d6ae28ce-fcb5-4180-aa62-d260a27e09ae/46dfb556-b92f-48ce-94c5-9a9e2140de94
+```shell
+terraform import openstack_networking_qos_minimum_bandwidth_rule_v2.minimum_bandwidth_rule_1 d6ae28ce-fcb5-4180-aa62-d260a27e09ae/46dfb556-b92f-48ce-94c5-9a9e2140de94
 ```

--- a/docs/resources/networking_qos_policy_v2.md
+++ b/docs/resources/networking_qos_policy_v2.md
@@ -74,6 +74,6 @@ The following attributes are exported:
 
 QoS Policies can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_networking_qos_policy_v2.qos_policy_1 d6ae28ce-fcb5-4180-aa62-d260a27e09ae
+```shell
+terraform import openstack_networking_qos_policy_v2.qos_policy_1 d6ae28ce-fcb5-4180-aa62-d260a27e09ae
 ```

--- a/docs/resources/networking_quota_v2.md
+++ b/docs/resources/networking_quota_v2.md
@@ -95,6 +95,6 @@ The following attributes are exported:
 
 Quotas can be imported using the `project_id/region_name`, e.g.
 
-```
-$ terraform import openstack_networking_quota_v2.quota_1 2a0f2240-c5e6-41de-896d-e80d97428d6b/region_1
+```shell
+terraform import openstack_networking_quota_v2.quota_1 2a0f2240-c5e6-41de-896d-e80d97428d6b/region_1
 ```

--- a/docs/resources/networking_rbac_policy_v2.md
+++ b/docs/resources/networking_rbac_policy_v2.md
@@ -79,6 +79,6 @@ The following attributes are exported:
 
 RBAC policies can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_networking_rbac_policy_v2.rbac_policy_1 eae26a3e-1c33-4cc1-9c31-0cd729c438a1
+```shell
+terraform import openstack_networking_rbac_policy_v2.rbac_policy_1 eae26a3e-1c33-4cc1-9c31-0cd729c438a1
 ```

--- a/docs/resources/networking_router_interface_v2.md
+++ b/docs/resources/networking_router_interface_v2.md
@@ -71,7 +71,7 @@ The following attributes are exported:
 
 Router Interfaces can be imported using the port `id`, e.g.
 
-```
-$ openstack port list --router <router name or id>
-$ terraform import openstack_networking_router_interface_v2.int_1 port_id
+```shell
+openstack port list --router <router name or id>
+terraform import openstack_networking_router_interface_v2.int_1 port_id
 ```

--- a/docs/resources/networking_router_route_v2.md
+++ b/docs/resources/networking_router_route_v2.md
@@ -72,14 +72,14 @@ The following attributes are exported:
 
 ## Notes
 
-The `next_hop` IP address must be directly reachable from the router at the ``openstack_networking_router_route_v2``
-resource creation time.  You can ensure that by explicitly specifying a dependency on the ``openstack_networking_router_interface_v2``
+The `next_hop` IP address must be directly reachable from the router at the `openstack_networking_router_route_v2`
+resource creation time.  You can ensure that by explicitly specifying a dependency on the `openstack_networking_router_interface_v2`
 resource that connects the next hop to the router, as in the example above.
 
 ## Import
 
-Routing entries can be imported using a combined ID using the following format: ``<router_id>-route-<destination_cidr>-<next_hop>``
+Routing entries can be imported using a combined ID using the following format: `<router_id>-route-<destination_cidr>-<next_hop>`
 
-```
-$ terraform import openstack_networking_router_route_v2.router_route_1 686fe248-386c-4f70-9f6c-281607dad079-route-10.0.1.0/24-192.168.199.25
+```shell
+terraform import openstack_networking_router_route_v2.router_route_1 686fe248-386c-4f70-9f6c-281607dad079-route-10.0.1.0/24-192.168.199.25
 ```

--- a/docs/resources/networking_router_routes_v2.md
+++ b/docs/resources/networking_router_routes_v2.md
@@ -85,15 +85,15 @@ The following attributes are exported:
 ## Notes
 
 The `next_hop` IP address must be directly reachable from the router at the
-``openstack_networking_router_routes_v2`` resource creation time.  You can
+`openstack_networking_router_routes_v2` resource creation time.  You can
 ensure that by explicitly specifying a dependency on the
-``openstack_networking_router_interface_v2`` resource that connects the next
+`openstack_networking_router_interface_v2` resource that connects the next
 hop to the router, as in the example above.
 
 ## Import
 
 Routing entries can be imported using a router `id`:
 
-```
-$ terraform import openstack_networking_router_routes_v2.router_routes_1 686fe248-386c-4f70-9f6c-281607dad079
+```shell
+terraform import openstack_networking_router_routes_v2.router_routes_1 686fe248-386c-4f70-9f6c-281607dad079
 ```

--- a/docs/resources/networking_router_v2.md
+++ b/docs/resources/networking_router_v2.md
@@ -123,6 +123,6 @@ The following attributes are exported:
 
 Routers can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_networking_router_v2.router_1 014395cd-89fc-4c9b-96b7-13d1ee79dad2
+```shell
+terraform import openstack_networking_router_v2.router_1 014395cd-89fc-4c9b-96b7-13d1ee79dad2
 ```

--- a/docs/resources/networking_secgroup_rule_v2.md
+++ b/docs/resources/networking_secgroup_rule_v2.md
@@ -46,39 +46,39 @@ The following arguments are supported:
 
 * `description` - (Optional) A description of the rule. Changing this creates a new security group rule.
 
-* `direction` - (Required) The direction of the rule, valid values are __ingress__
-    or __egress__. Changing this creates a new security group rule.
+* `direction` - (Required) The direction of the rule, valid values are **ingress**
+    or **egress**. Changing this creates a new security group rule.
 
-* `ethertype` - (Required) The layer 3 protocol type, valid values are __IPv4__
-    or __IPv6__. Changing this creates a new security group rule.
+* `ethertype` - (Required) The layer 3 protocol type, valid values are **IPv4**
+    or **IPv6**. Changing this creates a new security group rule.
 
 * `protocol` - (Optional) The layer 4 protocol type, valid values are
   following. Changing this creates a new security group rule. This is required
   if you want to specify a port range.
   * empty string or omitted (any protocol)
   * integer value between 0 and 255 (valid IP protocol number)
-  * __tcp__
-  * __udp__
-  * __icmp__
-  * __ah__
-  * __dccp__
-  * __egp__
-  * __esp__
-  * __gre__
-  * __igmp__
-  * __ipv6-encap__
-  * __ipv6-frag__
-  * __ipv6-icmp__
-  * __ipv6-nonxt__
-  * __ipv6-opts__
-  * __ipv6-route__
-  * __ospf__
-  * __pgm__
-  * __rsvp__
-  * __sctp__
-  * __udplite__
-  * __vrrp__
-  * __ipip__
+  * **tcp**
+  * **udp**
+  * **icmp**
+  * **ah**
+  * **dccp**
+  * **egp**
+  * **esp**
+  * **gre**
+  * **igmp**
+  * **ipv6-encap**
+  * **ipv6-frag**
+  * **ipv6-icmp**
+  * **ipv6-nonxt**
+  * **ipv6-opts**
+  * **ipv6-route**
+  * **ospf**
+  * **pgm**
+  * **rsvp**
+  * **sctp**
+  * **udplite**
+  * **vrrp**
+  * **ipip**
 
 * `port_range_min` - (Optional) The lower part of the allowed port range, valid
     integer value needs to be between 1 and 65535. Changing this creates a new
@@ -129,6 +129,6 @@ The following attributes are exported:
 
 Security Group Rules can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_networking_secgroup_rule_v2.secgroup_rule_1 aeb68ee3-6e9d-4256-955c-9584a6212745
+```shell
+terraform import openstack_networking_secgroup_rule_v2.secgroup_rule_1 aeb68ee3-6e9d-4256-955c-9584a6212745
 ```

--- a/docs/resources/networking_secgroup_v2.md
+++ b/docs/resources/networking_secgroup_v2.md
@@ -94,6 +94,6 @@ is moot).
 
 Security Groups can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_networking_secgroup_v2.secgroup_1 38809219-5e8a-4852-9139-6f461c90e8bc
+```shell
+terraform import openstack_networking_secgroup_v2.secgroup_1 38809219-5e8a-4852-9139-6f461c90e8bc
 ```

--- a/docs/resources/networking_segment_v2.md
+++ b/docs/resources/networking_segment_v2.md
@@ -80,5 +80,5 @@ The following attributes are exported:
 This resource can be imported by specifying the segment ID:
 
 ```shell
-$ terraform import openstack_networking_segment_v2.segment1 a5e3a494-26ee-4fde-ad26-2d846c47072e
+terraform import openstack_networking_segment_v2.segment1 a5e3a494-26ee-4fde-ad26-2d846c47072e
 ```

--- a/docs/resources/networking_subnet_route_v2.md
+++ b/docs/resources/networking_subnet_route_v2.md
@@ -68,8 +68,8 @@ The following attributes are exported:
 
 ## Import
 
-Routing entries can be imported using a combined ID using the following format: ``<subnet_id>-route-<destination_cidr>-<next_hop>``
+Routing entries can be imported using a combined ID using the following format: `<subnet_id>-route-<destination_cidr>-<next_hop>`
 
-```
-$ terraform import openstack_networking_subnet_route_v2.subnet_route_1 686fe248-386c-4f70-9f6c-281607dad079-route-10.0.1.0/24-192.168.199.25
+```shell
+terraform import openstack_networking_subnet_route_v2.subnet_route_1 686fe248-386c-4f70-9f6c-281607dad079-route-10.0.1.0/24-192.168.199.25
 ```

--- a/docs/resources/networking_subnet_v2.md
+++ b/docs/resources/networking_subnet_v2.md
@@ -135,6 +135,6 @@ The following attributes are exported:
 
 Subnets can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_networking_subnet_v2.subnet_1 da4faf16-5546-41e4-8330-4d0002b74048
+```shell
+terraform import openstack_networking_subnet_v2.subnet_1 da4faf16-5546-41e4-8330-4d0002b74048
 ```

--- a/docs/resources/networking_subnetpool_v2.md
+++ b/docs/resources/networking_subnetpool_v2.md
@@ -131,6 +131,6 @@ The following attributes are exported:
 
 Subnetpools can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_networking_subnetpool_v2.subnetpool_1 832cb7f3-59fe-40cf-8f64-8350ffc03272
+```shell
+terraform import openstack_networking_subnetpool_v2.subnetpool_1 832cb7f3-59fe-40cf-8f64-8350ffc03272
 ```

--- a/docs/resources/objectstorage_account_v1.md
+++ b/docs/resources/objectstorage_account_v1.md
@@ -56,6 +56,6 @@ The following attributes are exported:
 
 This resource can be imported by specifying the project ID of the account:
 
-```
-$ terraform import openstack_objectstorage_account_v1.account_1 1202b3d0aaa44cfc8b79475c007b0711
+```shell
+terraform import openstack_objectstorage_account_v1.account_1 1202b3d0aaa44cfc8b79475c007b0711
 ```

--- a/docs/resources/objectstorage_container_v1.md
+++ b/docs/resources/objectstorage_container_v1.md
@@ -103,7 +103,7 @@ provider "openstack" {
 }
 
 resource "openstack_objectstorage_container_v1" "container_1" {
-  name   = "tf-test-container-1"
+  name = "tf-test-container-1"
 
   storage_policy = "az1"
   storage_class  = "SSD"
@@ -166,11 +166,10 @@ The following arguments are supported:
 
 The `versioning_legacy` block supports:
 
-  * `type` - (Required) Versioning type which can be `versions` or `history`
+* `type` - (Required) Versioning type which can be `versions` or `history`
     according to [OpenStack
     documentation](https://docs.openstack.org/swift/latest/api/object_versioning.html).
-  * `location` - (Required) Container in which versions will be stored.
-
+* `location` - (Required) Container in which versions will be stored.
 
 ## Attributes Reference
 
@@ -194,6 +193,7 @@ The following attributes are exported:
 This resource can be imported by specifying the name of the container:
 
 Some attributes can't be imported :
+
 * `force_destroy`
 * `content_type`
 * `metadata`
@@ -202,6 +202,6 @@ Some attributes can't be imported :
 
 So you'll have to `terraform plan` and `terraform apply` after the import to fix those missing attributes.
 
-```
-$ terraform import openstack_objectstorage_container_v1.container_1 container_name
+```shell
+terraform import openstack_objectstorage_container_v1.container_1 container_name
 ```

--- a/docs/resources/objectstorage_object_v1.md
+++ b/docs/resources/objectstorage_object_v1.md
@@ -76,52 +76,52 @@ resource "openstack_objectstorage_object_v1" "doc_1" {
 
 The following arguments are supported:
 
-* `container_name` - (Required) A unique (within an account) name for the container. 
-    The container name must be from 1 to 256 characters long and can start 
-    with any character and contain any pattern. Character set must be UTF-8. 
-    The container name cannot contain a slash (/) character because this 
-    character delimits the container and object name. For example, the path 
+* `container_name` - (Required) A unique (within an account) name for the container.
+    The container name must be from 1 to 256 characters long and can start
+    with any character and contain any pattern. Character set must be UTF-8.
+    The container name cannot contain a slash (/) character because this
+    character delimits the container and object name. For example, the path
     /v1/account/www/pages specifies the www container, not the www/pages container.
 
 * `content` - (Optional) A string representing the content of the object. Conflicts with
    `source` and `copy_from`.
 
-* `content_disposition` - (Optional) A string which specifies the override behavior for 
+* `content_disposition` - (Optional) A string which specifies the override behavior for
      the browser. For example, this header might specify that the browser use a download
      program to save this file rather than show the file, which is the default.
-     
+
 * `content_encoding` - (Optional) A string representing the value of the Content-Encoding
      metadata.
 
 * `content_type` - (Optional) A string which sets the MIME type for the object.
 
-* `copy_from` - (Optional) A string representing the name of an object 
-    used to create the new object by copying the `copy_from` object. The value is in form 
-    {container}/{object}. You must UTF-8-encode and then URL-encode the names of the 
-    container and object before you include them in the header. Conflicts with `source` and 
+* `copy_from` - (Optional) A string representing the name of an object
+    used to create the new object by copying the `copy_from` object. The value is in form
+    {container}/{object}. You must UTF-8-encode and then URL-encode the names of the
+    container and object before you include them in the header. Conflicts with `source` and
     `content`.
-             
+
 * `delete_after` - (Optional) An integer representing the number of seconds after which the
-    system removes the object. Internally, the Object Storage system stores this value in 
+    system removes the object. Internally, the Object Storage system stores this value in
     the X-Delete-At metadata item.
 
-* `delete_at` - (Optional) An string representing the date when the system removes the object. 
+* `delete_at` - (Optional) An string representing the date when the system removes the object.
     For example, "2015-08-26" is equivalent to Mon, Wed, 26 Aug 2015 00:00:00 GMT.
-    
-* `detect_content_type` - (Optional) If set to true, Object Storage guesses the content 
-    type based on the file extension and ignores the value sent in the Content-Type 
+
+* `detect_content_type` - (Optional) If set to true, Object Storage guesses the content
+    type based on the file extension and ignores the value sent in the Content-Type
     header, if present.
 
 * `etag` - (Optional) Used to trigger updates. The only meaningful value is ${md5(file("path/to/file"))}.
 
 * `name` - (Required) A unique name for the object.
 
-* `object_manifest` - (Optional) A string set to specify that this is a dynamic large 
+* `object_manifest` - (Optional) A string set to specify that this is a dynamic large
     object manifest object. The value is the container and object name prefix of the
-    segment objects in the form container/prefix. You must UTF-8-encode and then 
-    URL-encode the names of the container and prefix before you include them in this 
+    segment objects in the form container/prefix. You must UTF-8-encode and then
+    URL-encode the names of the container and prefix before you include them in this
     header.
-    
+
 * `region` - (Optional) The region in which to create the container. If
     omitted, the `region` argument of the provider is used. Changing this
     creates a new container.
@@ -133,24 +133,24 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `content_length` - If the operation succeeds, this value is zero (0) or the 
+* `content_length` - If the operation succeeds, this value is zero (0) or the
     length of informational or error text in the response body.
-* `content_type` - If the operation succeeds, this value is the MIME type of the object. 
-    If the operation fails, this value is the MIME type of the error text in the response 
+* `content_type` - If the operation succeeds, this value is the MIME type of the object.
+    If the operation fails, this value is the MIME type of the error text in the response
     body.
-* `date` - The date and time the system responded to the request, using the preferred 
-    format of RFC 7231 as shown in this example Thu, 16 Jun 2016 15:10:38 GMT. The 
+* `date` - The date and time the system responded to the request, using the preferred
+    format of RFC 7231 as shown in this example Thu, 16 Jun 2016 15:10:38 GMT. The
     time is always in UTC.
-* `etag` - Whatever the value given in argument, will be overriden by the MD5 checksum of the uploaded object content. The value is not quoted. 
+* `etag` - Whatever the value given in argument, will be overriden by the MD5 checksum of the uploaded object content. The value is not quoted.
     If it is an SLO, it would be MD5 checksum of the segments’ etags.
-* `last_modified` - The date and time when the object was last modified. The date and time 
+* `last_modified` - The date and time when the object was last modified. The date and time
     stamp format is ISO 8601:
        CCYY-MM-DDThh:mm:ss±hh:mm
     For example, 2015-08-27T09:49:58-05:00.
-    The ±hh:mm value, if included, is the time zone as an offset from UTC. In the previous 
+    The ±hh:mm value, if included, is the time zone as an offset from UTC. In the previous
     example, the offset value is -05:00.
 * `static_large_object` - True if object is a multipart_manifest.
-* `trans_id` - A unique transaction ID for this request. Your service provider might 
+* `trans_id` - A unique transaction ID for this request. Your service provider might
     need this value if you report a problem.
 
 * `container_name` - See Argument Reference above.

--- a/docs/resources/orchestration_stack_v1.md
+++ b/docs/resources/orchestration_stack_v1.md
@@ -17,16 +17,16 @@ Manages a V1 stack resource within OpenStack.
 resource "openstack_orchestration_stack_v1" "stack_1" {
   name = "stack_1"
   parameters = {
-	length = 4
+    length = 4
   }
   template_opts = {
-	Bin = "heat_template_version: 2013-05-23\nparameters:\n  length:\n    type: number\nresources:\n  test_res:\n    type: OS::Heat::TestResource\n  random:\n    type: OS::Heat::RandomString\n    properties:\n      length: {get_param: length}\n"
+    Bin = "heat_template_version: 2013-05-23\nparameters:\n  length:\n    type: number\nresources:\n  test_res:\n    type: OS::Heat::TestResource\n  random:\n    type: OS::Heat::RandomString\n    properties:\n      length: {get_param: length}\n"
   }
   environment_opts = {
-	Bin = "\n"
+    Bin = "\n"
   }
   disable_rollback = true
-  timeout = 30
+  timeout          = 30
 }
 ```
 
@@ -91,6 +91,6 @@ The following attributes are exported:
 
 stacks can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_orchestration_stack_v1.stack_1 ea257959-eeb1-4c10-8d33-26f0409a755d
+```shell
+terraform import openstack_orchestration_stack_v1.stack_1 ea257959-eeb1-4c10-8d33-26f0409a755d
 ```

--- a/docs/resources/sharedfilesystem_securityservice_v2.md
+++ b/docs/resources/sharedfilesystem_securityservice_v2.md
@@ -13,7 +13,7 @@ Use this resource to configure a security service.
 
 ~> **Note:** All arguments including the security service password will be
 stored in the raw state as plain-text. [Read more about sensitive data in
-state](/docs/state/sensitive-data.html).
+state](https://developer.hashicorp.com/terraform/language/manage-sensitive-data).
 
 A security service stores configuration information for clients for
 authentication and authorization (AuthN/AuthZ). For example, a share server
@@ -90,6 +90,6 @@ The following arguments are supported:
 
 This resource can be imported by specifying the ID of the security service:
 
-```
-$ terraform import openstack_sharedfilesystem_securityservice_v2.securityservice_1 id
+```shell
+terraform import openstack_sharedfilesystem_securityservice_v2.securityservice_1 id
 ```

--- a/docs/resources/sharedfilesystem_share_access_v2.md
+++ b/docs/resources/sharedfilesystem_share_access_v2.md
@@ -15,7 +15,7 @@ Use this resource to control the share access lists.
 be stored *unencrypted* in your Terraform state file. If you use this resource
 in production, please make sure your state file is sufficiently protected.
 [Read more about sensitive data in
-state](https://www.terraform.io/docs/language/state/sensitive-data.html).
+state](https://developer.hashicorp.com/terraform/language/manage-sensitive-data).
 
 ## Example Usage
 
@@ -155,6 +155,6 @@ The following arguments are supported:
 This resource can be imported by specifying the ID of the share and the ID of the
 share access, separated by a slash, e.g.:
 
-```
-$ terraform import openstack_sharedfilesystem_share_access_v2.share_access_1 share_id/share_access_id
+```shell
+terraform import openstack_sharedfilesystem_share_access_v2.share_access_1 share_id/share_access_id
 ```

--- a/docs/resources/sharedfilesystem_share_v2.md
+++ b/docs/resources/sharedfilesystem_share_v2.md
@@ -110,6 +110,6 @@ The following arguments are supported:
 
 This resource can be imported by specifying the ID of the share:
 
-```
-$ terraform import openstack_sharedfilesystem_share_v2.share_1 id
+```shell
+terraform import openstack_sharedfilesystem_share_v2.share_1 id
 ```

--- a/docs/resources/sharedfilesystem_sharenetwork_v2.md
+++ b/docs/resources/sharedfilesystem_sharenetwork_v2.md
@@ -122,6 +122,6 @@ The following arguments are supported:
 
 This resource can be imported by specifying the ID of the share network:
 
-```
-$ terraform import openstack_sharedfilesystem_sharenetwork_v2.sharenetwork_1 id
+```shell
+terraform import openstack_sharedfilesystem_sharenetwork_v2.sharenetwork_1 id
 ```

--- a/docs/resources/taas_tap_mirror_v2.md
+++ b/docs/resources/taas_tap_mirror_v2.md
@@ -87,6 +87,6 @@ The following attributes are exported:
 
 Tap Mirrors can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_taas_tap_mirror_v2.tap_mirror_1 0837b488-f0e2-4689-99b3-e3ed531f9b10
+```shell
+terraform import openstack_taas_tap_mirror_v2.tap_mirror_1 0837b488-f0e2-4689-99b3-e3ed531f9b10
 ```

--- a/docs/resources/vpnaas_endpoint_group_v2.md
+++ b/docs/resources/vpnaas_endpoint_group_v2.md
@@ -17,8 +17,10 @@ Manages a V2 Neutron Endpoint Group resource within OpenStack.
 resource "openstack_vpnaas_endpoint_group_v2" "group_1" {
   name = "Group 1"
   type = "cidr"
-  endpoints = ["10.2.0.0/24",
-  "10.3.0.0/24", ]
+  endpoints = [
+    "10.2.0.0/24",
+    "10.3.0.0/24",
+  ]
 }
 ```
 
@@ -42,10 +44,10 @@ The following arguments are supported:
 
 * `type` - The type of the endpoints in the group. A valid value is subnet, cidr, network, router, or vlan.
     Changing this creates a new group.
-    
+
 * `endpoints` - List of endpoints of the same type, for the endpoint group. The values will depend on the type.
     Changing this creates a new group.
-    
+
 * `value_specs` - (Optional) Map of additional options.
 
 ## Attributes Reference
@@ -60,11 +62,10 @@ The following attributes are exported:
 * `endpoints` - See Argument Reference above.
 * `value_specs` - See Argument Reference above.
 
-
 ## Import
 
 Groups can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_vpnaas_endpoint_group_v2.group_1 832cb7f3-59fe-40cf-8f64-8350ffc03272
+```shell
+terraform import openstack_vpnaas_endpoint_group_v2.group_1 832cb7f3-59fe-40cf-8f64-8350ffc03272
 ```

--- a/docs/resources/vpnaas_ike_policy_v2.md
+++ b/docs/resources/vpnaas_ike_policy_v2.md
@@ -55,9 +55,9 @@ The following arguments are supported:
     Changing this updates the existing policy.
 
 * `lifetime` - (Optional) The lifetime of the security association. Consists of Unit and Value.
-    - `unit` - (Optional) The units for the lifetime of the security association. Can be either seconds or kilobytes.
+  * `unit` - (Optional) The units for the lifetime of the security association. Can be either seconds or kilobytes.
     Default is seconds.
-    - `value` - (Optional) The value for the lifetime of the security association. Must be a positive integer.
+  * `value` - (Optional) The value for the lifetime of the security association. Must be a positive integer.
     Default is 3600.
 
 * `value_specs` - (Optional) Map of additional options.
@@ -76,15 +76,14 @@ The following attributes are exported:
 * `pfs` - See Argument Reference above.
 * `transform_protocol` - See Argument Reference above.
 * `lifetime` - See Argument Reference above.
-    - `unit` - See Argument Reference above.
-    - `value` - See Argument Reference above.
+  * `unit` - See Argument Reference above.
+  * `value` - See Argument Reference above.
 * `value_specs` - See Argument Reference above.
-
 
 ## Import
 
 Services can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_vpnaas_ike_policy_v2.policy_1 832cb7f3-59fe-40cf-8f64-8350ffc03272
+```shell
+terraform import openstack_vpnaas_ike_policy_v2.policy_1 832cb7f3-59fe-40cf-8f64-8350ffc03272
 ```

--- a/docs/resources/vpnaas_ipsec_policy_v2.md
+++ b/docs/resources/vpnaas_ipsec_policy_v2.md
@@ -55,9 +55,9 @@ The following arguments are supported:
     Changing this updates the existing policy. Default is ESP.
 
 * `lifetime` - (Optional) The lifetime of the security association. Consists of Unit and Value.
-    - `unit` - (Optional) The units for the lifetime of the security association. Can be either seconds or kilobytes.
+  * `unit` - (Optional) The units for the lifetime of the security association. Can be either seconds or kilobytes.
     Default is seconds.
-    - `value` - (Optional) The value for the lifetime of the security association. Must be a positive integer.
+  * `value` - (Optional) The value for the lifetime of the security association. Must be a positive integer.
     Default is 3600.
 
 * `value_specs` - (Optional) Map of additional options.
@@ -76,15 +76,14 @@ The following attributes are exported:
 * `pfs` - See Argument Reference above.
 * `transform_protocol` - See Argument Reference above.
 * `lifetime` - See Argument Reference above.
-    - `unit` - See Argument Reference above.
-    - `value` - See Argument Reference above.
+  * `unit` - See Argument Reference above.
+  * `value` - See Argument Reference above.
 * `value_specs` - See Argument Reference above.
-
 
 ## Import
 
 Policies can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_vpnaas_ipsec_policy_v2.policy_1 832cb7f3-59fe-40cf-8f64-8350ffc03272
+```shell
+terraform import openstack_vpnaas_ipsec_policy_v2.policy_1 832cb7f3-59fe-40cf-8f64-8350ffc03272
 ```

--- a/docs/resources/vpnaas_service_v2.md
+++ b/docs/resources/vpnaas_service_v2.md
@@ -68,6 +68,6 @@ The following attributes are exported:
 
 Services can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_vpnaas_service_v2.service_1 832cb7f3-59fe-40cf-8f64-8350ffc03272
+```shell
+terraform import openstack_vpnaas_service_v2.service_1 832cb7f3-59fe-40cf-8f64-8350ffc03272
 ```

--- a/docs/resources/vpnaas_site_connection_v2.md
+++ b/docs/resources/vpnaas_site_connection_v2.md
@@ -58,22 +58,22 @@ The following arguments are supported:
 
 * `local_ep_group_id` - (Optional) The ID for the endpoint group that contains private subnets for the local side of the connection.
     You must specify this parameter with the peer_ep_group_id parameter unless
-	in backward- compatible mode where peer_cidrs is provided with a subnet_id for the VPN service.
+    in backward-compatible mode where peer_cidrs is provided with a subnet_id for the VPN service.
     Changing this updates the existing connection.
-    
+
 * `ipsecpolicy_id` - (Required) The ID of the IPsec policy. Changing this creates a new connection.
 
 * `peer_id` - (Required) The peer router identity for authentication. A valid value is an IPv4 address, IPv6 address, e-mail address, key ID, or FQDN.
-	Typically, this value matches the peer_address value.
-	Changing this updates the existing policy.
+    Typically, this value matches the peer_address value.
+    Changing this updates the existing policy.
 
 * `peer_ep_group_id` - (Optional) The ID for the endpoint group that contains private CIDRs in the form < net_address > / < prefix > for the peer side of the connection.
-	You must specify this parameter with the local_ep_group_id parameter unless in backward-compatible mode
-	where peer_cidrs is provided with a subnet_id for the VPN service.
+    You must specify this parameter with the local_ep_group_id parameter unless in backward-compatible mode
+    where peer_cidrs is provided with a subnet_id for the VPN service.
 
 * `local_id` - (Optional) An ID to be used instead of the external IP address for a virtual router used in traffic between instances on different networks in east-west traffic.
-	Most often, local ID would be domain name, email address, etc.
-	If this is not configured then the external IP address will be used as the ID.
+    Most often, local ID would be domain name, email address, etc.
+    If this is not configured then the external IP address will be used as the ID.
 
 * `peer_address` - (Required) The peer gateway public IPv4 or IPv6 address or FQDN.
 
@@ -84,21 +84,21 @@ The following arguments are supported:
 * `peer_cidrs` - (Optional) Unique list of valid peer private CIDRs in the form < net_address > / < prefix > .
 
 * `dpd` - (Optional) A dictionary with dead peer detection (DPD) protocol controls.
-    - `action` - (Optional) The dead peer detection (DPD) action.
-    	A valid value is clear, hold, restart, disabled, or restart-by-peer.
-    	Default value is hold.
-    
-    - `timeout` - (Optional) The dead peer detection (DPD) timeout in seconds.
-    	A valid value is a positive integer that is greater than the DPD interval value.
-    	Default is 120.
-    
-    - `interval` - (Optional) The dead peer detection (DPD) interval, in seconds.
-    	A valid value is a positive integer.
-    	Default is 30.
+  * `action` - (Optional) The dead peer detection (DPD) action.
+     A valid value is clear, hold, restart, disabled, or restart-by-peer.
+     Default value is hold.
+
+  * `timeout` - (Optional) The dead peer detection (DPD) timeout in seconds.
+     A valid value is a positive integer that is greater than the DPD interval value.
+     Default is 120.
+
+  * `interval` - (Optional) The dead peer detection (DPD) interval, in seconds.
+     A valid value is a positive integer.
+     Default is 30.
 
 * `mtu` - (Optional) The maximum transmission unit (MTU) value to address fragmentation.
-	Minimum value is 68 for IPv4, and 1280 for IPv6.
-	
+    Minimum value is 68 for IPv4, and 1280 for IPv6.
+
 * `value_specs` - (Optional) Map of additional options.
 
 ## Attributes Reference
@@ -128,6 +128,6 @@ The following attributes are exported:
 
 Site Connections can be imported using the `id`, e.g.
 
-```
-$ terraform import openstack_vpnaas_site_connection_v2.conn_1 832cb7f3-59fe-40cf-8f64-8350ffc03272
+```shell
+terraform import openstack_vpnaas_site_connection_v2.conn_1 832cb7f3-59fe-40cf-8f64-8350ffc03272
 ```

--- a/examples/app-with-networking/README.md
+++ b/examples/app-with-networking/README.md
@@ -5,9 +5,9 @@ cloud.
 
 To simplify the example, this intentionally ignores deploying and
 getting your application onto the servers. However, you could do so either via
-[provisioners](https://www.terraform.io/docs/provisioners/) and a configuration
+[provisioners](https://developer.hashicorp.com/terraform/language/provisioners) and a configuration
 management tool, or by pre-baking configured images with
-[Packer](http://www.packer.io).
+[Packer](https://www.packer.io).
 
 After you run `terraform apply` on this configuration, it will output the
 floating IP address assigned to the instance. After your instance started,
@@ -16,13 +16,13 @@ this should respond with the default nginx web page.
 First set the required environment variables for the OpenStack provider by
 sourcing the [credentials file](http://docs.openstack.org/cli-reference/content/cli_openrc.html).
 
-```
+```shell
 source openrc
 ```
 
 Afterwards run with a command like this:
 
-```
+```shell
 terraform apply \
   -var 'pool=public'
 ```
@@ -30,7 +30,7 @@ terraform apply \
 To get a list of usable floating IP pools run this command, and the UUID of the external gateway
 is in the following `ID` column:
 
-```
+```shell
 $ openstack network list --external
 +--------------------------------------+--------+----------------------------------------------------------------------------+
 | ID                                   | Name   | Subnets                                                                    |

--- a/examples/attach-format-mount-volume/README.md
+++ b/examples/attach-format-mount-volume/README.md
@@ -4,9 +4,9 @@ This provides a template for attaching, formating, and mounting a Block Storage 
 
 ## Usage
 
-Download and install [Terraform](https://www.terraform.io/downloads.html):
+Download and install [Terraform](https://developer.hashicorp.com/terraform/install):
 
-```sh
+```shell
 wget -P /tmp/ https://releases.hashicorp.com/terraform/0.12.9/terraform_0.12.9_linux_amd64.zip
 unzip /tmp/terraform_0.12.9_linux_amd64.zip
 sudo mv terraform /usr/local/bin/
@@ -15,20 +15,20 @@ terraform --version
 
 Log in to the OpenStack dashboard, choose the project for which you want to download the OpenStack RC file, and run the following commands:
 
-```sh
+```shell
 source ~/Downloads/PROJECT-openrc.sh
 Please enter your OpenStack Password for project PROJECT as user username:
 ```
 
 ### Initialize providers
 
-```sh
+```shell
 terraform init
 ```
 
 ### Generate an execution plan
 
-```sh
+```shell
 terraform plan
 # or with specific variables
 terraform plan -var 'pool=gateway' \
@@ -40,7 +40,7 @@ terraform plan -var 'pool=gateway' \
 
 ### Apply the plan
 
-```sh
+```shell
 terraform apply -auto-approve
 # or with specific variables
 terraform apply -auto-approve \
@@ -57,7 +57,7 @@ Upon completion,the instances floating IP can be viewed in `instance_ip.txt`.
 
  > watch the `-force` will not ask for any confirmation.
 
-```sh
+```shell
 terraform destroy -force
 # or with specific variables
 terraform destroy -force \

--- a/examples/multiple-vm-with-floating-ip/README.md
+++ b/examples/multiple-vm-with-floating-ip/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-We assume you already installed terraform using the following instructions: https://www.terraform.io/downloads.html
+We assume you already installed terraform using the following instructions: <https://developer.hashicorp.com/terraform/install>
 
 ## Getting started
 
@@ -10,22 +10,21 @@ First, download an openrc file from the OpenStack dashboard. If your cloud provi
 
 After you have modified it, source it into your shell environment:
 
-```
+```shell
 source ./openrc
 ```
 
 Init providers
 
-```
+```shell
 terraform init
 ```
-
 
 ## Deploy the Configuration
 
 plan the deployment
 
-```
+```shell
 terraform plan
 # or with specific variables
 terraform plan -var 'pool=gateway' \
@@ -37,7 +36,7 @@ terraform plan -var 'pool=gateway' \
 
 Apply the plan
 
-```
+```shell
 terraform apply -auto-approve
 # or with specific variables
 terraform apply -auto-approve \
@@ -48,12 +47,11 @@ terraform apply -auto-approve \
                 -var 'ssh_key_file=./id_rsa_os'
 ```
 
-
 ## Tear down
 
 cleanup, watch the `-force` will not ask for any confirmation.
 
-```
+```shell
 terraform destroy -force
 # or with specific variables
 terraform destroy -force \

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 const providerAddr = "registry.terraform.io/terraform-provider-openstack/openstack"
 
 func main() {
-	// added debugMode to enable debugging for provider per https://www.terraform.io/plugin/sdkv2/debugging
+	// added debugMode to enable debugging for provider per https://developer.hashicorp.com/terraform/plugin/sdkv2/debugging
 	var debugMode bool
 
 	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")


### PR DESCRIPTION
* Updated Terraform code blocks to `hcl`
* Updated shell/CLI code blocks to `shell`
* Fixed missing code block languages
* Fixed Markdown spacing, removed extra blank lines + consistent formatting
* Fix links

I used mainly [markdownlint](https://github.com/DavidAnson/markdownlint/) to lint the Markdown files.

Next step could be to migrate to [terraform-plugin-docs](https://github.com/hashicorp/terraform-plugin-docs).