### PR TITLE
Improve compute resource  micro version handling

### DIFF
--- a/openstack/util.go
+++ b/openstack/util.go
@@ -367,3 +367,18 @@ func stringSliceToSet(in []string) *schema.Set {
 
 	return schema.NewSet(schema.HashString, result)
 }
+
+// update the computeClient microversion properly by checking if it already was set.
+// If it was set only update it when the currently set microversion is less than the required one.
+func bumpClientMicroversion(client *gophercloud.ServiceClient, requiredMicroversion string) {
+	if client.Microversion == "" {
+		client.Microversion = requiredMicroversion
+
+		return
+	}
+
+	compatible, _ := compatibleMicroversion("max", requiredMicroversion, client.Microversion)
+	if compatible {
+		client.Microversion = requiredMicroversion
+	}
+}

--- a/openstack/util.go
+++ b/openstack/util.go
@@ -368,7 +368,7 @@ func stringSliceToSet(in []string) *schema.Set {
 	return schema.NewSet(schema.HashString, result)
 }
 
-// update the computeClient microversion properly by checking if it already was set.
+// Update the client microversion properly by checking if it already was set.
 // If it was set only update it when the currently set microversion is less than the required one.
 func bumpClientMicroversion(client *gophercloud.ServiceClient, requiredMicroversion string) {
 	if client.Microversion == "" {


### PR DESCRIPTION
The current micro version handling can downgrade the micro version to a
lower than required version. This addresses the issue in
`resource_openstack_compute_instance_v2`

fixes #2007 
