### PR TITLE
lbaas: ensure listener ALPN order is respected

### DIFF
--- a/openstack/data_source_openstack_lb_pool_v2.go
+++ b/openstack/data_source_openstack_lb_pool_v2.go
@@ -207,7 +207,7 @@ func dataSourceLBPoolV2() *schema.Resource {
 			},
 
 			"alpn_protocols": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -240,7 +240,7 @@ func dataSourceLBPoolV2() *schema.Resource {
 			},
 
 			"tls_versions": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/openstack/resource_openstack_lb_listener_v2.go
+++ b/openstack/resource_openstack_lb_listener_v2.go
@@ -99,7 +99,7 @@ func resourceListenerV2() *schema.Resource {
 			},
 
 			"alpn_protocols": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true, // unsetting this parameter results in a default value
 				Elem: &schema.Schema{
@@ -246,7 +246,7 @@ func resourceListenerV2Create(ctx context.Context, d *schema.ResourceData, meta 
 		Description:             d.Get("description").(string),
 		DefaultTlsContainerRef:  d.Get("default_tls_container_ref").(string),
 		SniContainerRefs:        expandToStringSlice(d.Get("sni_container_refs").([]any)),
-		ALPNProtocols:           expandToStringSlice(d.Get("alpn_protocols").(*schema.Set).List()),
+		ALPNProtocols:           expandToStringSlice(d.Get("alpn_protocols").([]any)),
 		ClientAuthentication:    listeners.ClientAuthentication(d.Get("client_authentication").(string)),
 		ClientCATLSContainerRef: d.Get("client_ca_tls_container_ref").(string),
 		ClientCRLContainerRef:   d.Get("client_crl_container_ref").(string),
@@ -476,7 +476,7 @@ func resourceListenerV2Update(ctx context.Context, d *schema.ResourceData, meta 
 
 	if d.HasChange("alpn_protocols") {
 		hasChange = true
-		v := expandToStringSlice(d.Get("alpn_protocols").(*schema.Set).List())
+		v := expandToStringSlice(d.Get("alpn_protocols").([]any))
 		updateOpts.ALPNProtocols = &v
 	}
 

--- a/openstack/resource_openstack_lb_pool_v2.go
+++ b/openstack/resource_openstack_lb_pool_v2.go
@@ -112,7 +112,7 @@ func resourcePoolV2() *schema.Resource {
 			},
 
 			"alpn_protocols": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true, // unsetting this parameter results in a default value
 				Elem: &schema.Schema{
@@ -197,7 +197,7 @@ func resourcePoolV2Create(ctx context.Context, d *schema.ResourceData, meta any)
 		LoadbalancerID:    lbID,
 		ListenerID:        listenerID,
 		LBMethod:          pools.LBMethod(d.Get("lb_method").(string)),
-		ALPNProtocols:     expandToStringSlice(d.Get("alpn_protocols").(*schema.Set).List()),
+		ALPNProtocols:     expandToStringSlice(d.Get("alpn_protocols").([]any)),
 		CATLSContainerRef: d.Get("ca_tls_container_ref").(string),
 		CRLContainerRef:   d.Get("crl_container_ref").(string),
 		TLSEnabled:        d.Get("tls_enabled").(bool),
@@ -343,7 +343,7 @@ func resourcePoolV2Update(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	if d.HasChange("alpn_protocols") {
-		v := expandToStringSlice(d.Get("alpn_protocols").(*schema.Set).List())
+		v := expandToStringSlice(d.Get("alpn_protocols").([]any))
 		updateOpts.ALPNProtocols = &v
 	}
 


### PR DESCRIPTION
Resolves #2009 

@nikParasyr this is a schema change, and newer provider versions may trigger a listener update due to an explicitly defined ALPN order, which should not be a significant issue. However, the schema change could break existing TF configurations if they reference `openstack_lb_listener_v2.<name>.alpn_protocols`, although this is unlikely but it is easy to fix.

What do you think? Should we wait for a major release, or is it safe to include this fix in a minor release?