### PR TITLE
[workflow] add openstack_workflow_cron_trigger_v2 datasource

### DIFF
--- a/docs/data-sources/workflow_cron_trigger_v2.md
+++ b/docs/data-sources/workflow_cron_trigger_v2.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Workflow / Mistral"
+layout: "openstack"
+page_title: "OpenStack: openstack_workflow_cron_trigger_v2"
+sidebar_current: "docs-openstack-datasource-workflow-cron-trigger-v2"
+description: |-
+  Retrieve information about an existing Mistral Cron Trigger.
+---
+
+# openstack\_workflow\_cron\_trigger\_v2
+
+Use this data source to retrieve information about an existing Mistral Cron Trigger.
+
+## Example Usage
+
+```hcl
+data "openstack_workflow_cron_trigger_v2" "cron_trigger" {
+  name = "cron_trigger"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional) The region in which to obtain the Workflow V2 client.
+    If omitted, the `region` argument of the provider is used.
+
+* `name` - (Optional) The name of the cron trigger.
+
+* `workflow_id` - (Optional) The ID of the workflow associated with the cron trigger.
+
+* `project_id` - (Optional) The ID of the project from which to retrieve the cron trigger.
+    Requires admin privileges.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the cron trigger.
+* `region` - The region in which the cron trigger was found.
+* `project_id` - The ID of the project owning the cron trigger.
+* `name` - The name of the cron trigger.
+* `pattern` - The cron-like schedule pattern that defines when the workflow is executed.
+* `workflow_id` - The ID of the workflow associated with the cron trigger.
+* `workflow_input` - A map of input parameters passed to the workflow when it is executed.
+* `workflow_params` - A map of additional workflow execution parameters.
+* `created_at` - The time at which the cron trigger was created.

--- a/docs/data-sources/workflow_workflow_v2.md
+++ b/docs/data-sources/workflow_workflow_v2.md
@@ -7,7 +7,7 @@ description: |-
   Get information on a workflow.
 ---
 
-# openstack\_workflow\_workflow_v2
+# openstack\_workflow\_workflow\_v2
 
 Use this data source to get the ID of an available Mistral workflow.
 

--- a/docs/resources/workflow_cron_trigger_v2.md
+++ b/docs/resources/workflow_cron_trigger_v2.md
@@ -65,7 +65,7 @@ The following attributes are exported:
 
 * `id` - The unique ID of the cron trigger.
 * `region` - See Argument Reference above.
-* `project_id` - The owner of the Cron Trigger.
+* `project_id` - The owner of the cron trigger.
 * `name` - See Argument Reference above.
 * `workflow_id` - See Argument Reference above.
 * `pattern` - See Argument Reference above.

--- a/openstack/data_source_openstack_workflow_cron_trigger_v2.go
+++ b/openstack/data_source_openstack_workflow_cron_trigger_v2.go
@@ -1,0 +1,133 @@
+package openstack
+
+import (
+	"context"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/workflow/v2/crontriggers"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceWorkflowCronTriggerV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceWorkflowCronTriggerV2Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"pattern": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"workflow_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"workflow_input": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+
+			"workflow_params": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceWorkflowCronTriggerV2Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	config := meta.(*Config)
+
+	workflowClient, err := config.WorkflowV2Client(ctx, GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating OpenStack workflow client: %s", err)
+	}
+
+	listOpts := crontriggers.ListOpts{}
+
+	if v, ok := d.GetOk("project_id"); ok {
+		listOpts.ProjectID = v.(string)
+	}
+
+	if v, ok := d.GetOk("workflow_id"); ok {
+		listOpts.WorkflowID = v.(string)
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		listOpts.Name = &crontriggers.ListFilter{
+			Filter: crontriggers.FilterEQ,
+			Value:  v.(string),
+		}
+	}
+
+	allPages, err := crontriggers.List(workflowClient, listOpts).AllPages(ctx)
+	if err != nil {
+		return diag.Errorf("Unable to query cron triggers: %s", err)
+	}
+
+	allCrontriggers, err := crontriggers.ExtractCronTriggers(allPages)
+	if err != nil {
+		return diag.Errorf("Unable to retrieve cron triggers: %s", err)
+	}
+
+	if len(allCrontriggers) < 1 {
+		return diag.Errorf("Your query returned no results. Please change your search criteria and try again")
+	}
+
+	if len(allCrontriggers) > 1 {
+		tflog.Debug(ctx, "Multiple results found", map[string]any{
+			"cronTriggers": allCrontriggers,
+		})
+
+		return diag.Errorf("Your query returned more than one result. Please try a more specific search criteria")
+	}
+
+	dataSourceWorkflowCronTriggerV2Attributes(ctx, d, &allCrontriggers[0], GetRegion(d, config))
+
+	return nil
+}
+
+func dataSourceWorkflowCronTriggerV2Attributes(ctx context.Context, d *schema.ResourceData, crontrigger *crontriggers.CronTrigger, region string) {
+	d.SetId(crontrigger.ID)
+	d.Set("region", region)
+	d.Set("name", crontrigger.Name)
+	d.Set("project_id", crontrigger.ProjectID)
+	d.Set("pattern", crontrigger.Pattern)
+	d.Set("workflow_id", crontrigger.WorkflowID)
+	d.Set("workflow_input", crontrigger.WorkflowInput)
+	d.Set("workflow_params", crontrigger.WorkflowParams)
+
+	if err := d.Set("created_at", crontrigger.CreatedAt.Format(time.RFC3339)); err != nil {
+		tflog.Warn(ctx, "Unable to set created_at for openstack_workflow_cron_trigger_v2", map[string]any{
+			"id":    crontrigger.ID,
+			"error": err,
+		})
+	}
+}

--- a/openstack/data_source_openstack_workflow_cron_trigger_v2_test.go
+++ b/openstack/data_source_openstack_workflow_cron_trigger_v2_test.go
@@ -1,0 +1,100 @@
+package openstack
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccWorkflowV2CronTriggerDataSource_basic(t *testing.T) {
+	var workflowID string
+
+	if os.Getenv("TF_ACC") != "" {
+		workflow, err := testAccWorkflowV2WorkflowCreate(t.Context())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		workflowID = workflow.ID
+
+		defer testAccWorkflowV2WorkflowDelete(t, workflow.ID)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWorkflow(t)
+			testAccPreCheckNonAdminOnly(t)
+		},
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkflowV2CronTriggerDataSourceBasic(workflowID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWorkflowV2CronTriggerDataSourceID("data.openstack_workflow_cron_trigger_v2.cron_trigger_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_workflow_cron_trigger_v2.cron_trigger_1", "name", "hello_cron_trigger"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_workflow_cron_trigger_v2.cron_trigger_1", "pattern", "0 5 * * *"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_workflow_cron_trigger_v2.cron_trigger_1", "workflow_id", workflowID),
+					resource.TestCheckResourceAttr(
+						"data.openstack_workflow_cron_trigger_v2.cron_trigger_1", "workflow_input.%", "1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_workflow_cron_trigger_v2.cron_trigger_1", "workflow_input.message", "Hello, OpenStack!"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_workflow_cron_trigger_v2.cron_trigger_1", "workflow_params.%", "2"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_workflow_cron_trigger_v2.cron_trigger_1", "workflow_params.priority", "high"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_workflow_cron_trigger_v2.cron_trigger_1", "workflow_params.notify", "mistral@openstack.org"),
+					resource.TestCheckResourceAttrSet(
+						"data.openstack_workflow_cron_trigger_v2.cron_trigger_1", "project_id"),
+					resource.TestCheckResourceAttrSet(
+						"data.openstack_workflow_cron_trigger_v2.cron_trigger_1", "created_at"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckWorkflowV2CronTriggerDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find cron trigger data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("Cron trigger data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+func testAccWorkflowV2CronTriggerDataSourceBasic(workflowID string) string {
+	return fmt.Sprintf(`
+resource "openstack_workflow_cron_trigger_v2" "cron_trigger_1" {
+  name        = "hello_cron_trigger"
+  workflow_id = "%s"
+  pattern     = "0 5 * * *"
+
+  workflow_input = {
+    message = "Hello, OpenStack!"
+  }
+
+  workflow_params = {
+    priority = "high"
+    notify   = "mistral@openstack.org"
+  }
+}
+
+data "openstack_workflow_cron_trigger_v2" "cron_trigger_1" {
+  name = openstack_workflow_cron_trigger_v2.cron_trigger_1.name
+}
+`, workflowID)
+}

--- a/openstack/data_source_openstack_workflow_workflow_v2.go
+++ b/openstack/data_source_openstack_workflow_workflow_v2.go
@@ -84,7 +84,7 @@ func dataSourceWorkflowWorkflowV2Read(ctx context.Context, d *schema.ResourceDat
 	name := d.Get("name").(string)
 	if name != "" {
 		listOpts.Name = &workflows.ListFilter{
-			Filter: "eq",
+			Filter: workflows.FilterEQ,
 			Value:  name,
 		}
 	}
@@ -92,7 +92,7 @@ func dataSourceWorkflowWorkflowV2Read(ctx context.Context, d *schema.ResourceDat
 	namespace := d.Get("namespace").(string)
 	if namespace != "" {
 		listOpts.Namespace = &workflows.ListFilter{
-			Filter: "eq",
+			Filter: workflows.FilterEQ,
 			Value:  namespace,
 		}
 	}

--- a/openstack/provider.go
+++ b/openstack/provider.go
@@ -393,6 +393,7 @@ func Provider() *schema.Provider {
 			"openstack_lb_member_v2":                             dataSourceLBMemberV2(),
 			"openstack_lb_monitor_v2":                            dataSourceLBMonitorV2(),
 			"openstack_lb_pool_v2":                               dataSourceLBPoolV2(),
+			"openstack_workflow_cron_trigger_v2":                 dataSourceWorkflowCronTriggerV2(),
 			"openstack_workflow_workflow_v2":                     dataSourceWorkflowWorkflowV2(),
 		},
 


### PR DESCRIPTION
This introduce the openstack_workflow_cron_trigger_v2 datasource, which allows users to retrieve information on Mistral cron triggers.

See issue #1818