### PR TITLE
Add skip_destroy to openstack_networking_port_secgroup_associate_v2

### DIFF
--- a/docs/resources/networking_port_secgroup_associate_v2.md
+++ b/docs/resources/networking_port_secgroup_associate_v2.md
@@ -15,7 +15,10 @@ not created by Terraform (e.g. Manila or LBaaS).
 When the resource is deleted, Terraform doesn't delete the port, but unsets the
 list of user defined security group IDs.  However, if `enforce` is set to `true`
 and the resource is deleted, Terraform will remove all assigned security group
-IDs.
+IDs. Setting `skip_destroy` to `true` overrides both behaviors and leaves the
+port's security groups untouched on destroy — useful when the port (or the
+instance behind it) is managed by external tooling that will reprovision it,
+and the security groups must not be cleared in the meantime.
 
 ~> **Warning:** This resource should **not** be used when the
 port was created directly within Terraform. If it is, it can lead  
@@ -76,6 +79,31 @@ resource "openstack_networking_port_secgroup_associate_v2" "port_1" {
 }
 ```
 
+### Enforce security groups but keep them on destroy
+
+When the port lifecycle is owned by an external system, the resource can
+enforce the exact list of security groups while it exists and skip clearing
+them when it is destroyed.
+
+```hcl
+data "openstack_networking_port_v2" "system_port" {
+  fixed_ip = "10.0.0.10"
+}
+
+data "openstack_networking_secgroup_v2" "secgroup" {
+  name = "secgroup"
+}
+
+resource "openstack_networking_port_secgroup_associate_v2" "port_1" {
+  port_id      = data.openstack_networking_port_v2.system_port.id
+  enforce      = "true"
+  skip_destroy = "true"
+  security_group_ids = [
+    data.openstack_networking_secgroup_v2.secgroup.id,
+  ]
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -93,6 +121,13 @@ The following arguments are supported:
 
 * `enforce` - (Optional) Whether to replace or append the list of security
     groups, specified in the `security_group_ids`. Defaults to `false`.
+
+* `skip_destroy` - (Optional) If `true`, the port's security groups are left
+    untouched when the resource is destroyed. This is independent of
+    `enforce`, which still controls reconcile semantics on create and update.
+    Useful when the port (or the instance behind it) is managed by external
+    tooling and must retain its security groups across Terraform destroys.
+    Defaults to `false`.
 
 ## Attributes Reference
 

--- a/openstack/resource_openstack_networking_port_secgroup_associate_v2.go
+++ b/openstack/resource_openstack_networking_port_secgroup_associate_v2.go
@@ -47,6 +47,12 @@ func resourceNetworkingPortSecGroupAssociateV2() *schema.Resource {
 				Default:  false,
 			},
 
+			"skip_destroy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"all_security_group_ids": {
 				Type:     schema.TypeSet,
 				Computed: true,
@@ -140,6 +146,7 @@ func resourceNetworkingPortSecGroupAssociateV2Read(ctx context.Context, d *schem
 	}
 
 	d.Set("enforce", enforce)
+	d.Set("skip_destroy", d.Get("skip_destroy"))
 	d.Set("port_id", d.Id())
 	d.Set("region", GetRegion(d, config))
 
@@ -210,6 +217,12 @@ func resourceNetworkingPortSecGroupAssociateV2Delete(ctx context.Context, d *sch
 	portID := d.Id()
 	config.Lock(portID)
 	defer config.Unlock(portID)
+
+	if d.Get("skip_destroy").(bool) {
+		log.Printf("[DEBUG] skip_destroy is set; leaving port %s security groups untouched", portID)
+
+		return nil
+	}
 
 	var updateOpts ports.UpdateOpts
 

--- a/openstack/resource_openstack_networking_port_secgroup_associate_v2_test.go
+++ b/openstack/resource_openstack_networking_port_secgroup_associate_v2_test.go
@@ -135,6 +135,64 @@ func TestAccNetworkingV2PortSecGroupAssociate_update(t *testing.T) {
 	})
 }
 
+func TestAccNetworkingV2PortSecGroupAssociate_skipDestroy(t *testing.T) {
+	var port ports.Port
+
+	if os.Getenv("TF_ACC") != "" {
+		testAccPreCheck(t)
+		testAccPreCheckNonAdminOnly(t)
+
+		hiddenPort, err := testAccCheckNetworkingV2PortSecGroupCreatePort(t, "hidden_port_1", true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		defer testAccCheckNetworkingV2PortSecGroupDeletePort(t, hiddenPort)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckNonAdminOnly(t)
+		},
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			// enforce=true + skip_destroy=true: only secgroup_1 attached
+			{ // step 0
+				Config: testAccNetworkingV2PortSecGroupAssociateManifestSkipDestroy0(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2PortSecGroupAssociateExists(t.Context(), "openstack_networking_port_secgroup_associate_v2.port_1", &port),
+					testAccCheckNetworkingV2PortSecGroupAssociateCountSecurityGroups(&port, 1),
+				),
+			},
+			// destroy with skip_destroy=true: secgroup_1 must remain on the port
+			{ // step 1
+				Config: testAccNetworkingV2PortSecGroupAssociateManifestSkipDestroy1(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2PortSecGroupAssociateExists(t.Context(), "data.openstack_networking_port_v2.hidden_port_1", &port),
+					testAccCheckNetworkingV2PortSecGroupAssociateCountSecurityGroups(&port, 1),
+				),
+			},
+			// enforce=false + skip_destroy=true: appends secgroup_2 → 2 groups
+			{ // step 2
+				Config: testAccNetworkingV2PortSecGroupAssociateManifestSkipDestroy2(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2PortSecGroupAssociateExists(t.Context(), "openstack_networking_port_secgroup_associate_v2.port_1", &port),
+					testAccCheckNetworkingV2PortSecGroupAssociateCountSecurityGroups(&port, 2),
+				),
+			},
+			// destroy again with skip_destroy=true: both groups stay
+			{ // step 3
+				Config: testAccNetworkingV2PortSecGroupAssociateManifestSkipDestroy3(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2PortSecGroupAssociateExists(t.Context(), "data.openstack_networking_port_v2.hidden_port_1", &port),
+					testAccCheckNetworkingV2PortSecGroupAssociateCountSecurityGroups(&port, 2),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkingV2PortSecGroupCreatePort(t *testing.T, portName string, defaultSecGroups bool) (*ports.Port, error) {
 	config := testAccProvider.Meta().(*Config)
 
@@ -475,6 +533,48 @@ resource "openstack_networking_port_secgroup_associate_v2" "port_1" {
 }
 
 func testAccNetworkingV2PortSecGroupAssociateManifestUpdate12() string {
+	return fmt.Sprintf(`
+%s
+`, testAccNetworkingV2PortSecGroupAssociate)
+}
+
+func testAccNetworkingV2PortSecGroupAssociateManifestSkipDestroy0() string {
+	return fmt.Sprintf(`
+%s
+
+resource "openstack_networking_port_secgroup_associate_v2" "port_1" {
+  port_id      = data.openstack_networking_port_v2.hidden_port_1.id
+  enforce      = "true"
+  skip_destroy = "true"
+  security_group_ids = [
+    openstack_networking_secgroup_v2.secgroup_1.id,
+  ]
+}
+`, testAccNetworkingV2PortSecGroupAssociate)
+}
+
+func testAccNetworkingV2PortSecGroupAssociateManifestSkipDestroy1() string {
+	return fmt.Sprintf(`
+%s
+`, testAccNetworkingV2PortSecGroupAssociate)
+}
+
+func testAccNetworkingV2PortSecGroupAssociateManifestSkipDestroy2() string {
+	return fmt.Sprintf(`
+%s
+
+resource "openstack_networking_port_secgroup_associate_v2" "port_1" {
+  port_id      = data.openstack_networking_port_v2.hidden_port_1.id
+  enforce      = "false"
+  skip_destroy = "true"
+  security_group_ids = [
+    openstack_networking_secgroup_v2.secgroup_2.id,
+  ]
+}
+`, testAccNetworkingV2PortSecGroupAssociate)
+}
+
+func testAccNetworkingV2PortSecGroupAssociateManifestSkipDestroy3() string {
 	return fmt.Sprintf(`
 %s
 `, testAccNetworkingV2PortSecGroupAssociate)


### PR DESCRIPTION
## Summary

Adds an opt-in `skip_destroy` (bool, default `false`) attribute to
`openstack_networking_port_secgroup_associate_v2`. When set, destroying
the resource leaves the port's security groups untouched instead of
clearing them (with `enforce=true`) or removing the user-managed subset
(with `enforce=false`). Create / update / read semantics are unchanged.

## Motivation

In some deployments the port (or the instance behind it) is reprovisioned
by external tooling outside of Terraform. Clearing the port's security
groups during a Terraform destroy breaks networking for the still-running
instance — Neutron enforces SG rules on live traffic, and a port with no
groups attached typically drops connectivity until the external system
reattaches them.

`skip_destroy` lets users keep the strict reconcile behavior of
`enforce=true` during the resource's lifetime while preventing that
destroy-time disruption. The two concerns (reconcile policy vs. destroy
policy) are now independent.