### PR TITLE
fix(db): update Trove instance options

### DIFF
--- a/docs/resources/db_instance_v1.md
+++ b/docs/resources/db_instance_v1.md
@@ -27,7 +27,8 @@ resource "openstack_db_instance_v1" "test" {
   size      = 8
 
   network {
-    uuid = "c0612505-caf2-4fb0-b7cb-56a0240a2b12"
+    network_id = "c0612505-caf2-4fb0-b7cb-56a0240a2b12"
+    subnet_id  = "25ea4ca0-6f57-4dc6-947b-012e9bdf1f3a"
   }
 
   datastore {
@@ -54,8 +55,7 @@ The following arguments are supported:
 
 * `size` - (Required) Specifies the volume size in GB. Changing this creates new instance.
 
-* `volume_type` - (Optional) Specifies the volume type to use. If you want to
-  specify a volume type, you must also specify a volume size. Changing this
+* `volume_type` - (Optional) Specifies the volume type to use. Changing this
   creates new instance.
 
 * `datastore` - (Required) An array of database engine type and version. The datastore
@@ -80,17 +80,38 @@ The `datastore` block supports:
 
 The `network` block supports:
 
-* `uuid` - (Required unless `port` is provided) The network UUID to
-    attach to the instance. Changing this creates a new instance.
+* `network_id` - (Optional) The network UUID to attach to the instance using
+    Trove's modern `network_id` NIC key. Changing this creates a new instance.
 
-* `port` - (Required unless `uuid` is provided) The port UUID of a
-    network to attach to the instance. Changing this creates a new instance.
+* `subnet_id` - (Optional) The subnet UUID to attach to the instance using
+    Trove's modern `subnet_id` NIC key. Changing this creates a new instance.
 
-* `fixed_ip_v4` - (Optional) Specifies a fixed IPv4 address to be used on this
-    network. Changing this creates a new instance.
+* `ip_address` - (Optional) Specifies a fixed IP address to be used on this
+    network using Trove's modern `ip_address` NIC key. Changing this creates a
+    new instance.
 
-* `fixed_ip_v6` - (Optional) Specifies a fixed IPv6 address to be used on this
-    network. Changing this creates a new instance.
+* `uuid` - (Optional; Deprecated) The network UUID to attach to the instance
+    using the legacy `net-id` NIC key. Use `network_id` for modern Trove
+    deployments. Changing this creates a new instance.
+
+* `port` - (Optional; Deprecated) The port UUID of a network to attach to the
+    instance using the legacy `port-id` NIC key. Trove no longer supports
+    port-based NIC specification in modern deployments. Changing this creates a
+    new instance.
+
+* `fixed_ip_v4` - (Optional; Deprecated) Specifies a fixed IPv4 address using
+    the legacy `v4-fixed-ip` NIC key. Use `ip_address` for modern Trove
+    deployments. Changing this creates a new instance.
+
+* `fixed_ip_v6` - (Optional; Deprecated) Specifies a fixed IPv6 address using
+    the legacy `v6-fixed-ip` NIC key. Use `ip_address` for modern Trove
+    deployments. Changing this creates a new instance.
+
+~> **Note:** Do not mix legacy network fields (`uuid`, `port`, `fixed_ip_v4`,
+`fixed_ip_v6`) with modern network fields (`network_id`, `subnet_id`,
+`ip_address`) in the same `network` block. Modern Trove validates NICs against
+the `network_id`, `subnet_id`, and `ip_address` keys and rejects the legacy
+keys.
 
 The `user` block supports:
 
@@ -128,6 +149,9 @@ The following attributes are exported:
 * `configuration_id` - See Argument Reference above.
 * `datastore/type` - See Argument Reference above.
 * `datastore/version` - See Argument Reference above.
+* `network/network_id` - See Argument Reference above.
+* `network/subnet_id` - See Argument Reference above.
+* `network/ip_address` - See Argument Reference above.
 * `network/uuid` - See Argument Reference above.
 * `network/port` - See Argument Reference above.
 * `network/fixed_ip_v4` - The Fixed IPv4 address of the Instance on that

--- a/openstack/db_instance_v1.go
+++ b/openstack/db_instance_v1.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/gophercloud/gophercloud/v2"
@@ -12,6 +13,154 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+type databaseInstanceV1CreateOpts struct {
+	FlavorRef  string
+	Size       int
+	VolumeType string
+	Name       string
+	Databases  databases.CreateOptsBuilder
+	Users      users.CreateOptsBuilder
+	Datastore  *instances.DatastoreOpts
+	Networks   []databaseInstanceV1NetworkOpts
+}
+
+func (opts databaseInstanceV1CreateOpts) ToInstanceCreateMap() (map[string]any, error) {
+	if opts.Size > 300 || opts.Size < 1 {
+		err := gophercloud.ErrInvalidInput{}
+		err.Argument = "instances.CreateOpts.Size"
+		err.Value = opts.Size
+		err.Info = "Size (GB) must be between 1-300"
+
+		return nil, err
+	}
+
+	if opts.FlavorRef == "" {
+		return nil, gophercloud.ErrMissingInput{Argument: "instances.CreateOpts.FlavorRef"}
+	}
+
+	instance := map[string]any{
+		"flavorRef": opts.FlavorRef,
+	}
+
+	if opts.Name != "" {
+		instance["name"] = opts.Name
+	}
+
+	if opts.Databases != nil {
+		dbs, err := opts.Databases.ToDBCreateMap()
+		if err != nil {
+			return nil, err
+		}
+
+		instance["databases"] = dbs["databases"]
+	}
+
+	if opts.Users != nil {
+		userList, err := opts.Users.ToUserCreateMap()
+		if err != nil {
+			return nil, err
+		}
+
+		instance["users"] = userList["users"]
+	}
+
+	if opts.Datastore != nil {
+		datastore, err := opts.Datastore.ToMap()
+		if err != nil {
+			return nil, err
+		}
+
+		instance["datastore"] = datastore
+	}
+
+	if len(opts.Networks) > 0 {
+		networks := make([]map[string]any, len(opts.Networks))
+		for i, network := range opts.Networks {
+			networks[i] = network.ToMap()
+		}
+
+		instance["nics"] = networks
+	}
+
+	volume := map[string]any{
+		"size": opts.Size,
+	}
+
+	if opts.VolumeType != "" {
+		volume["type"] = opts.VolumeType
+	}
+
+	instance["volume"] = volume
+
+	return map[string]any{"instance": instance}, nil
+}
+
+type databaseInstanceV1NetworkOpts struct {
+	UUID      string
+	Port      string
+	V4FixedIP string
+	V6FixedIP string
+	NetworkID string
+	SubnetID  string
+	IPAddress string
+}
+
+func (opts databaseInstanceV1NetworkOpts) ToMap() map[string]any {
+	if opts.usesModernKeys() {
+		return opts.toModernMap()
+	}
+
+	return opts.toLegacyMap()
+}
+
+func (opts databaseInstanceV1NetworkOpts) usesModernKeys() bool {
+	return opts.NetworkID != "" || opts.SubnetID != "" || opts.IPAddress != ""
+}
+
+func (opts databaseInstanceV1NetworkOpts) usesLegacyKeys() bool {
+	return opts.UUID != "" || opts.Port != "" || opts.V4FixedIP != "" || opts.V6FixedIP != ""
+}
+
+func (opts databaseInstanceV1NetworkOpts) toModernMap() map[string]any {
+	network := make(map[string]any)
+
+	if opts.NetworkID != "" {
+		network["network_id"] = opts.NetworkID
+	}
+
+	if opts.SubnetID != "" {
+		network["subnet_id"] = opts.SubnetID
+	}
+
+	if opts.IPAddress != "" {
+		network["ip_address"] = opts.IPAddress
+	}
+
+	return network
+}
+
+func (opts databaseInstanceV1NetworkOpts) toLegacyMap() map[string]any {
+	network := make(map[string]any)
+
+	if opts.UUID != "" {
+		network["net-id"] = opts.UUID
+	}
+
+	if opts.Port != "" {
+		network["port-id"] = opts.Port
+	}
+
+	if opts.V4FixedIP != "" {
+		network["v4-fixed-ip"] = opts.V4FixedIP
+	}
+
+	if opts.V6FixedIP != "" {
+		network["v6-fixed-ip"] = opts.V6FixedIP
+	}
+
+	return network
+}
 
 func expandDatabaseInstanceV1Datastore(rawDatastore []any) instances.DatastoreOpts {
 	v := rawDatastore[0].(map[string]any)
@@ -23,24 +172,33 @@ func expandDatabaseInstanceV1Datastore(rawDatastore []any) instances.DatastoreOp
 	return datastore
 }
 
-func expandDatabaseInstanceV1Networks(rawNetworks []any) []instances.NetworkOpts {
-	networks := make([]instances.NetworkOpts, 0, len(rawNetworks))
+func expandDatabaseInstanceV1Networks(rawNetworks []any) ([]databaseInstanceV1NetworkOpts, error) {
+	networks := make([]databaseInstanceV1NetworkOpts, 0, len(rawNetworks))
 
-	for _, v := range rawNetworks {
-		network := v.(map[string]any)
-		networks = append(networks, instances.NetworkOpts{
-			UUID:      network["uuid"].(string),
-			Port:      network["port"].(string),
-			V4FixedIP: network["fixed_ip_v4"].(string),
-			V6FixedIP: network["fixed_ip_v6"].(string),
-		})
+	for i, v := range rawNetworks {
+		rawNetwork := v.(map[string]any)
+		network := databaseInstanceV1NetworkOpts{
+			UUID:      rawNetwork["uuid"].(string),
+			Port:      rawNetwork["port"].(string),
+			V4FixedIP: rawNetwork["fixed_ip_v4"].(string),
+			V6FixedIP: rawNetwork["fixed_ip_v6"].(string),
+			NetworkID: rawNetwork["network_id"].(string),
+			SubnetID:  rawNetwork["subnet_id"].(string),
+			IPAddress: rawNetwork["ip_address"].(string),
+		}
+
+		if network.usesLegacyKeys() && network.usesModernKeys() {
+			return nil, fmt.Errorf("network.%d cannot mix legacy fields uuid, port, fixed_ip_v4, or fixed_ip_v6 with modern fields network_id, subnet_id, or ip_address", i)
+		}
+
+		networks = append(networks, network)
 	}
 
-	return networks
+	return networks, nil
 }
 
 func expandDatabaseInstanceV1Databases(rawDatabases []any) databases.BatchCreateOpts {
-	var dbs databases.BatchCreateOpts
+	dbs := make(databases.BatchCreateOpts, 0, len(rawDatabases))
 
 	for _, v := range rawDatabases {
 		db := v.(map[string]any)
@@ -55,7 +213,7 @@ func expandDatabaseInstanceV1Databases(rawDatabases []any) databases.BatchCreate
 }
 
 func expandDatabaseInstanceV1Users(rawUsers []any) users.BatchCreateOpts {
-	var userList users.BatchCreateOpts
+	userList := make(users.BatchCreateOpts, 0, len(rawUsers))
 
 	for _, v := range rawUsers {
 		user := v.(map[string]any)
@@ -92,7 +250,7 @@ func databaseInstanceV1StateRefreshFunc(ctx context.Context, client *gophercloud
 }
 
 func expandInstanceV1UserDatabases(v []any) databases.BatchCreateOpts {
-	var dbs databases.BatchCreateOpts
+	dbs := make(databases.BatchCreateOpts, 0, len(v))
 
 	for _, db := range v {
 		dbs = append(dbs, databases.CreateOpts{

--- a/openstack/db_instance_v1_test.go
+++ b/openstack/db_instance_v1_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/users"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUnitExpandDatabaseInstanceV1Datastore(t *testing.T) {
@@ -30,20 +31,195 @@ func TestUnitExpandDatabaseInstanceV1Datastore(t *testing.T) {
 func TestUnitExpandDatabaseInstanceV1Networks(t *testing.T) {
 	network := []any{
 		map[string]any{
-			"uuid":        "foobar",
+			"uuid":        "legacy-network-id",
+			"port":        "legacy-port-id",
+			"fixed_ip_v4": "192.0.2.10",
+			"fixed_ip_v6": "2001:db8::10",
+			"network_id":  "",
+			"subnet_id":   "",
+			"ip_address":  "",
+		},
+	}
+
+	expected := []databaseInstanceV1NetworkOpts{
+		{
+			UUID:      "legacy-network-id",
+			Port:      "legacy-port-id",
+			V4FixedIP: "192.0.2.10",
+			V6FixedIP: "2001:db8::10",
+		},
+	}
+
+	actual, err := expandDatabaseInstanceV1Networks(network)
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestUnitExpandDatabaseInstanceV1NetworksModern(t *testing.T) {
+	network := []any{
+		map[string]any{
+			"uuid":        "",
 			"port":        "",
 			"fixed_ip_v4": "",
 			"fixed_ip_v6": "",
+			"network_id":  "modern-network-id",
+			"subnet_id":   "modern-subnet-id",
+			"ip_address":  "192.0.2.20",
 		},
 	}
 
-	expected := []instances.NetworkOpts{
+	expected := []databaseInstanceV1NetworkOpts{
 		{
-			UUID: "foobar",
+			NetworkID: "modern-network-id",
+			SubnetID:  "modern-subnet-id",
+			IPAddress: "192.0.2.20",
 		},
 	}
 
-	actual := expandDatabaseInstanceV1Networks(network)
+	actual, err := expandDatabaseInstanceV1Networks(network)
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestUnitExpandDatabaseInstanceV1NetworksMixed(t *testing.T) {
+	network := []any{
+		map[string]any{
+			"uuid":        "legacy-network-id",
+			"port":        "",
+			"fixed_ip_v4": "",
+			"fixed_ip_v6": "",
+			"network_id":  "modern-network-id",
+			"subnet_id":   "",
+			"ip_address":  "",
+		},
+	}
+
+	actual, err := expandDatabaseInstanceV1Networks(network)
+	assert.Nil(t, actual)
+	assert.EqualError(t, err, "network.0 cannot mix legacy fields uuid, port, fixed_ip_v4, or fixed_ip_v6 with modern fields network_id, subnet_id, or ip_address")
+}
+
+func TestUnitDatabaseInstanceV1NetworkOptsToMapLegacy(t *testing.T) {
+	network := databaseInstanceV1NetworkOpts{
+		UUID:      "legacy-network-id",
+		Port:      "legacy-port-id",
+		V4FixedIP: "192.0.2.10",
+		V6FixedIP: "2001:db8::10",
+	}
+
+	expected := map[string]any{
+		"net-id":      "legacy-network-id",
+		"port-id":     "legacy-port-id",
+		"v4-fixed-ip": "192.0.2.10",
+		"v6-fixed-ip": "2001:db8::10",
+	}
+
+	assert.Equal(t, expected, network.ToMap())
+}
+
+func TestUnitDatabaseInstanceV1NetworkOptsToMapModern(t *testing.T) {
+	network := databaseInstanceV1NetworkOpts{
+		NetworkID: "modern-network-id",
+		SubnetID:  "modern-subnet-id",
+		IPAddress: "192.0.2.20",
+	}
+
+	expected := map[string]any{
+		"network_id": "modern-network-id",
+		"subnet_id":  "modern-subnet-id",
+		"ip_address": "192.0.2.20",
+	}
+
+	assert.Equal(t, expected, network.ToMap())
+}
+
+func TestUnitDatabaseInstanceV1CreateOptsToInstanceCreateMapModernNetworks(t *testing.T) {
+	createOpts := databaseInstanceV1CreateOpts{
+		FlavorRef: "flavor-id",
+		Name:      "db-instance",
+		Size:      10,
+		Datastore: &instances.DatastoreOpts{
+			Version: "mysql-8.0",
+			Type:    "mysql",
+		},
+		Networks: []databaseInstanceV1NetworkOpts{
+			{
+				NetworkID: "modern-network-id",
+				SubnetID:  "modern-subnet-id",
+				IPAddress: "192.0.2.20",
+			},
+		},
+	}
+
+	expected := map[string]any{
+		"instance": map[string]any{
+			"flavorRef": "flavor-id",
+			"name":      "db-instance",
+			"datastore": map[string]any{
+				"version": "mysql-8.0",
+				"type":    "mysql",
+			},
+			"nics": []map[string]any{
+				{
+					"network_id": "modern-network-id",
+					"subnet_id":  "modern-subnet-id",
+					"ip_address": "192.0.2.20",
+				},
+			},
+			"volume": map[string]any{
+				"size": 10,
+			},
+		},
+	}
+
+	actual, err := createOpts.ToInstanceCreateMap()
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestUnitDatabaseInstanceV1CreateOptsToInstanceCreateMapWithVolumeType(t *testing.T) {
+	createOpts := databaseInstanceV1CreateOpts{
+		FlavorRef:  "flavor-id",
+		Name:       "db-instance",
+		Size:       10,
+		VolumeType: "ssd",
+	}
+
+	expected := map[string]any{
+		"instance": map[string]any{
+			"flavorRef": "flavor-id",
+			"name":      "db-instance",
+			"volume": map[string]any{
+				"size": 10,
+				"type": "ssd",
+			},
+		},
+	}
+
+	actual, err := createOpts.ToInstanceCreateMap()
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestUnitDatabaseInstanceV1CreateOptsToInstanceCreateMapWithoutVolumeType(t *testing.T) {
+	createOpts := databaseInstanceV1CreateOpts{
+		FlavorRef: "flavor-id",
+		Name:      "db-instance",
+		Size:      10,
+	}
+
+	expected := map[string]any{
+		"instance": map[string]any{
+			"flavorRef": "flavor-id",
+			"name":      "db-instance",
+			"volume": map[string]any{
+				"size": 10,
+			},
+		},
+	}
+
+	actual, err := createOpts.ToInstanceCreateMap()
+	require.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
 

--- a/openstack/resource_openstack_db_instance_v1.go
+++ b/openstack/resource_openstack_db_instance_v1.go
@@ -47,10 +47,9 @@ func resourceDatabaseInstanceV1() *schema.Resource {
 			},
 
 			"size": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				RequiredWith: []string{"volume_type"},
-				ForceNew:     true,
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
 			},
 
 			"volume_type": {
@@ -87,21 +86,40 @@ func resourceDatabaseInstanceV1() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"uuid": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
+							Type:       schema.TypeString,
+							Optional:   true,
+							ForceNew:   true,
+							Deprecated: "Use network_id for modern Trove deployments. uuid serializes the legacy net-id key.",
 						},
 						"port": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
+							Type:       schema.TypeString,
+							Optional:   true,
+							ForceNew:   true,
+							Deprecated: "Trove no longer supports port-based NIC specification in modern deployments.",
 						},
 						"fixed_ip_v4": {
+							Type:       schema.TypeString,
+							Optional:   true,
+							ForceNew:   true,
+							Deprecated: "Use ip_address for modern Trove deployments. fixed_ip_v4 serializes the legacy v4-fixed-ip key.",
+						},
+						"fixed_ip_v6": {
+							Type:       schema.TypeString,
+							Optional:   true,
+							ForceNew:   true,
+							Deprecated: "Use ip_address for modern Trove deployments. fixed_ip_v6 serializes the legacy v6-fixed-ip key.",
+						},
+						"network_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
 						},
-						"fixed_ip_v6": {
+						"subnet_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"ip_address": {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
@@ -195,7 +213,7 @@ func resourceDatabaseInstanceV1Create(ctx context.Context, d *schema.ResourceDat
 		return diag.Errorf("Error creating OpenStack database client: %s", err)
 	}
 
-	createOpts := &instances.CreateOpts{
+	createOpts := &databaseInstanceV1CreateOpts{
 		FlavorRef: d.Get("flavor_id").(string),
 		Name:      d.Get("name").(string),
 		Size:      d.Get("size").(int),
@@ -215,9 +233,12 @@ func resourceDatabaseInstanceV1Create(ctx context.Context, d *schema.ResourceDat
 	createOpts.Datastore = &datastore
 
 	// networks
-	var networks []instances.NetworkOpts
+	var networks []databaseInstanceV1NetworkOpts
 	if v, ok := d.GetOk("network"); ok {
-		networks = expandDatabaseInstanceV1Networks(v.([]any))
+		networks, err = expandDatabaseInstanceV1Networks(v.([]any))
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	createOpts.Networks = networks


### PR DESCRIPTION
## Summary

- Adds provider-local Trove DB instance create request serialization so modern NIC keys can be emitted without waiting on gophercloud changes.
- Adds `network_id`, `subnet_id`, and `ip_address` to the `openstack_db_instance_v1` `network` block.
- Preserves legacy `uuid`, `port`, `fixed_ip_v4`, and `fixed_ip_v6` behavior when only legacy fields are used.
- Rejects mixed legacy and modern NIC fields in the same `network` block.
- Removes the schema constraint requiring `volume_type` with `size`; Trove allows volume size without an explicit type, and `volume.type` is still only serialized when configured.
- Updates docs and unit tests.

## Test & Lint Summary

Commands run:

```sh
make fmtcheck
go vet ./...
go test ./openstack -run 'TestUnit.*DatabaseInstanceV1' -count=1 -v
go test ./openstack ./openstack/internal/pathorcontents -run 'TestUnit' -count=1
go test -json ./openstack ./openstack/internal/pathorcontents -run 'TestUnit' -count=1
golangci-lint run --new-from-rev=origin/main ./openstack
```

Results:

- Focused DB unit tests: 11 passed, 0 failed, 0 skipped.
- Unit test suite (`TestUnit`, counted once via `go test -json`): 93 passed, 0 failed, 1 skipped.
- `go vet ./...`: passed.
- `make fmtcheck`: passed.
- `golangci-lint run --new-from-rev=origin/main ./openstack`: passed with 0 issues.

Note: `golangci-lint run ./openstack` still reports pre-existing unrelated findings in this workspace, so I used `--new-from-rev=origin/main` to validate this PR's changes.