### PR TITLE
Fix: use getOkExists for zero-value fields in openstack_compute_flavor_v2 data source

### DIFF
--- a/openstack/data_source_openstack_compute_flavor_v2.go
+++ b/openstack/data_source_openstack_compute_flavor_v2.go
@@ -191,32 +191,32 @@ func dataSourceComputeFlavorV2Read(ctx context.Context, d *schema.ResourceData, 
 				}
 			}
 
-			// d.GetOk is used because 0 might be a valid choice.
-			if v, ok := d.GetOk("ram"); ok {
+			// d.GetOkExists is used because 0 might be a valid choice.
+			if v, ok := d.GetOkExists("ram"); ok {
 				if flavor.RAM != v.(int) {
 					continue
 				}
 			}
 
-			if v, ok := d.GetOk("vcpus"); ok {
+			if v, ok := d.GetOkExists("vcpus"); ok {
 				if flavor.VCPUs != v.(int) {
 					continue
 				}
 			}
 
-			if v, ok := d.GetOk("disk"); ok {
+			if v, ok := d.GetOkExists("disk"); ok {
 				if flavor.Disk != v.(int) {
 					continue
 				}
 			}
 
-			if v, ok := d.GetOk("swap"); ok {
+			if v, ok := d.GetOkExists("swap"); ok {
 				if flavor.Swap != v.(int) {
 					continue
 				}
 			}
 
-			if v, ok := d.GetOk("rx_tx_factor"); ok {
+			if v, ok := d.GetOkExists("rx_tx_factor"); ok {
 				if flavor.RxTxFactor != v.(float64) {
 					continue
 				}

--- a/openstack/data_source_openstack_compute_flavor_v2.go
+++ b/openstack/data_source_openstack_compute_flavor_v2.go
@@ -191,32 +191,32 @@ func dataSourceComputeFlavorV2Read(ctx context.Context, d *schema.ResourceData, 
 				}
 			}
 
-			// d.GetOkExists is used because 0 might be a valid choice.
-			if v, ok := d.GetOkExists("ram"); ok {
+			// d.GetOk is used because 0 might be a valid choice.
+			if v, ok := getOkExists(d, "ram"); ok {
 				if flavor.RAM != v.(int) {
 					continue
 				}
 			}
 
-			if v, ok := d.GetOkExists("vcpus"); ok {
+			if v, ok := getOkExists(d, "vcpus"); ok {
 				if flavor.VCPUs != v.(int) {
 					continue
 				}
 			}
 
-			if v, ok := d.GetOkExists("disk"); ok {
+			if v, ok := getOkExists(d, "disk"); ok {
 				if flavor.Disk != v.(int) {
 					continue
 				}
 			}
 
-			if v, ok := d.GetOkExists("swap"); ok {
+			if v, ok := getOkExists(d, "swap"); ok {
 				if flavor.Swap != v.(int) {
 					continue
 				}
 			}
 
-			if v, ok := d.GetOkExists("rx_tx_factor"); ok {
+			if v, ok := getOkExists(d, "rx_tx_factor"); ok {
 				if flavor.RxTxFactor != v.(float64) {
 					continue
 				}

--- a/openstack/data_source_openstack_compute_flavor_v2_test.go
+++ b/openstack/data_source_openstack_compute_flavor_v2_test.go
@@ -249,21 +249,17 @@ func testAccComputeV2FlavorDataSourceFlavorID(flavorName string) string {
 }
 
 func TestAccComputeV2FlavorDataSource_queryDiskZero(t *testing.T) {
-	flavorName := acctest.RandomWithPrefix("tf-acc-flavor")
-
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckAdminOnly(t)
+			testAccPreCheckNonAdminOnly(t)
 		},
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2FlavorDataSourceQueryZeroValues(flavorName),
+				Config: testAccComputeV2FlavorDataSourceQueryZeroValues,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2FlavorDataSourceID("data.openstack_compute_flavor_v2.flavor_1"),
-					resource.TestCheckResourceAttr(
-						"data.openstack_compute_flavor_v2.flavor_1", "name", flavorName),
 					resource.TestCheckResourceAttr(
 						"data.openstack_compute_flavor_v2.flavor_1", "ram", "8192"),
 					resource.TestCheckResourceAttr(
@@ -276,20 +272,10 @@ func TestAccComputeV2FlavorDataSource_queryDiskZero(t *testing.T) {
 	})
 }
 
-func testAccComputeV2FlavorDataSourceQueryZeroValues(flavorName string) string {
-	return fmt.Sprintf(`
-          resource "openstack_compute_flavor_v2" "flavor_1" {
-            name = "%s"
-            ram = 8192
-            vcpus = 2
-            disk = 0
-            is_public = true
-          }
-
-          data "openstack_compute_flavor_v2" "flavor_1" {
-            vcpus = 2
-            ram = 8192
-            disk = 0
-          }
-          `, flavorName)
+const testAccComputeV2FlavorDataSourceQueryZeroValues = `
+data "openstack_compute_flavor_v2" "flavor_1" {
+  vcpus = 2
+  ram = 8192
+  disk = 0
 }
+`

--- a/openstack/data_source_openstack_compute_flavor_v2_test.go
+++ b/openstack/data_source_openstack_compute_flavor_v2_test.go
@@ -247,3 +247,48 @@ func testAccComputeV2FlavorDataSourceFlavorID(flavorName string) string {
           }
           `, flavorResource)
 }
+
+func TestAccComputeV2FlavorDataSource_queryDiskZero(t *testing.T) {
+	flavorName := acctest.RandomWithPrefix("tf-acc-flavor")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeV2FlavorDataSourceQueryDiskZero(flavorName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2FlavorDataSourceID("data.openstack_compute_flavor_v2.flavor_1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "name", flavorName),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "ram", "512"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "vcpus", "1"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "disk", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccComputeV2FlavorDataSourceQueryDiskZero(flavorName string) string {
+	return fmt.Sprintf(`
+          resource "openstack_compute_flavor_v2" "flavor_1" {
+            name = "%s"
+            ram = 512
+            vcpus = 1
+            disk = 0
+            is_public = true
+          }
+
+          data "openstack_compute_flavor_v2" "flavor_1" {
+            name = openstack_compute_flavor_v2.flavor_1.name
+            disk = 0
+          }
+          `, flavorName)
+}

--- a/openstack/data_source_openstack_compute_flavor_v2_test.go
+++ b/openstack/data_source_openstack_compute_flavor_v2_test.go
@@ -287,7 +287,7 @@ resource "openstack_compute_flavor_v2" "flavor_1" {
 }
 
 data "openstack_compute_flavor_v2" "flavor_1" {
-  vcpus = 1
+  vcpus = openstack_compute_flavor_v2.flavor_1.vcpus
   ram   = 512
   disk  = 0
 }

--- a/openstack/data_source_openstack_compute_flavor_v2_test.go
+++ b/openstack/data_source_openstack_compute_flavor_v2_test.go
@@ -259,15 +259,15 @@ func TestAccComputeV2FlavorDataSource_queryDiskZero(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2FlavorDataSourceQueryDiskZero(flavorName),
+				Config: testAccComputeV2FlavorDataSourceQueryZeroValues(flavorName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2FlavorDataSourceID("data.openstack_compute_flavor_v2.flavor_1"),
 					resource.TestCheckResourceAttr(
 						"data.openstack_compute_flavor_v2.flavor_1", "name", flavorName),
 					resource.TestCheckResourceAttr(
-						"data.openstack_compute_flavor_v2.flavor_1", "ram", "512"),
+						"data.openstack_compute_flavor_v2.flavor_1", "ram", "8192"),
 					resource.TestCheckResourceAttr(
-						"data.openstack_compute_flavor_v2.flavor_1", "vcpus", "1"),
+						"data.openstack_compute_flavor_v2.flavor_1", "vcpus", "2"),
 					resource.TestCheckResourceAttr(
 						"data.openstack_compute_flavor_v2.flavor_1", "disk", "0"),
 				),
@@ -276,18 +276,19 @@ func TestAccComputeV2FlavorDataSource_queryDiskZero(t *testing.T) {
 	})
 }
 
-func testAccComputeV2FlavorDataSourceQueryDiskZero(flavorName string) string {
+func testAccComputeV2FlavorDataSourceQueryZeroValues(flavorName string) string {
 	return fmt.Sprintf(`
           resource "openstack_compute_flavor_v2" "flavor_1" {
             name = "%s"
-            ram = 512
-            vcpus = 1
+            ram = 8192
+            vcpus = 2
             disk = 0
             is_public = true
           }
 
           data "openstack_compute_flavor_v2" "flavor_1" {
-            name = openstack_compute_flavor_v2.flavor_1.name
+            vcpus = 2
+            ram = 8192
             disk = 0
           }
           `, flavorName)

--- a/openstack/data_source_openstack_compute_flavor_v2_test.go
+++ b/openstack/data_source_openstack_compute_flavor_v2_test.go
@@ -249,21 +249,25 @@ func testAccComputeV2FlavorDataSourceFlavorID(flavorName string) string {
 }
 
 func TestAccComputeV2FlavorDataSource_queryDiskZero(t *testing.T) {
+	flavorName := acctest.RandomWithPrefix("tf-acc-flavor")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckNonAdminOnly(t)
+			testAccPreCheckAdminOnly(t)
 		},
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2FlavorDataSourceQueryZeroValues,
+				Config: testAccComputeV2FlavorDataSourceZeroDisk(flavorName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2FlavorDataSourceID("data.openstack_compute_flavor_v2.flavor_1"),
 					resource.TestCheckResourceAttr(
-						"data.openstack_compute_flavor_v2.flavor_1", "ram", "8192"),
+						"data.openstack_compute_flavor_v2.flavor_1", "name", flavorName),
 					resource.TestCheckResourceAttr(
-						"data.openstack_compute_flavor_v2.flavor_1", "vcpus", "2"),
+						"data.openstack_compute_flavor_v2.flavor_1", "ram", "512"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_compute_flavor_v2.flavor_1", "vcpus", "1"),
 					resource.TestCheckResourceAttr(
 						"data.openstack_compute_flavor_v2.flavor_1", "disk", "0"),
 				),
@@ -272,10 +276,20 @@ func TestAccComputeV2FlavorDataSource_queryDiskZero(t *testing.T) {
 	})
 }
 
-const testAccComputeV2FlavorDataSourceQueryZeroValues = `
-data "openstack_compute_flavor_v2" "flavor_1" {
-  vcpus = 2
-  ram = 8192
-  disk = 0
+func testAccComputeV2FlavorDataSourceZeroDisk(flavorName string) string {
+	return fmt.Sprintf(`
+resource "openstack_compute_flavor_v2" "flavor_1" {
+  name      = "%s"
+  ram       = 512
+  vcpus     = 1
+  disk      = 0
+  is_public = true
 }
-`
+
+data "openstack_compute_flavor_v2" "flavor_1" {
+  vcpus = 1
+  ram   = 512
+  disk  = 0
+}
+`, flavorName)
+}


### PR DESCRIPTION
## Problem

`d.GetOk()` returns `false` for zero-values (0, 0.0), causing `disk = 0`, `ram = 0`, `vcpus = 0`, and `swap = 0` filters to be silently skipped in the `openstack_compute_flavor_v2` data source. The existing comment says "0 might be a valid choice" — but `GetOk` treats 0 as "unset".

## Fix

Replace `d.GetOk()` with `d.GetOkExists()` for `ram`, `vcpus`, `disk`, `swap`, and `rx_tx_factor`. `GetOkExists` distinguishes between "field not set" and "field explicitly set to zero".

## Verification

Built the provider locally and tested against a real OpenStack installation. Verified that `disk = 0` is now correctly honored as a filter — only flavors with `disk = 0` match, whereas before the filter was ignored and any flavor matching the other criteria was returned.

> **Disclaimer:** This bug report and fix were created with the assistance of AI tools. The root cause analysis was performed by an AI assistant reviewing the provider source code. The fix was reviewed and verified by me on a real OpenStack installation.

Fixes #2050