### PR TITLE
vpnaas: deprecate sha1 and 3des crypto algorithms

### DIFF
--- a/docs/resources/vpnaas_ike_policy_v2.md
+++ b/docs/resources/vpnaas_ike_policy_v2.md
@@ -37,11 +37,11 @@ The following arguments are supported:
 * `description` - (Optional) The human-readable description for the policy.
     Changing this updates the description of the existing policy.
 
-* `auth_algorithm` - (Optional) The authentication hash algorithm. Valid values are sha1, sha256, sha384, sha512,
-    aes-xcbc, aes-cmac. Default is sha1.
+* `auth_algorithm` - (Optional) The authentication hash algorithm. Valid values are sha256, sha384, sha512,
+    aes-xcbc, aes-cmac. Default is sha256.
     Changing this updates the algorithm of the existing policy.
 
-* `encryption_algorithm` - (Optional) The encryption algorithm. Valid values are 3des, aes-128, aes-192, aes-256,
+* `encryption_algorithm` - (Optional) The encryption algorithm. Valid values are aes-128, aes-192, aes-256,
     aes-KKK-ctr, aes-KKK-ccm-II, aes-KKK-gcm-II (with KKK = 128/192/256 bits key size and II = 8/12/16 octets ICV).
     The default value is aes-128. Changing this updates the existing policy.
 

--- a/docs/resources/vpnaas_ipsec_policy_v2.md
+++ b/docs/resources/vpnaas_ipsec_policy_v2.md
@@ -37,14 +37,14 @@ The following arguments are supported:
 * `description` - (Optional) The human-readable description for the policy.
     Changing this updates the description of the existing policy.
 
-* `auth_algorithm` - (Optional) The authentication hash algorithm. Valid values are sha1, sha256, sha384, sha512,
-    aes-xcbc, aes-cmac. Default is sha1.
+* `auth_algorithm` - (Optional) The authentication hash algorithm. Valid values are sha256, sha384, sha512,
+    aes-xcbc, aes-cmac. Default is sha256.
     Changing this updates the algorithm of the existing policy.
 
 * `encapsulation_mode` - (Optional) The encapsulation mode. Valid values are tunnel and transport. Default is tunnel.
     Changing this updates the existing policy.
 
-* `encryption_algorithm` - (Optional) The encryption algorithm. Valid values are 3des, aes-128, aes-192, aes-256,
+* `encryption_algorithm` - (Optional) The encryption algorithm. Valid values are aes-128, aes-192, aes-256,
     aes-KKK-ctr, aes-KKK-ccm-II, aes-KKK-gcm-II (with KKK = 128/192/256 bits key size and II = 8/12/16 octets ICV).
     The default value is aes-128. Changing this updates the existing policy.
 

--- a/openstack/resource_openstack_vpnaas_ike_policy_v2.go
+++ b/openstack/resource_openstack_vpnaas_ike_policy_v2.go
@@ -47,7 +47,7 @@ func resourceIKEPolicyV2() *schema.Resource {
 			"auth_algorithm": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "sha1",
+				Default:      "sha256",
 				ValidateFunc: resourceIKEPolicyV2AuthAlgorithm,
 			},
 			"encryption_algorithm": {

--- a/openstack/resource_openstack_vpnaas_ipsec_policy_v2.go
+++ b/openstack/resource_openstack_vpnaas_ipsec_policy_v2.go
@@ -44,7 +44,7 @@ func resourceIPSecPolicyV2() *schema.Resource {
 			"auth_algorithm": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Computed:     true,
+				Default:      "sha256",
 				ValidateFunc: resourceIPSecPolicyV2AuthAlgorithm,
 			},
 			"encapsulation_mode": {
@@ -62,7 +62,7 @@ func resourceIPSecPolicyV2() *schema.Resource {
 			"encryption_algorithm": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Computed:     true,
+				Default:      "aes-128",
 				ValidateFunc: resourceIPSecPolicyV2EncryptionAlgorithm,
 			},
 			"description": {


### PR DESCRIPTION
see https://review.opendev.org/c/openstack/neutron-vpnaas/+/982383