### PR TITLE
[workflow] add openstack_workflow_cron_trigger_v2 resource

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -153,6 +153,7 @@ linters:
             - github.com/gophercloud/gophercloud/v2
             - github.com/gophercloud/utils/v2
             - github.com/mitchellh/go-homedir
+            - github.com/hashicorp/terraform-plugin-log
             - github.com/hashicorp/terraform-plugin-sdk/v2
             - github.com/ulikunitz/xz
             - github.com/klauspost/compress

--- a/docs/data-sources/workflow_workflow_v2.md
+++ b/docs/data-sources/workflow_workflow_v2.md
@@ -9,13 +9,13 @@ description: |-
 
 # openstack\_workflow\_workflow_v2
 
-Use this data source to get the ID of an available workflow.
+Use this data source to get the ID of an available Mistral workflow.
 
 ## Example Usage
 
 ```hcl
-data "openstack_workflow_workflow_v2" "workflow_1" {
-  name = "workflow_1"
+data "openstack_workflow_workflow_v2" "hello_workflow" {
+  name = "hello_workflow"
 }
 ```
 

--- a/docs/resources/workflow_cron_trigger_v2.md
+++ b/docs/resources/workflow_cron_trigger_v2.md
@@ -1,0 +1,82 @@
+---
+subcategory: "Workflow / Mistral"
+layout: "openstack"
+page_title: "OpenStack: openstack_workflow_cron_trigger_v2"
+sidebar_current: "docs-openstack-workflow-cron-trigger-v2"
+description: |-
+  Manages a Mistral V2 Cron Trigger resource within OpenStack.
+---
+
+# openstack\_workflow\_cron\_trigger\_v2
+
+Manages a Mistral V2 Cron Trigger resource within OpenStack.
+
+A cron trigger schedules the execution of a workflow using a cron-like pattern.
+
+## Example Usage
+
+```hcl
+data "openstack_workflow_workflow_v2" "hello_workflow" {
+  name = "hello_workflow"
+}
+
+resource "openstack_workflow_cron_trigger_v2" "hello_cron_trigger" {
+  name          = "hello_cron_trigger"
+  workflow_id   = data.openstack_workflow_workflow_v2.hello_workflow.id
+  pattern       = "0 5 * * *"
+
+  workflow_input = {
+    message = "Hello, OpenStack!"
+  }
+
+  workflow_params = {
+    priority = "high"
+    notify   = ["mistral@openstack.org"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional) The region in which to obtain the V2 Workflow client.
+    If omitted, the `region` argument of the provider is used. Changing this
+    creates a new cron trigger.
+
+* `name` - (Required) The name of the cron trigger. Changing this creates a new
+    cron trigger.
+
+* `workflow_id` - (Required) The ID of the workflow to be executed by this cron
+    trigger. Changing this creates a new cron trigger.
+
+* `pattern` - (Required) A cron-like schedule pattern indicating when the
+    workflow should be executed. Changing this creates a new cron trigger.
+
+* `workflow_input` - (Optional) Map of input parameters passed to the workflow
+    upon execution. Changing this creates a new cron trigger.
+
+* `workflow_params` - (Optional) Map of additional workflow parameters.
+    Changing this creates a new cron trigger.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The unique ID of the cron trigger.
+* `region` - See Argument Reference above.
+* `project_id` - The owner of the Cron Trigger.
+* `name` - See Argument Reference above.
+* `workflow_id` - See Argument Reference above.
+* `pattern` - See Argument Reference above.
+* `workflow_input` - See Argument Reference above.
+* `workflow_params` - See Argument Reference above.
+* `created_at` - The time at which cron trigger was created.
+
+## Import
+
+Cron triggers can be imported using the `id`, e.g.
+
+```shell
+terraform import openstack_workflow_cron_trigger_v2.cron_trigger_1 bae24970-d96e-4ed0-80c1-b798cb2208c6
+```

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/gophercloud/gophercloud/v2 v2.10.0
 	github.com/gophercloud/utils/v2 v2.0.0-20250710092215-8f6f0255f600
+	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
 	github.com/klauspost/compress v1.18.2
@@ -41,7 +42,6 @@ require (
 	github.com/hashicorp/terraform-exec v0.24.0 // indirect
 	github.com/hashicorp/terraform-json v0.27.2 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.29.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.10.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect

--- a/openstack/data_source_openstack_workflow_workflow_v2_test.go
+++ b/openstack/data_source_openstack_workflow_workflow_v2_test.go
@@ -37,11 +37,11 @@ func TestAccWorkflowV2WorkflowDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.openstack_workflow_workflow_v2.workflow_1", "id", workflowID),
 					resource.TestCheckResourceAttr(
-						"data.openstack_workflow_workflow_v2.workflow_1", "name", "my_workflow"),
+						"data.openstack_workflow_workflow_v2.workflow_1", "name", "hello_workflow"),
 					resource.TestCheckResourceAttr(
 						"data.openstack_workflow_workflow_v2.workflow_1", "namespace", "my_namespace"),
 					resource.TestCheckResourceAttr(
-						"data.openstack_workflow_workflow_v2.workflow_1", "input", "my_arg1, my_arg2"),
+						"data.openstack_workflow_workflow_v2.workflow_1", "input", "message"),
 					resource.TestCheckResourceAttrSet(
 						"data.openstack_workflow_workflow_v2.workflow_1", "definition"),
 					resource.TestCheckResourceAttr(
@@ -104,7 +104,7 @@ func testAccWorkflowV2WorkflowDelete(t *testing.T, workflowID string) {
 
 const testAccWorkflowV2WorkflowDataSourceBasic = `
 data "openstack_workflow_workflow_v2" "workflow_1" {
-	name      = "my_workflow"
+	name      = "hello_workflow"
 	namespace = "my_namespace"
 }
 `
@@ -112,12 +112,11 @@ data "openstack_workflow_workflow_v2" "workflow_1" {
 const testAccWorkflowV2WorkflowDataSourceBasicDefinition = `
 version: '2.0'
 
-my_workflow:
+hello_workflow:
   description: Simple echo example
 
   input:
-    - my_arg1
-    - my_arg2
+    - message
 
   tags:
     - echo
@@ -127,6 +126,5 @@ my_workflow:
       action: std.echo
       input:
         output:
-          my_arg1: <% $.my_arg1 %>
-          my_arg2: <% $.my_arg2 %>
+          my_message: <% $.message %>
 `

--- a/openstack/import_openstack_workflow_cron_trigger_v2_test.go
+++ b/openstack/import_openstack_workflow_cron_trigger_v2_test.go
@@ -1,0 +1,43 @@
+package openstack
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccWorkflowV2CronTrigger_importBasic(t *testing.T) {
+	resourceName := "openstack_workflow_cron_trigger_v2.cron_trigger_1"
+
+	var workflowID string
+
+	if os.Getenv("TF_ACC") != "" {
+		workflow, err := testAccWorkflowV2WorkflowCreate(t.Context())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		workflowID = workflow.ID
+		defer testAccWorkflowV2WorkflowDelete(t, workflowID)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckWorkflowV2CronTriggerDestroy(t.Context()),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkflowV2CronTriggerBasic(workflowID),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -505,6 +505,7 @@ func Provider() *schema.Provider {
 			"openstack_bgpvpn_network_associate_v2":              resourceBGPVPNNetworkAssociateV2(),
 			"openstack_bgpvpn_router_associate_v2":               resourceBGPVPNRouterAssociateV2(),
 			"openstack_bgpvpn_port_associate_v2":                 resourceBGPVPNPortAssociateV2(),
+			"openstack_workflow_cron_trigger_v2":                 resourceWorkflowCronTriggerV2(),
 		},
 	}
 

--- a/openstack/resource_openstack_workflow_cron_trigger_v2.go
+++ b/openstack/resource_openstack_workflow_cron_trigger_v2.go
@@ -1,0 +1,150 @@
+package openstack
+
+import (
+	"context"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/workflow/v2/crontriggers"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceWorkflowCronTriggerV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWorkflowCronTriggerV2Create,
+		ReadContext:   resourceWorkflowCronTriggerV2Read,
+		DeleteContext: resourceWorkflowCronTriggerV2Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"workflow_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"workflow_input": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"workflow_params": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"pattern": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceWorkflowCronTriggerV2Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	config := meta.(*Config)
+	workflowClient, err := config.WorkflowV2Client(ctx, GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating OpenStack workflow client: %s", err)
+	}
+
+	createOpts := crontriggers.CreateOpts{
+		Name:           d.Get("name").(string),
+		WorkflowID:     d.Get("workflow_id").(string),
+		WorkflowInput:  d.Get("workflow_input").(map[string]any),
+		WorkflowParams: d.Get("workflow_params").(map[string]any),
+		Pattern:        d.Get("pattern").(string),
+	}
+
+	tflog.Debug(ctx, "openstack_workflow_cron_trigger_v2 create options", map[string]any{
+		"createOpts": createOpts,
+	})
+
+	crontrigger, err := crontriggers.Create(ctx, workflowClient, createOpts).Extract()
+	if err != nil {
+		return diag.Errorf("Unable to create openstack_workflow_cron_trigger_v2: %s", err)
+	}
+
+	d.SetId(crontrigger.ID)
+
+	return resourceWorkflowCronTriggerV2Read(ctx, d, meta)
+}
+
+func resourceWorkflowCronTriggerV2Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	config := meta.(*Config)
+	workflowClient, err := config.WorkflowV2Client(ctx, GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating OpenStack workflow client: %s", err)
+	}
+
+	crontrigger, err := crontriggers.Get(ctx, workflowClient, d.Id()).Extract()
+	if err != nil {
+		return diag.FromErr(CheckDeleted(d, err, "Error retrieving openstack_workflow_cron_trigger_v2"))
+	}
+
+	tflog.Debug(ctx, "Retrieved openstack_workflow_cron_trigger_v2", map[string]any{
+		"id":          d.Id(),
+		"crontrigger": crontrigger,
+	})
+
+	d.Set("name", crontrigger.Name)
+	d.Set("region", GetRegion(d, config))
+	d.Set("workflow_id", crontrigger.WorkflowID)
+	d.Set("workflow_input", crontrigger.WorkflowInput)
+	d.Set("workflow_params", crontrigger.WorkflowParams)
+	d.Set("pattern", crontrigger.Pattern)
+	d.Set("project_id", crontrigger.ProjectID)
+
+	if err := d.Set("created_at", crontrigger.CreatedAt.Format(time.RFC3339)); err != nil {
+		tflog.Warn(ctx, "Unable to set created_at for openstack_workflow_cron_trigger_v2", map[string]any{
+			"id":    crontrigger.ID,
+			"error": err,
+		})
+	}
+
+	return nil
+}
+
+func resourceWorkflowCronTriggerV2Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	config := meta.(*Config)
+	workflowClient, err := config.WorkflowV2Client(ctx, GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating OpenStack workflow client: %s", err)
+	}
+
+	err = crontriggers.Delete(ctx, workflowClient, d.Id()).ExtractErr()
+	if err != nil {
+		return diag.FromErr(CheckDeleted(d, err, "Error deleting openstack_workflow_cron_trigger_v2"))
+	}
+
+	return nil
+}

--- a/openstack/resource_openstack_workflow_cron_trigger_v2_test.go
+++ b/openstack/resource_openstack_workflow_cron_trigger_v2_test.go
@@ -1,0 +1,138 @@
+package openstack
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/workflow/v2/crontriggers"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccWorkflowV2CronTrigger_basic(t *testing.T) {
+	var workflowID string
+
+	if os.Getenv("TF_ACC") != "" {
+		workflow, err := testAccWorkflowV2WorkflowCreate(t.Context())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		workflowID = workflow.ID
+		defer testAccWorkflowV2WorkflowDelete(t, workflowID)
+	}
+
+	var crontrigger crontriggers.CronTrigger
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckWorkflow(t)
+		},
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckWorkflowV2CronTriggerDestroy(t.Context()),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkflowV2CronTriggerBasic(workflowID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWorkflowV2CronTriggerExists(t.Context(),
+						"openstack_workflow_cron_trigger_v2.cron_trigger_1", &crontrigger),
+					resource.TestCheckResourceAttrSet(
+						"openstack_workflow_cron_trigger_v2.cron_trigger_1", "id"),
+					resource.TestCheckResourceAttr(
+						"openstack_workflow_cron_trigger_v2.cron_trigger_1", "name", "hello_cron_trigger"),
+					resource.TestCheckResourceAttr(
+						"openstack_workflow_cron_trigger_v2.cron_trigger_1", "workflow_id", workflowID),
+					resource.TestCheckResourceAttr(
+						"openstack_workflow_cron_trigger_v2.cron_trigger_1", "pattern", "0 5 * * *"),
+					resource.TestCheckResourceAttr(
+						"openstack_workflow_cron_trigger_v2.cron_trigger_1", "workflow_input.%", "1"),
+					resource.TestCheckResourceAttr(
+						"openstack_workflow_cron_trigger_v2.cron_trigger_1", "workflow_params.%", "2"),
+					resource.TestCheckResourceAttrSet(
+						"openstack_workflow_cron_trigger_v2.cron_trigger_1", "project_id"),
+					resource.TestCheckResourceAttrSet(
+						"openstack_workflow_cron_trigger_v2.cron_trigger_1", "created_at"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckWorkflowV2CronTriggerDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*Config)
+		workflowClient, err := config.WorkflowV2Client(ctx, osRegionName)
+		if err != nil {
+			return fmt.Errorf("Error creating OpenStack workflow client: %w", err)
+		}
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "openstack_workflow_cron_trigger_v2" {
+				continue
+			}
+
+			_, err := crontriggers.Get(ctx, workflowClient, rs.Primary.ID).Extract()
+			if err == nil {
+				return errors.New("CronTrigger still exists")
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckWorkflowV2CronTriggerExists(ctx context.Context, n string, crontrigger *crontriggers.CronTrigger) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		workflowClient, err := config.WorkflowV2Client(ctx, osRegionName)
+		if err != nil {
+			return fmt.Errorf("Error creating OpenStack workflow client: %w", err)
+		}
+
+		found, err := crontriggers.Get(ctx, workflowClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return errors.New("CronTrigger not found")
+		}
+
+		*crontrigger = *found
+
+		return nil
+	}
+}
+
+func testAccWorkflowV2CronTriggerBasic(workflowID string) string {
+	return fmt.Sprintf(`
+resource "openstack_workflow_cron_trigger_v2" "cron_trigger_1" {
+  name        = "hello_cron_trigger"
+  workflow_id = "%s"
+  pattern     = "0 5 * * *"
+
+  workflow_input = {
+    message = "Hello, OpenStack!"
+  }
+
+  workflow_params = {
+    priority = "high"
+    notify   = "mistral@openstack.org"
+  }
+}
+`, workflowID)
+}


### PR DESCRIPTION
This introduce the `openstack_workflow_cron_trigger_v2` resource, which allows users to manage Mistral cron triggers in OpenStack.

See issue #1818